### PR TITLE
Disable market mood ring

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Gentlebot is a modular Discord bot composed of several **cogs** that handle diff
 ## Features
 - **F1Cog** – `/nextf1` and `/f1standings` commands show upcoming Formula 1 sessions and current standings.
 - **MarketCog** – `/stock` renders stock charts with Matplotlib and `/earnings` shows the next earnings date.
-- **MarketMoodCog** – posts a daily "Market Mood Ring" with a Monday sentiment poll and Friday wrap-up.
+- **MarketMoodCog** – *(disabled)* posts a daily "Market Mood Ring" with a Monday sentiment poll and Friday wrap-up.
 - **RolesCog** – Manages vanity reaction roles and activity‑based roles.
 - **PromptCog** – Posts a daily prompt generated via the Hugging Face API.
 - **HuggingFaceCog** – Adds AI conversation and emoji reactions using Hugging Face models.
@@ -47,8 +47,9 @@ dev_run.sh         # auto-restart helper (dev)
    DISCORD_TOKEN=<your bot token>
    DISCORD_APPLICATION_ID=<app id>
    DISCORD_GUILD_ID=<guild id>
-   ALPHA_VANTAGE_KEY=<alpha vantage api key>
-   MONEY_TALK_CHANNEL=<market mood channel id>
+    ALPHA_VANTAGE_KEY=<alpha vantage api key>
+    MONEY_TALK_CHANNEL=<market mood channel id>
+    ENABLE_MARKET_MOOD=1  # set to 1 to enable the Market Mood Ring
    ```
 5. Run the bot:
    ```bash

--- a/bot_config.py
+++ b/bot_config.py
@@ -28,6 +28,7 @@ IS_TEST = env == "TEST"
 # ─── Tokens ───────────────────────────────────────────────────────────────
 TOKEN = os.getenv("DISCORD_TOKEN")
 ALPHA_VANTAGE_KEY = os.getenv("ALPHA_VANTAGE_KEY")
+ENABLE_MARKET_MOOD = os.getenv("ENABLE_MARKET_MOOD", "0") == "1"
 
 # ─── IDs per environment ──────────────────────────────────────────────────
 if IS_TEST:

--- a/main.py
+++ b/main.py
@@ -40,6 +40,9 @@ class GentleBot(commands.Bot):
         for file in cog_dir.glob("*_cog.py"):
             if file.stem == "test_logging_cog" and not cfg.IS_TEST:
                 continue
+            if file.stem == "market_mood_cog" and not cfg.ENABLE_MARKET_MOOD:
+                logger.info("Market mood ring disabled; skipping %s", file.stem)
+                continue
             await self.load_extension(f"cogs.{file.stem}")
 
 


### PR DESCRIPTION
## Summary
- disable MarketMoodCog via new config constant
- skip loading the cog unless `ENABLE_MARKET_MOOD=1`
- document new setting and mark the feature as disabled

## Testing
- `python -m py_compile bot_config.py main.py cogs/market_mood_cog.py`

------
https://chatgpt.com/codex/tasks/task_e_6855ab2410b8832bb2ce580ad1cde569