### PR TITLE
Fix dev_run token check and add test harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,22 +27,13 @@ cogs/               # feature cogs
   stats_cog.py      # engagement statistics
 run_bot.sh         # run helper (prod)
 dev_run.sh         # auto-restart helper (dev)
+setup.sh           # install dependencies and create the venv
 ```
 
 ## Setup
 1. Install Python 3.10 or newer.
-2. Create and activate a virtual environment:
-   ```bash
-   python -m venv venv
-   source venv/bin/activate
-   ```
-3. Install dependencies:
-   ```bash
-   pip install -r requirements.txt
-   pip install python-dateutil pytz beautifulsoup4 yfinance matplotlib pandas \
-       timezonefinder huggingface-hub watchdog
-   ```
-4. Create a `.env` file with your bot token and other IDs (see `bot_config.py` for variables).  Example:
+2. Run `./setup.sh` to create a virtual environment and install the required packages.  You can re-run it at any time to ensure everything is up to date.
+3. Create a `.env` file with your bot token and other IDs (see `bot_config.py` for variables).  Example:
    ```ini
    DISCORD_TOKEN=<your bot token>
    DISCORD_APPLICATION_ID=<app id>
@@ -54,11 +45,12 @@ dev_run.sh         # auto-restart helper (dev)
    # optional fallback if the primary token hits a billing error
    HF_API_TOKEN_ALT=<secondary hugging face token>
    ```
-5. Run the bot:
+4. Run the bot:
    ```bash
    ./run_bot.sh
    ```
-During development you can use `./dev_run.sh` for automatic restarts when files change (requires `watchdog`).
+During development you can use `./dev_run.sh` for automatic restarts when files change. Install the optional `watchfiles` or `watchdog` package for this convenience.
+Pass `--offline` to `dev_run.sh` (or set `BOT_OFFLINE=1`) to run the bundled `test_harness.py` instead, which loads all cogs without connecting to Discord.
 
 ## Docker
 You can also run the bot inside a container on a Raspberry Pi. A `Dockerfile`

--- a/dev_run.sh
+++ b/dev_run.sh
@@ -5,14 +5,50 @@ set -e
 
 cd "$(dirname "$0")"
 
+# parse optional --offline flag or BOT_OFFLINE env var
+OFFLINE=0
+if [[ "$1" == "--offline" ]]; then
+    OFFLINE=1
+    shift
+fi
+if [[ "${BOT_OFFLINE:-0}" == "1" ]]; then
+    OFFLINE=1
+fi
+
+# Load environment variables from .env if present
+if [[ -f ".env" ]]; then
+    set -a
+    source .env
+    set +a
+fi
+
 # Activate virtual environment if present
 if [[ -f "venv/bin/activate" ]]; then
     source venv/bin/activate
 fi
 
+if [[ "$OFFLINE" == "1" ]]; then
+    echo "Running in offline mode: loading cogs only" >&2
+    python test_harness.py
+    exit 0
+fi
+
 # Ensure the bot loads the TEST config
 export env=TEST
 export BOT_ENV=TEST
+
+
+# Verify that a token is available; otherwise notify the user and exit
+if [[ -z "$DISCORD_TOKEN" ]]; then
+    echo "DISCORD_TOKEN not set. Create a .env file or export the token before running." >&2
+    exit 1
+fi
+
+# Ensure discord.py is available before attempting to run
+if ! python -c "import discord" >/dev/null 2>&1; then
+    echo "discord.py is missing. Run 'pip install -r requirements.txt' first." >&2
+    exit 1
+fi
 
 cmd="python main.py"
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# setup.sh - Create virtual environment and install dependencies
+set -e
+cd "$(dirname "$0")"
+
+if [[ ! -d "venv" ]]; then
+    python3 -m venv venv
+fi
+
+source venv/bin/activate
+
+python -m pip install --upgrade pip
+
+python -m pip install -r requirements.txt
+
+# Optional extras used by certain cogs
+python -m pip install python-dateutil pytz beautifulsoup4 yfinance matplotlib pandas timezonefinder huggingface-hub watchfiles watchdog
+
+echo "Setup complete. Activate the environment with 'source venv/bin/activate'"

--- a/test_harness.py
+++ b/test_harness.py
@@ -1,0 +1,41 @@
+import asyncio
+import logging
+import os
+
+import discord
+
+os.environ.setdefault("env", "TEST")
+os.environ.setdefault("HF_API_TOKEN", "dummy")
+os.environ.setdefault("DISCORD_TOKEN", "dummy")
+
+from bot_config import TOKEN
+
+from main import GentleBot
+
+
+class HarnessBot(GentleBot):
+    async def load_extension(self, name: str, *, package: str | None = None) -> None:
+        try:
+            await super().load_extension(name, package=package)
+        except Exception as e:
+            logging.warning("Skipping %s: %s", name, e)
+
+
+async def load_cogs() -> int:
+    bot = HarnessBot(command_prefix="!", intents=discord.Intents.none())
+    await bot.setup_hook()
+    count = len(bot.cogs)
+    await bot.close()
+    return count
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    if not TOKEN:
+        logging.warning("DISCORD_TOKEN not set; cogs will still be loaded")
+    num = asyncio.run(load_cogs())
+    print(f"Loaded {num} cogs successfully")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- load env vars from `.env` in `dev_run.sh`
- provide `test_harness.py` for offline cog loading
- document test harness in README
- ensure dev runner warns when `discord.py` is missing
- add `setup.sh` script for installing dependencies
- refine test harness to set env vars before import
- add offline mode flag to dev runner script for testing in restricted environments

## Testing
- `python test_harness.py`
- `./dev_run.sh` (without token)
- `./dev_run.sh --offline`


------
https://chatgpt.com/codex/tasks/task_e_685cc28481cc832b81238d2dc05f629c