### PR TITLE
Fix timezone comparison bug

### DIFF
--- a/cogs/stats_cog.py
+++ b/cogs/stats_cog.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import logging
 from collections import defaultdict
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 import random
 import io
 import matplotlib
@@ -51,7 +51,7 @@ class StatsCog(commands.Cog):
             "months": 12 * 30,
         }[window]
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         after = now - timedelta(days=span_days * 2)
         start_current = now - timedelta(days=span_days)
 


### PR DESCRIPTION
## Summary
- make datetimes timezone aware in stats cog

## Testing
- `./dev_run.sh` *(fails: venv missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840e64a72b0832b8543cd4ce301a46c