### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,37 @@
+name: Build & publish Gentlebot image
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.sha }}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl-dev \
     libjpeg-dev \
     libopenjp2-7 \
-    libtiff5 \
+    libtiff6 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Dockerfile for Gentlebot on Raspberry Pi
+# Uses Python 3 on Debian and installs system build deps
+
+FROM arm64v8/python:3.11-slim-bookworm
+
+# Install build tools and libraries required by Pillow and Matplotlib
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    python3-dev \
+    libatlas-base-dev \
+    libffi-dev \
+    libssl-dev \
+    libjpeg-dev \
+    libopenjp2-7 \
+    libtiff5 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir python-dateutil pytz beautifulsoup4 \
+        yfinance matplotlib pandas huggingface-hub watchdog
+
+# Copy source code
+COPY . .
+
+# Set default environment to production
+ENV env=PROD
+
+CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -84,6 +84,28 @@ sudo apt install python3-dev build-essential libatlas-base-dev libffi-dev \
     libssl-dev libjpeg-dev libopenjp2-7 libtiff5
 ```
 
+## Docker
+
+You can also run the bot inside a container on a Raspberry Pi. A `Dockerfile`
+is provided. Build the image and pass your `.env` file at runtime:
+
+```bash
+docker build -t gentlebot .
+docker run --env-file .env --rm gentlebot
+```
+
+### GitHub Actions
+
+A workflow in `.github/workflows/docker-image.yml` automatically builds and
+pushes a multi-architecture image to **GitHub Container Registry** whenever the
+`main` branch is updated. The image is tagged with `latest` and the commit SHA.
+You can pull and run the prebuilt container instead of building locally:
+
+```bash
+docker pull ghcr.io/<owner>/<repo>:latest
+docker run --env-file .env --rm ghcr.io/<owner>/<repo>:latest
+```
+
 ## Notes
 
 - `BOT_ENV` controls whether `bot_config.py` loads **TEST** or **PROD** IDs.


### PR DESCRIPTION
## Summary
- automatically build a multi-arch Docker image on pushes to `main`
- document the workflow in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `bash -n dev_run.sh run_bot.sh`


------
https://chatgpt.com/codex/tasks/task_e_6844a7f83924832bad8fffc89a34e4dc