### PR TITLE
Add startup slash command sync logs

### DIFF
--- a/cogs/test_logging_cog.py
+++ b/cogs/test_logging_cog.py
@@ -3,6 +3,7 @@ import logging
 
 import discord
 from discord.ext import commands
+import bot_config as cfg
 
 # Use the same logger as main.py so handlers are attached
 log = logging.getLogger("gentlebot")
@@ -12,6 +13,16 @@ class TestLoggingCog(commands.Cog):
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_ready(self):
+        """Log all slash commands once synced."""
+        try:
+            cmds = await self.bot.tree.sync(guild=discord.Object(id=cfg.GUILD_ID))
+            for cmd in cmds:
+                log.info("[TEST] Synced /%s", cmd.name)
+        except Exception as e:
+            log.exception("[TEST] Failed to sync slash commands: %s", e)
 
     @commands.Cog.listener()
     async def on_interaction(self, interaction: discord.Interaction):


### PR DESCRIPTION
## Summary
- add a ready listener in test_logging_cog to sync slash commands and log each one

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ced401e4832b9f6e8270e0d4ec8f