### PR TITLE
Remove character limits in /techmeme

### DIFF
--- a/cogs/techmeme_cog.py
+++ b/cogs/techmeme_cog.py
@@ -49,15 +49,9 @@ class TechmemeCog(commands.Cog):
             title = e.title
             summary = re.sub(r"<[^>]+>", "", getattr(e, "summary", ""))
             summary = html.unescape(summary).replace("\n", " ").strip()
-            if len(title) > 90:
-                title = title[:87] + "…"
-            if len(summary) > 120:
-                summary = summary[:117] + "…"
             lines.append(f"**{i}.** [{title}]({e.link}) - {summary}")
 
         text = "\n".join(lines)
-        if len(text) > 1900:
-            text = text[:1895] + "…"
 
         date_str = datetime.now(timezone.utc).strftime("%b %d")
         embed = discord.Embed(


### PR DESCRIPTION
## Summary
- stop truncating titles, summaries, and overall text in `techmeme` command

## Testing
- `python -m py_compile cogs/techmeme_cog.py`


------
https://chatgpt.com/codex/tasks/task_e_6858cb256f08832ba7fba8115230a0ae