### PR TITLE
Show PST times for nextf1 command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ dev_run.sh         # auto-restart helper (dev)
    ```bash
    pip install -r requirements.txt
    pip install python-dateutil pytz beautifulsoup4 yfinance matplotlib pandas \
-       huggingface-hub watchdog
+       timezonefinder huggingface-hub watchdog
    ```
 4. Create a `.env` file with your bot token and other IDs (see `bot_config.py` for variables).  Example:
    ```ini

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ discord.py>=2.3
 requests
 feedparser
 python-dotenv>=1.0.0
+timezonefinder


### PR DESCRIPTION
## Summary
- fetch track timezone using timezonefinder
- show session times in PST and local track time
- mention timezonefinder in docs and requirements

## Testing
- `python -m py_compile cogs/f1_cog.py`

------
https://chatgpt.com/codex/tasks/task_e_6848f7d8f244832b94ba18d455127df1