### PR TITLE
Add rotating log file handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ venv.bak/
 
 # Logs and install artifacts
 *.log
+logs/
 pip-log.txt
 pip-delete-this-directory.txt
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ setup.sh           # install dependencies and create the venv
    ```bash
    ./run_bot.sh
    ```
-During development you can use `./dev_run.sh` for automatic restarts when files change. Install the optional `watchfiles` or `watchdog` package for this convenience.
+During development you can use `./dev_run.sh` for automatic restarts when files change. Install the optional `watchfiles` or `watchdog` package for this convenience. Logs are written to `logs/bot.log` with daily rotation so you can review past activity.
 Pass `--offline` to `dev_run.sh` (or set `BOT_OFFLINE=1`) to run the bundled `test_harness.py` instead, which loads all cogs without connecting to Discord.
 
 ## Docker

--- a/main.py
+++ b/main.py
@@ -22,11 +22,14 @@ file_handler = TimedRotatingFileHandler(
     log_dir / "bot.log", when="midnight", backupCount=90
 )
 file_handler.setFormatter(log_format)
-logger.addHandler(file_handler)
 
 console_handler = logging.StreamHandler()
 console_handler.setFormatter(log_format)
-logger.addHandler(console_handler)
+
+root_logger = logging.getLogger()
+root_logger.setLevel(level)
+root_logger.addHandler(file_handler)
+root_logger.addHandler(console_handler)
 
 logger.info(
     "Starting GentleBot in %s environment with level %s",

--- a/test_harness.py
+++ b/test_harness.py
@@ -30,7 +30,7 @@ async def load_cogs() -> int:
 
 
 def main():
-    logging.basicConfig(level=logging.INFO)
+    logging.getLogger().setLevel(logging.INFO)
     if not TOKEN:
         logging.warning("DISCORD_TOKEN not set; cogs will still be loaded")
     num = asyncio.run(load_cogs())


### PR DESCRIPTION
## Summary
- ensure root logger writes to `logs/bot.log`
- document log file location in README
- tweak test harness logging level
- ignore `logs/` directory

## Testing
- `./dev_run.sh --offline`

------
https://chatgpt.com/codex/tasks/task_e_686e9a4cfcc8832ba4584ee0093f3629