### PR TITLE
Fix ghost role default last-online check

### DIFF
--- a/cogs/roles_cog.py
+++ b/cogs/roles_cog.py
@@ -264,7 +264,8 @@ class RoleCog(commands.Cog):
         for member in guild.members:
             if member.bot:
                 continue
-            last = self.last_online.get(member.id, datetime.fromtimestamp(0, tz=timezone.utc))
+            # Default last online to now so new members aren't immediately flagged
+            last = self.last_online.get(member.id, now)
             if now - last > timedelta(days=14):
                 await self._assign_flag(guild, member, ROLE_GHOST)
                 continue


### PR DESCRIPTION
## Summary
- fix default last-online fallback so new members aren't all flagged as ghosts

## Testing
- `python -m py_compile cogs/roles_cog.py`


------
https://chatgpt.com/codex/tasks/task_e_686e8015d36c832ba1db0e314ee44167