### PR TITLE
Improve /refreshroles

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Gentlebot is a modular Discord bot composed of several **cogs** that handle diff
 - **SportsCog** – `/nextf1` and `/f1standings` plus `/bigdumper` for Mariners stats.
 - **MarketCog** – `/stock` renders stock charts with Matplotlib and `/earnings` shows the next earnings date.
 - **MarketsCog** – `/marketmood` shows a quick sentiment snapshot and `/marketbet` runs a weekly bull/bear game.
-- **RolesCog** – Manages vanity reaction roles and activity‑based roles. Admins can run `/refreshroles` to trigger updates manually (admin‑only).
+- **RolesCog** – Manages vanity reaction roles and activity‑based roles. Admins
+  can run `/refreshroles` to fetch 14 days of history and refresh roles
+  manually (admin‑only).
   Ensure the bot's role is above these vanity roles and has the **Manage Roles** permission so it can assign and remove them.
 - **PromptCog** – Posts a daily prompt generated via the Hugging Face API.
 - **HuggingFaceCog** – Adds AI conversation and emoji reactions using Hugging Face models.


### PR DESCRIPTION
## Summary
- refreshroles fetches last 14d of history before rotation
- document the new behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e87b37fe8832bb953fe0a8fd6e2c0