### PR TITLE
Update fallback prompts

### DIFF
--- a/cogs/prompt_cog.py
+++ b/cogs/prompt_cog.py
@@ -38,12 +38,106 @@ SCHEDULE_HOUR = getattr(cfg, 'PROMPT_SCHEDULE_HOUR', 8)
 
 # Fallback prompts
 FALLBACK_PROMPTS = [
-    "What's a book you think everyone should read?",
-    "If you could instantly learn any language, which would it be and why?",
-    "Share the last photo you took and tell us the story behind it.",
-    "What’s a habit you’ve picked up this year that’s improved your life?",
-    "What’s the weirdest fact you know?",
-    "Describe your dream vacation in three words.",
+    "If happiness was the national currency, what kind of work would make you rich?",
+    "What's a belief you've recently changed your mind about?",
+    "Do we have free will, or is everything predetermined?",
+    "Would society benefit more from truth at all costs or kindness at all costs?",
+    "What is one lesson you feel you learned too late in life?",
+    "How would humanity change if all humans lived to be 500 years old?",
+    "Is ignorance truly bliss?",
+    "Can morality exist independently of religion?",
+    "Would immortality be a gift or a curse?",
+    "Does art imitate life, or does life imitate art?",
+    "What's something you've accomplished that your younger self wouldn't believe?",
+    "What's one thing about your childhood you'd like to recreate as an adult?",
+    "If you could instantly master one skill, what would it be?",
+    "How do you recharge when you're emotionally drained?",
+    "What would your life look like if you had zero fear of failure?",
+    "Who is someone you're grateful to have in your life, and why?",
+    "What’s a personal boundary you've set recently?",
+    "What's your most unusual comfort food?",
+    "Describe a perfect Sunday afternoon.",
+    "How do you define personal success?",
+    "If you could live in any fictional world, which would you choose and why?",
+    "Imagine a world where people age backward. How would society adapt?",
+    "If you could teleport anywhere right now, where would you go?",
+    "If your life had a soundtrack, what would be the theme song?",
+    "If you could design a planet from scratch, what unique features would it have?",
+    "If you could experience someone else’s memory, whose would it be?",
+    "You wake up tomorrow fluent in a new language. Which language and why?",
+    "If colors had tastes, what flavor would blue be?",
+    "You get to write one law everyone must follow. What's your law?",
+    "Imagine you could have dinner with a historical figure—who and why?",
+    "What’s your favorite harmless conspiracy theory?",
+    "If animals could talk, which species would be the most annoying?",
+    "What's your favorite weird food combination?",
+    "What's an embarrassing story you're willing to share?",
+    "What's the funniest misunderstanding you've ever experienced?",
+    "If your life was a movie, who would narrate it?",
+    "Which emoji do you secretly wish existed?",
+    "If your pet could text you, what would their messages look like?",
+    "What is the most overrated snack?",
+    "Describe your personality as a type of bread.",
+    "What's your favorite morning ritual?",
+    "How do you keep your life organized?",
+    "What's one thing you bought that improved your quality of life significantly?",
+    "What's a trend you resisted but later enjoyed?",
+    "Do you prefer routine or spontaneity in your day-to-day life?",
+    "What’s one underrated habit that changed your life for the better?",
+    "What's your ideal way to spend a vacation day?",
+    "What’s something small you do that brings you consistent joy?",
+    "If you could simplify one aspect of your life immediately, what would it be?",
+    "Describe your perfect workspace setup.",
+    "What current technology feels like magic to you?",
+    "How would you feel if AI started managing all your communications?",
+    "If you could invent a new gadget, what problem would it solve?",
+    "What's a piece of technology you think humanity might regret inventing?",
+    "If you had the power to control technology for one day, what would you do?",
+    "Which future innovation do you look forward to most?",
+    "What’s one way technology has unexpectedly improved your life?",
+    "Should humans colonize other planets, or fix Earth first?",
+    "What tech product would you redesign completely?",
+    "How do you think the internet has changed your personality?",
+    "What's the last movie or show that genuinely surprised you?",
+    "If you could erase one film or book from your memory to experience it fresh again, which would it be?",
+    "What's your guilty pleasure TV show or movie?",
+    "What band or musician has influenced you most?",
+    "What’s a book you think everyone should read at least once?",
+    "Which fictional character do you identify with the most?",
+    "If you could host your own podcast, what would the main theme be?",
+    "Recommend a hidden gem (book, movie, or music).",
+    "What's the best live event you've ever attended?",
+    "What's an unpopular entertainment opinion you strongly hold?",
+    "What makes you feel immediately connected to someone new?",
+    "What quality do you value most in a friendship?",
+    "What's something you wish your community did better?",
+    "How do you navigate disagreements with people you care about?",
+    "What's a memorable act of kindness someone did for you?",
+    "How important are shared interests vs. shared values in friendships?",
+    "What's one thing people misunderstand about you?",
+    "How do you show appreciation to the people you care about?",
+    "When do you feel most connected to your community?",
+    "What's a lesson a friend taught you without realizing it?",
+    "What's the best professional advice you've ever received?",
+    "What motivates you beyond money and recognition?",
+    "If you didn't have to work for money, what would you do instead?",
+    "How do you know when it’s time to change jobs or careers?",
+    "What's a professional mistake you learned the most from?",
+    "Describe your ideal work culture.",
+    "How do you stay curious and continuously learn in your profession?",
+    "What's one thing your current career taught you about yourself?",
+    "How would your ideal workday look?",
+    "What's a professional achievement you're especially proud of?",
+    "What's one topic you could give an impromptu TED Talk on?",
+    "If you could only keep five possessions, what would they be?",
+    "How do you balance staying informed with avoiding information overload?",
+    "What's a random fact you love sharing with people?",
+    "What do you wish was taught more in schools?",
+    "What’s one rule you live your life by?",
+    "Do you think humans are fundamentally good or fundamentally flawed?",
+    "If you could see into the future, would you choose to look?",
+    "What's a challenge you initially hated but now appreciate?",
+    "What small daily pleasure makes life worth living for you?",
 ]
 
 # Prompt types for rotation
@@ -70,6 +164,8 @@ class PromptCog(commands.Cog):
         # Start with a random prompt type index
         self.rotation_index = random.randrange(len(PROMPT_TYPES))
         self._scheduler_task = None
+        self._unused_fallback = list(FALLBACK_PROMPTS)
+        random.shuffle(self._unused_fallback)
 
     def fetch_prompt(self) -> str:
         """Generate a new prompt via HF inference, including rotation and history."""
@@ -102,7 +198,10 @@ class PromptCog(commands.Cog):
                     return prompt
             except Exception as e:
                 log.exception("inference error: %s", e)
-        prompt = random.choice(FALLBACK_PROMPTS)
+        if not self._unused_fallback:
+            self._unused_fallback = list(FALLBACK_PROMPTS)
+            random.shuffle(self._unused_fallback)
+        prompt = self._unused_fallback.pop()
         self.history.append(prompt)
         return prompt
 


### PR DESCRIPTION
## Summary
- expand default fallback prompts to 100 items
- avoid repeating fallback prompts until all have been used

## Testing
- `python -m py_compile cogs/prompt_cog.py`

------
https://chatgpt.com/codex/tasks/task_e_6855abe6b56c832bbad9db4d6429ed98