### PR TITLE
Enable detailed logging in test env

### DIFF
--- a/cogs/test_logging_cog.py
+++ b/cogs/test_logging_cog.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+import logging
+
+import discord
+from discord.ext import commands
+
+# Use the same logger as main.py so handlers are attached
+log = logging.getLogger("gentlebot")
+
+class TestLoggingCog(commands.Cog):
+    """Extra verbose logging for test environment."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_interaction(self, interaction: discord.Interaction):
+        if interaction.type is discord.InteractionType.application_command:
+            data = interaction.data or {}
+            name = data.get("name")
+            log.info("[TEST] Slash command /%s by %s in %s", name, interaction.user.id, getattr(interaction.channel, "name", interaction.channel_id))
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message):
+        if message.author.bot:
+            return
+        log.info("[TEST] Message from %s in %s: %s", message.author.id, getattr(message.channel, "name", message.channel.id), message.content.replace('\n', ' '))
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
+        log.info(
+            "[TEST] Reaction %s added by %s to %s in %s",
+            str(payload.emoji),
+            payload.user_id,
+            payload.message_id,
+            payload.channel_id,
+        )
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(TestLoggingCog(bot))

--- a/main.py
+++ b/main.py
@@ -38,6 +38,8 @@ class GentleBot(commands.Bot):
     async def setup_hook(self):
         cog_dir = Path(__file__).parent / "cogs"
         for file in cog_dir.glob("*_cog.py"):
+            if file.stem == "test_logging_cog" and not cfg.IS_TEST:
+                continue
             await self.load_extension(f"cogs.{file.stem}")
 
 


### PR DESCRIPTION
## Summary
- add a `TestLoggingCog` that logs slash commands, messages, and reactions
- load the new cog only when `env=TEST`
- fix `TestLoggingCog` to use the configured `gentlebot` logger

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6840cb30654c832ba6dd475a1910e749