### PR TITLE
Fix StatsCog default parameter

### DIFF
--- a/cogs/stats_cog.py
+++ b/cogs/stats_cog.py
@@ -244,7 +244,7 @@ class StatsCog(commands.Cog):
     async def engagement(
         self,
         interaction: discord.Interaction,
-        time_window: app_commands.Choice[str] = app_commands.Choice(name="Days", value="days"),
+        time_window: app_commands.Choice[str] = "days",
         chart: app_commands.Choice[str] | None = None,
     ):
         log.info("/engagement invoked by %s in %s", interaction.user.id, getattr(interaction.channel, "name", interaction.channel_id))


### PR DESCRIPTION
## Summary
- fix invalid default parameter type for `engagement`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6840e4c96c8c832b981b1835dbb2dc9b