### PR TITLE
Add ephemeral response to version command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Gentlebot is a modular Discord bot composed of several **cogs** that handle diff
 - **StatsCog** – `/engagement` now replies "Working on it..." and then gathers
   unlimited history in the background before posting the stats and optional
   activity chart.
+- **VersionCog** – `/version` prints the current commit hash for debugging.
 
 ## Repository Layout
 ```

--- a/cogs/version_cog.py
+++ b/cogs/version_cog.py
@@ -1,0 +1,36 @@
+"""
+version_cog.py – Simple version info command for Gentlebot
+==========================================================
+Provides a slash command `/version` that returns the current Git commit
+hash for debugging purposes.
+"""
+from __future__ import annotations
+
+import logging
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from version import VERSION
+from util import chan_name
+
+log = logging.getLogger(__name__)
+
+
+class VersionCog(commands.Cog):
+    """Slash command to show the running Gentlebot version."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @app_commands.command(name="version", description="Show the current bot version")
+    async def version(self, interaction: discord.Interaction):
+        """Reply with the Git commit hash of the running bot."""
+        log.info("/version invoked by %s in %s", interaction.user.id, chan_name(interaction.channel))
+        await interaction.response.send_message(
+            f"Gentlebot version: {VERSION}", ephemeral=True
+        )
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(VersionCog(bot))

--- a/version.py
+++ b/version.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+import subprocess
+from pathlib import Path
+
+
+def get_version() -> str:
+    """Return short git commit hash or 'unknown'."""
+    try:
+        repo_dir = Path(__file__).parent
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"], cwd=repo_dir
+        )
+        return out.decode().strip()
+    except Exception:
+        return "unknown"
+
+
+VERSION = get_version()


### PR DESCRIPTION
## Summary
- make `/version` replies ephemeral so only the invoking user can see them

## Testing
- `python -m py_compile version.py cogs/version_cog.py`
- `python -m py_compile cogs/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6848f56286a0832b9e6bac33962d446f