### PR TITLE
Handle Yahoo Finance rate limit

### DIFF
--- a/cogs/market_cog.py
+++ b/cogs/market_cog.py
@@ -30,6 +30,7 @@ import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 import pytz
 import yfinance as yf
+from yfinance.exceptions import YFRateLimitError
 import pandas as pd
 
 import bot_config as cfg
@@ -158,6 +159,10 @@ class MarketCog(commands.Cog):
         except asyncio.TimeoutError:
             log.exception("Timeout retrieving earnings for %s", symbol)
             await itx.followup.send("Could not retrieve earnings data right now.")
+            return
+        except YFRateLimitError:
+            log.warning("Rate limit hit retrieving earnings for %s", symbol)
+            await itx.followup.send("Yahoo Finance rate limit reached. Please try again later.")
             return
         except Exception:
             log.exception("Error retrieving earnings for %s", symbol)


### PR DESCRIPTION
## Summary
- handle YFRateLimitError in `/earnings`
- add specific message when the Yahoo Finance API rate limit is hit

## Testing
- `python -m py_compile main.py cogs/*.py bot_config.py`


------
https://chatgpt.com/codex/tasks/task_e_6840d28f3a30832ba015ff17ba80742d