### PR TITLE
Sync slash commands once

### DIFF
--- a/cogs/huggingface_cog.py
+++ b/cogs/huggingface_cog.py
@@ -66,12 +66,6 @@ class HuggingFaceCog(commands.Cog):
     async def on_ready(self):
         bot_id = self.bot.user.id
         self.mention_strs = [f"<@{bot_id}>", f"<@!{bot_id}>"]
-        # Sync slash commands once we're ready
-        try:
-            await self.bot.tree.sync()
-            log.info("Slash commands synced on ready.")
-        except Exception as e:
-            log.exception("Failed to sync commands: %s", e)
         log.info("Ready to interact with the guild.")
 
     def sanitize_prompt(self, raw: str) -> str | None:

--- a/cogs/stats_cog.py
+++ b/cogs/stats_cog.py
@@ -31,15 +31,6 @@ class StatsCog(commands.Cog):
         if window == "months":
             return date(dt.year, dt.month, 1)
         return dt.date()
-
-    @commands.Cog.listener()
-    async def on_ready(self):
-        try:
-            await self.bot.tree.sync()
-            log.info("Slash commands synced on ready.")
-        except Exception as e:
-            log.exception("Failed to sync commands: %s", e)
-
     async def _gather_stats(self, window: str, per_channel: int = 1000):
         """Collect message, reaction and event stats for the given time window."""
         guild = self.bot.get_guild(cfg.GUILD_ID)

--- a/cogs/test_logging_cog.py
+++ b/cogs/test_logging_cog.py
@@ -16,13 +16,9 @@ class TestLoggingCog(commands.Cog):
 
     @commands.Cog.listener()
     async def on_ready(self):
-        """Log all slash commands once synced."""
-        try:
-            cmds = await self.bot.tree.sync(guild=discord.Object(id=cfg.GUILD_ID))
-            for cmd in cmds:
-                log.info("[TEST] Synced /%s", cmd.name)
-        except Exception as e:
-            log.exception("[TEST] Failed to sync slash commands: %s", e)
+        """Log all registered slash commands."""
+        for cmd in self.bot.tree.get_commands():
+            log.info("[TEST] Loaded /%s", cmd.name)
 
     @commands.Cog.listener()
     async def on_interaction(self, interaction: discord.Interaction):

--- a/main.py
+++ b/main.py
@@ -45,9 +45,19 @@ class GentleBot(commands.Bot):
 
 bot = GentleBot(command_prefix="!", intents=intents)
 
+_synced = False
+
 @bot.event
 async def on_ready():
+    global _synced
     logger.info("%s is now online in this guild", bot.user)
+    if not _synced:
+        try:
+            cmds = await bot.tree.sync()
+            logger.info("Synced %d commands.", len(cmds))
+        except Exception as e:
+            logger.exception("Failed to sync commands: %s", e)
+        _synced = True
 
 @bot.event
 async def on_error(event: str, *args, **kwargs):


### PR DESCRIPTION
## Summary
- stop syncing each cog independently
- sync slash commands once globally on ready
- log loaded commands in test cog

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684239504508832bab9337515f5dd360