### PR TITLE
Add fallback HF API token

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Gentlebot is a modular Discord bot built with **discord.py** v2. Each feature li
 - Include a short docstring explaining any new commands.
 
 ## Interacting with APIs
-- API tokens and IDs are read from `.env` variables. Never commit actual tokens.
-- The Hugging Face cogs require `HF_API_TOKEN`; other cogs may use public APIs.
+ - API tokens and IDs are read from `.env` variables. Never commit actual tokens.
+ - The Hugging Face cogs require `HF_API_TOKEN` and optionally `HF_API_TOKEN_ALT` for billing fallback; other cogs may use public APIs.
 
 No automated test suite is present. Run `./dev_run.sh` and interact with the bot in a test guild to verify changes.

--- a/README.md
+++ b/README.md
@@ -48,8 +48,11 @@ dev_run.sh         # auto-restart helper (dev)
    DISCORD_APPLICATION_ID=<app id>
    DISCORD_GUILD_ID=<guild id>
     ALPHA_VANTAGE_KEY=<alpha vantage api key>
-    MONEY_TALK_CHANNEL=<market mood channel id>
-    ENABLE_MARKET_MOOD=1  # set to 1 to enable the Market Mood Ring
+   MONEY_TALK_CHANNEL=<market mood channel id>
+   ENABLE_MARKET_MOOD=1  # set to 1 to enable the Market Mood Ring
+   HF_API_TOKEN=<hugging face token>
+   # optional fallback if the primary token hits a billing error
+   HF_API_TOKEN_ALT=<secondary hugging face token>
    ```
 5. Run the bot:
    ```bash
@@ -79,7 +82,9 @@ docker run --env-file .env --rm ghcr.io/<owner>/<repo>:latest
 
 ## Notes
 - `BOT_ENV` controls whether `bot_config.py` loads **TEST** or **PROD** IDs.
-- The Hugging Face cogs require an API key in `HF_API_TOKEN` and optionally `HF_MODEL`.
+ - The Hugging Face cogs require an API key in `HF_API_TOKEN` and optionally `HF_MODEL`.
+   You can provide a backup key in `HF_API_TOKEN_ALT` which will be used if the
+   primary token hits a billing error.
 
 ## Contributing
 Each cog is self-contained. Add a new `*_cog.py` file under `cogs/` and it will be loaded automatically.


### PR DESCRIPTION
## Summary
- support optional `HF_API_TOKEN_ALT` for HuggingFace inference
- retry with alternate API token on billing errors
- document the new environment variable

## Testing
- `python -m py_compile cogs/huggingface_cog.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6858ba97cc94832bbdaa75005a27e108