### PR TITLE
Improve refreshroles command error handling

### DIFF
--- a/cogs/roles_cog.py
+++ b/cogs/roles_cog.py
@@ -65,8 +65,17 @@ class RoleCog(commands.Cog):
         """Admins can manually trigger the role rotation."""
         log.info("/refreshroles invoked by %s in %s", interaction.user.id, chan_name(interaction.channel))
         await interaction.response.defer(thinking=True, ephemeral=True)
-        await self.badge_task()
-        await interaction.followup.send("Role rotation complete.", ephemeral=True)
+        try:
+            await self.badge_task()
+        except Exception as exc:
+            log.exception("refreshroles failed: %s", exc)
+            await interaction.followup.send(
+                "Failed to refresh roles.", ephemeral=True
+            )
+        else:
+            await interaction.followup.send(
+                "Role rotation complete.", ephemeral=True
+            )
 
     async def _get_member(self, guild: discord.Guild, user_id: int) -> discord.Member | None:
         """Return a member from cache or fetch if missing."""

--- a/main.py
+++ b/main.py
@@ -71,6 +71,15 @@ async def on_error(event: str, *args, **kwargs):
 async def on_command_error(ctx: commands.Context, exc: commands.CommandError):
     logger.exception("Error in command '%s'", getattr(ctx.command, 'name', 'unknown'), exc_info=exc)
 
+@bot.tree.error
+async def on_app_command_error(interaction: discord.Interaction, exc: discord.app_commands.AppCommandError):
+    cmd_name = getattr(interaction.command, "name", "unknown")
+    logger.exception("Error in slash command '%s'", cmd_name, exc_info=exc)
+    if interaction.response.is_done():
+        await interaction.followup.send("An error occurred.", ephemeral=True)
+    else:
+        await interaction.response.send_message("An error occurred.", ephemeral=True)
+
 async def main():
     async with bot:
         await bot.start(cfg.TOKEN)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 feedparser
 python-dotenv>=1.0.0
 timezonefinder
+pytz


### PR DESCRIPTION
## Summary
- add slash command error logging
- log and reply if `/refreshroles` fails

## Testing
- `./dev_run.sh --offline` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686de5e33430832b9a438f78d305de0d