### PR TITLE
Auto refresh roles on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ Gentlebot is a modular Discord bot composed of several **cogs** that handle diff
 - **SportsCog** – `/nextf1` and `/f1standings` plus `/bigdumper` for Mariners stats.
 - **MarketCog** – `/stock` renders stock charts with Matplotlib and `/earnings` shows the next earnings date.
 - **MarketsCog** – `/marketmood` shows a quick sentiment snapshot and `/marketbet` runs a weekly bull/bear game.
-- **RolesCog** – Manages vanity reaction roles and activity‑based roles. Admins
-  can run `/refreshroles` to fetch 14 days of history and refresh roles
-  manually (admin‑only).
-  Ensure the bot's role is above these vanity roles and has the **Manage Roles** permission so it can assign and remove them.
+**RolesCog** – Manages vanity reaction roles and activity-based roles. Roles are
+  refreshed automatically on startup so redeployments keep badges up to date.
+  Admins can still run `/refreshroles` to fetch 14 days of history and refresh
+  roles manually. Ensure the bot's role is above these vanity roles and has the
+  **Manage Roles** permission so it can assign and remove them.
 - **PromptCog** – Posts a daily prompt generated via the Hugging Face API.
 - **HuggingFaceCog** – Adds AI conversation and emoji reactions using Hugging Face models.
 - **StatsCog** – `/engagement` now replies "Working on it..." and then gathers

--- a/cogs/roles_cog.py
+++ b/cogs/roles_cog.py
@@ -2,6 +2,9 @@
 ================================
 Rotating engagement badges and inactivity flags.
 
+Roles are refreshed automatically on startup so a redeploy won't reset
+any of the vanity badges or inactivity flags.
+
 Engagement badges: Top Poster, Certified Banger, Top Curator, First Drop,
 The Summoner, Lore Creator, Reaction Engineer, Galaxy Brain, Wordsmith,
 Sniper, Night Owl, Comeback Kid, Ghostbuster.
@@ -72,7 +75,15 @@ class RoleCog(commands.Cog):
         self.first_drop_user: int | None = None
         self.last_message_ts: datetime = discord.utils.utcnow()
         self.assign_counts: Counter[int] = Counter()
+        self._startup_refreshed: bool = False
         self.badge_task.start()
+
+    @commands.Cog.listener()
+    async def on_ready(self):
+        if not self._startup_refreshed:
+            await self._fetch_recent_activity()
+            await self.badge_task()
+            self._startup_refreshed = True
 
     @app_commands.command(name="refreshroles", description="Fetch history and rotate badges")
     @app_commands.checks.has_permissions(administrator=True)


### PR DESCRIPTION
## Summary
- automatically refresh vanity roles on ready
- document automatic refresh in RolesCog section

## Testing
- `./dev_run.sh --offline`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f370e305c832bad730b1fd06e10be