### PR TITLE
Remove duplicate slash command registration

### DIFF
--- a/cogs/huggingface_cog.py
+++ b/cogs/huggingface_cog.py
@@ -66,9 +66,8 @@ class HuggingFaceCog(commands.Cog):
     async def on_ready(self):
         bot_id = self.bot.user.id
         self.mention_strs = [f"<@{bot_id}>", f"<@!{bot_id}>"]
-        # Register slash command and sync
+        # Sync slash commands once we're ready
         try:
-            self.bot.tree.add_command(self.ask)
             await self.bot.tree.sync()
             log.info("Slash commands synced on ready.")
         except Exception as e:


### PR DESCRIPTION
## Summary
- fix `on_ready` to just sync the command tree instead of re-adding `ask`

## Testing
- `python -m py_compile cogs/huggingface_cog.py`

------
https://chatgpt.com/codex/tasks/task_e_6840c96e0388832badaeae97f8df0c8e