### PR TITLE
Fix missing dependency for RolesCog

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 feedparser
 python-dotenv>=1.0.0
 timezonefinder
+pytz


### PR DESCRIPTION
## Summary
- include `pytz` in requirements so RolesCog loads properly

## Testing
- `./dev_run.sh --offline`

------
https://chatgpt.com/codex/tasks/task_e_686de5e33430832b9a438f78d305de0d