### PR TITLE
Fix crash in MarketMoodCog when price missing

### DIFF
--- a/cogs/market_mood_cog.py
+++ b/cogs/market_mood_cog.py
@@ -69,12 +69,20 @@ class MarketMoodCog(commands.Cog):
 
     async def _fetch_quote_price(self, symbol: str) -> Optional[float]:
         try:
-            j = await self._get_json({"function": "GLOBAL_QUOTE", "symbol": symbol, "apikey": cfg.ALPHA_VANTAGE_KEY})
+            j = await self._get_json(
+                {
+                    "function": "GLOBAL_QUOTE",
+                    "symbol": symbol,
+                    "apikey": cfg.ALPHA_VANTAGE_KEY,
+                }
+            )
             quote = j.get("Global Quote", {})
-            return float(quote.get("05. price"))
+            price = quote.get("05. price")
+            if price is not None:
+                return float(price)
         except Exception:
             log.exception("Failed to fetch price for %s", symbol)
-            return None
+        return None
 
     async def _fetch_yield(self) -> Optional[float]:
         try:


### PR DESCRIPTION
## Summary
- handle missing AlphaVantage price data when building the Market Mood Ring

## Testing
- `./dev_run.sh` *(fails: venv missing)*

------
https://chatgpt.com/codex/tasks/task_e_6848ec6966d4832bb170aa39ac1d8f15