### PR TITLE
Fix Reaction Error with Ephemeral Messages

### DIFF
--- a/cogs/huggingface_cog.py
+++ b/cogs/huggingface_cog.py
@@ -230,6 +230,10 @@ class HuggingFaceCog(commands.Cog):
         if message.author.bot:
             return
 
+        # 1a) Ignore ephemeral messages to avoid reaction errors
+        if getattr(message.flags, "ephemeral", False):
+            return
+
         content = message.content.strip()
 
         # 2) Determine reaction probability


### PR DESCRIPTION
## Summary
- ignore ephemeral messages in the Hugging Face message listener

## Testing
- `pip install -q -r requirements.txt`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_686c867b53d0832bb5cdc35d7d7f9eb4