### PR TITLE
Add root AGENTS guide for Discord bot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Repository Guide
+
+Gentlebot is a modular Discord bot built with **discord.py** v2. Each feature lives in a separate _cog_ under the `cogs/` folder. The bot integrates with third‑party APIs such as Hugging Face and Yahoo Finance.
+
+## Running the bot
+1. Create a virtual environment and install the libraries listed in the README.
+2. Create a `.env` file containing `DISCORD_TOKEN` and other IDs (see `bot_config.py`).
+3. Use `./dev_run.sh` during development for auto‑restart when files change. For production use `./run_bot.sh` or run `python main.py` with `env=PROD`.
+
+## Adding new features
+- Write each feature as a `commands.Cog` subclass in a new file ending with `_cog.py` under `cogs/`.
+- The bot automatically loads all cogs on startup.
+- Keep Discord responses under 1900 characters and use async functions.
+- Include a short docstring explaining any new commands.
+
+## Interacting with APIs
+- API tokens and IDs are read from `.env` variables. Never commit actual tokens.
+- The Hugging Face cogs require `HF_API_TOKEN`; other cogs may use public APIs.
+
+No automated test suite is present. Run `./dev_run.sh` and interact with the bot in a test guild to verify changes.


### PR DESCRIPTION
## Summary
- add `AGENTS.md` describing how to run Gentlebot, add cogs, and manage API tokens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840e5025cd8832b8f713ee189b5278a