### PR TITLE
Enable debug logs by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN pip install --no-cache-dir -r requirements.txt \
 # Copy source code
 COPY . .
 
-# Set default environment to production
+# Set default environment to production and enable debug logging
 ENV env=PROD
+ENV LOG_LEVEL=DEBUG
 
 CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ docker pull ghcr.io/<owner>/<repo>:latest
 docker run --env-file .env --rm ghcr.io/<owner>/<repo>:latest
 ```
 
+The container sets `LOG_LEVEL=DEBUG` so logs are verbose by default.
+
 ## Notes
 - `BOT_ENV` controls whether `bot_config.py` loads **TEST** or **PROD** IDs.
  - The Hugging Face cogs require an API key in `HF_API_TOKEN` and optionally `HF_MODEL`.

--- a/run_bot.sh
+++ b/run_bot.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 source venv/bin/activate
 export env=PROD
+export LOG_LEVEL=DEBUG
 python main.py


### PR DESCRIPTION
## Summary
- configure container with LOG_LEVEL=DEBUG
- ensure `run_bot.sh` also uses debug logging
- document the default debug level in README

## Testing
- `python test_harness.py` *(fails: ModuleNotFoundError: matplotlib etc)*

------
https://chatgpt.com/codex/tasks/task_e_686e8f863f14832baaa1b64014d1f260