### PR TITLE
Fix refreshroles command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Gentlebot is a modular Discord bot composed of several **cogs** that handle diff
 - **SportsCog** – `/nextf1` and `/f1standings` plus `/bigdumper` for Mariners stats.
 - **MarketCog** – `/stock` renders stock charts with Matplotlib and `/earnings` shows the next earnings date.
 - **MarketsCog** – `/marketmood` shows a quick sentiment snapshot and `/marketbet` runs a weekly bull/bear game.
-- **RolesCog** – Manages vanity reaction roles and activity‑based roles.
+- **RolesCog** – Manages vanity reaction roles and activity‑based roles. Admins can run `/refreshroles` to trigger updates manually (admin‑only).
 - **PromptCog** – Posts a daily prompt generated via the Hugging Face API.
 - **HuggingFaceCog** – Adds AI conversation and emoji reactions using Hugging Face models.
 - **StatsCog** – `/engagement` now replies "Working on it..." and then gathers

--- a/cogs/roles_cog.py
+++ b/cogs/roles_cog.py
@@ -17,7 +17,10 @@ from datetime import datetime, timedelta, date
 import pytz
 
 import discord
+from discord import app_commands
 from discord.ext import commands, tasks
+
+from util import chan_name
 
 log = logging.getLogger(__name__)
 
@@ -54,6 +57,16 @@ class RoleCog(commands.Cog):
         self.first_drop_day: date | None = None
         self.first_drop_user: int | None = None
         self.badge_task.start()
+
+    @app_commands.command(name="refreshroles", description="Force badge and flag updates")
+    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.default_permissions(administrator=True)
+    async def refresh_roles(self, interaction: discord.Interaction):
+        """Admins can manually trigger the role rotation."""
+        log.info("/refreshroles invoked by %s in %s", interaction.user.id, chan_name(interaction.channel))
+        await interaction.response.defer(thinking=True, ephemeral=True)
+        await self.badge_task()
+        await interaction.followup.send("Role rotation complete.", ephemeral=True)
 
     async def _get_member(self, guild: discord.Guild, user_id: int) -> discord.Member | None:
         """Return a member from cache or fetch if missing."""


### PR DESCRIPTION
## Summary
- document `/refreshroles` in README
- fix the manual role rotation command to invoke the task correctly
- restrict `/refreshroles` to server administrators

## Testing
- `pip install -r requirements.txt`
- `pip install huggingface-hub`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ddfb18aa4832bb704e2d7de978591