### PR TITLE
Fix dev_run token check and add test harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ dev_run.sh         # auto-restart helper (dev)
    ./run_bot.sh
    ```
 During development you can use `./dev_run.sh` for automatic restarts when files change (requires `watchdog`).
+For a quick offline sanity check you can run `python test_harness.py` which loads all cogs without connecting to Discord.
 
 ## Docker
 You can also run the bot inside a container on a Raspberry Pi. A `Dockerfile`

--- a/dev_run.sh
+++ b/dev_run.sh
@@ -5,6 +5,13 @@ set -e
 
 cd "$(dirname "$0")"
 
+# Load environment variables from .env if present
+if [[ -f ".env" ]]; then
+    set -a
+    source .env
+    set +a
+fi
+
 # Activate virtual environment if present
 if [[ -f "venv/bin/activate" ]]; then
     source venv/bin/activate
@@ -13,6 +20,13 @@ fi
 # Ensure the bot loads the TEST config
 export env=TEST
 export BOT_ENV=TEST
+
+
+# Verify that a token is available; otherwise notify the user and exit
+if [[ -z "$DISCORD_TOKEN" ]]; then
+    echo "DISCORD_TOKEN not set. Create a .env file or export the token before running." >&2
+    exit 1
+fi
 
 cmd="python main.py"
 

--- a/test_harness.py
+++ b/test_harness.py
@@ -1,0 +1,39 @@
+import asyncio
+import logging
+import os
+
+import discord
+
+from bot_config import TOKEN
+
+from main import GentleBot
+
+
+class HarnessBot(GentleBot):
+    async def load_extension(self, name: str, *, package: str | None = None) -> None:
+        try:
+            await super().load_extension(name, package=package)
+        except Exception as e:
+            logging.warning("Skipping %s: %s", name, e)
+
+
+async def load_cogs() -> int:
+    bot = HarnessBot(command_prefix="!", intents=discord.Intents.none())
+    await bot.setup_hook()
+    count = len(bot.cogs)
+    await bot.close()
+    return count
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    os.environ.setdefault("HF_API_TOKEN", "dummy")
+    os.environ.setdefault("DISCORD_TOKEN", "dummy")
+    if not TOKEN:
+        logging.warning("DISCORD_TOKEN not set; cogs will still be loaded")
+    num = asyncio.run(load_cogs())
+    print(f"Loaded {num} cogs successfully")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- load environment vars from `.env` in `dev_run.sh`
- provide `test_harness.py` for offline cog loading
- document test harness in README

## Testing
- `python test_harness.py`
- `./dev_run.sh` with and without `.env`

------
https://chatgpt.com/codex/tasks/task_e_685cc28481cc832b81238d2dc05f629c