### PR TITLE
Add Docker support for Raspberry Pi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Dockerfile for Gentlebot on Raspberry Pi
+# Uses Python 3 on Debian and installs system build deps
+
+FROM arm64v8/python:3.11-slim-bookworm
+
+# Install build tools and libraries required by Pillow and Matplotlib
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    python3-dev \
+    libatlas-base-dev \
+    libffi-dev \
+    libssl-dev \
+    libjpeg-dev \
+    libopenjp2-7 \
+    libtiff5 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir python-dateutil pytz beautifulsoup4 \
+        yfinance matplotlib pandas huggingface-hub watchdog
+
+# Copy source code
+COPY . .
+
+# Set default environment to production
+ENV env=PROD
+
+CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ sudo apt install python3-dev build-essential libatlas-base-dev libffi-dev \
     libssl-dev libjpeg-dev libopenjp2-7 libtiff5
 ```
 
+## Docker
+
+You can also run the bot inside a container on a Raspberry Pi. A `Dockerfile`
+is provided. Build the image and pass your `.env` file at runtime:
+
+```bash
+docker build -t gentlebot .
+docker run --env-file .env --rm gentlebot
+```
+
 ## Notes
 
 - `BOT_ENV` controls whether `bot_config.py` loads **TEST** or **PROD** IDs.


### PR DESCRIPTION
## Summary
- add a Dockerfile that installs system dependencies and Python packages
- document how to build and run the container on Raspberry Pi

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `bash -n dev_run.sh run_bot.sh`


------
https://chatgpt.com/codex/tasks/task_e_6844a7f83924832bad8fffc89a34e4dc