### PR TITLE
Fix reaction user iteration in StatsCog

### DIFF
--- a/cogs/stats_cog.py
+++ b/cogs/stats_cog.py
@@ -87,7 +87,7 @@ class StatsCog(commands.Cog):
                     # reactions on this message
                     for reaction in msg.reactions:
                         try:
-                            users = await reaction.users().flatten()
+                            users = [u async for u in reaction.users()]
                         except Exception as e:
                             log.exception("Reaction fetch failed for %s: %s", reaction.message.id, e)
                             continue


### PR DESCRIPTION
## Summary
- fetch reaction users with async list comprehension

## Testing
- `python -m py_compile cogs/stats_cog.py`

------
https://chatgpt.com/codex/tasks/task_e_6840e87f2f30832bab30744be0b5f38b