### PR TITLE
Fix error handling in role removal

### DIFF
--- a/cogs/roles_cog.py
+++ b/cogs/roles_cog.py
@@ -249,8 +249,16 @@ class RoleCog(commands.Cog):
 
     async def _remove(self, member: discord.Member, role_id: int):
         role = member.guild.get_role(role_id)
-        if role and role in member.roles:
+        if not role:
+            log.error("ERROR - role_id=%s not found in guild %s", role_id, member.guild.id)
+            return
+        if role not in member.roles:
+            return
+        try:
             await member.remove_roles(role, reason="RoleCog auto-remove")
+            log.info("Successfully removed role %s (%s) from member %s", role.name, role_id, member.id)
+        except Exception as e:
+            log.error("Failed removing role %s from %s: %s", role_id, member.id, e)
 
 async def setup(bot: commands.Bot):
     await bot.add_cog(RoleCog(bot))


### PR DESCRIPTION
## Summary
- gracefully handle exceptions when removing roles

## Testing
- `python -m py_compile cogs/roles_cog.py`

------
https://chatgpt.com/codex/tasks/task_e_68426d3271fc832bbc29be4c11f0589c