### PR TITLE
Fix cog logging hierarchy

### DIFF
--- a/cogs/huggingface_cog.py
+++ b/cogs/huggingface_cog.py
@@ -16,7 +16,8 @@ from util import chan_name
 from huggingface_hub import InferenceClient
 
 
-log = logging.getLogger(__name__)
+# Use a hierarchical logger so messages propagate to the main gentlebot logger
+log = logging.getLogger(f"gentlebot.{__name__}")
 
 
 class HuggingFaceCog(commands.Cog):

--- a/cogs/market_cog.py
+++ b/cogs/market_cog.py
@@ -36,7 +36,8 @@ import pandas as pd
 
 import bot_config as cfg
 
-log = logging.getLogger(__name__)
+# Use a hierarchical logger so messages propagate to the main gentlebot logger
+log = logging.getLogger(f"gentlebot.{__name__}")
 
 # ── ENV -------------------------------------------------------------------
 TOKEN    = cfg.TOKEN

--- a/cogs/markets_cog.py
+++ b/cogs/markets_cog.py
@@ -23,7 +23,8 @@ import requests
 import bot_config as cfg
 from util import chan_name
 
-log = logging.getLogger(__name__)
+# Use a hierarchical logger so messages propagate to the main gentlebot logger
+log = logging.getLogger(f"gentlebot.{__name__}")
 
 NY_TZ = ZoneInfo("US/Eastern")
 PT_TZ = ZoneInfo("US/Pacific")

--- a/cogs/prompt_cog.py
+++ b/cogs/prompt_cog.py
@@ -30,7 +30,8 @@ from huggingface_hub import InferenceClient
 import bot_config as cfg
 from zoneinfo import ZoneInfo
 
-log = logging.getLogger(__name__)
+# Use a hierarchical logger so messages propagate to the main gentlebot logger
+log = logging.getLogger(f"gentlebot.{__name__}")
 
 # Timezone for scheduling
 LOCAL_TZ = ZoneInfo("America/Los_Angeles")

--- a/cogs/roles_cog.py
+++ b/cogs/roles_cog.py
@@ -22,7 +22,8 @@ from discord.ext import commands, tasks
 
 from util import chan_name
 
-log = logging.getLogger(__name__)
+# Use a hierarchical logger so messages propagate to the main gentlebot logger
+log = logging.getLogger(f"gentlebot.{__name__}")
 
 import bot_config as cfg
 

--- a/cogs/sports_cog.py
+++ b/cogs/sports_cog.py
@@ -32,7 +32,8 @@ from bs4 import BeautifulSoup
 # ── time zones --------------------------------------------------------------
 import bot_config as cfg
 
-log = logging.getLogger(__name__)
+# Use a hierarchical logger so messages propagate to the main gentlebot logger
+log = logging.getLogger(f"gentlebot.{__name__}")
 
 # Local timezone for display (fallback to UTC)
 LOCAL_TZ = pytz.timezone(os.getenv("LOCAL_TZ", "UTC"))

--- a/cogs/stats_cog.py
+++ b/cogs/stats_cog.py
@@ -18,7 +18,8 @@ from discord.ext import commands
 import bot_config as cfg
 from util import chan_name
 
-log = logging.getLogger(__name__)
+# Use a hierarchical logger so messages propagate to the main gentlebot logger
+log = logging.getLogger(f"gentlebot.{__name__}")
 
 
 class StatsCog(commands.Cog):

--- a/cogs/techmeme_cog.py
+++ b/cogs/techmeme_cog.py
@@ -17,7 +17,8 @@ from bs4 import BeautifulSoup
 
 from util import chan_name
 
-log = logging.getLogger(__name__)
+# Use a hierarchical logger so messages propagate to the main gentlebot logger
+log = logging.getLogger(f"gentlebot.{__name__}")
 
 TECHMEME_RSS = "https://www.techmeme.com/feed.xml"
 

--- a/cogs/version_cog.py
+++ b/cogs/version_cog.py
@@ -14,7 +14,8 @@ from discord.ext import commands
 from version import VERSION
 from util import chan_name
 
-log = logging.getLogger(__name__)
+# Use a hierarchical logger so messages propagate to the main gentlebot logger
+log = logging.getLogger(f"gentlebot.{__name__}")
 
 
 class VersionCog(commands.Cog):

--- a/cogs/vibecheck_cog.py
+++ b/cogs/vibecheck_cog.py
@@ -22,7 +22,8 @@ from huggingface_hub import InferenceClient
 from util import chan_name
 import bot_config as cfg
 
-log = logging.getLogger(__name__)
+# Use a hierarchical logger so messages propagate to the main gentlebot logger
+log = logging.getLogger(f"gentlebot.{__name__}")
 
 
 UNICODE_EMOJI_RE = re.compile(


### PR DESCRIPTION
## Summary
- use a hierarchical logger name in each cog so log messages propagate to the main logger
- keep root logging setup untouched

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e99339f58832b80303c84a91a7cd1