### PR TITLE
Set console log level to INFO

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ RUN pip install --no-cache-dir -r requirements.txt \
 # Copy source code
 COPY . .
 
-# Set default environment to production and enable debug logging
+# Set default environment to production and limit console logging to INFO
 ENV env=PROD
-ENV LOG_LEVEL=DEBUG
+ENV LOG_LEVEL=INFO
 
 CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ docker pull ghcr.io/<owner>/<repo>:latest
 docker run --env-file .env --rm ghcr.io/<owner>/<repo>:latest
 ```
 
-The container sets `LOG_LEVEL=DEBUG` so logs are verbose by default.
+The container sets `LOG_LEVEL=INFO` so console output is less verbose by default.
 
 ## Notes
 - `BOT_ENV` controls whether `bot_config.py` loads **TEST** or **PROD** IDs.

--- a/main.py
+++ b/main.py
@@ -25,6 +25,8 @@ file_handler.setFormatter(log_format)
 
 console_handler = logging.StreamHandler()
 console_handler.setFormatter(log_format)
+# Limit console output to INFO and above even when file logging is DEBUG
+console_handler.setLevel(logging.INFO)
 
 root_logger = logging.getLogger()
 root_logger.setLevel(level)

--- a/run_bot.sh
+++ b/run_bot.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 source venv/bin/activate
 export env=PROD
-export LOG_LEVEL=DEBUG
+# Console output defaults to INFO; override via LOG_LEVEL if needed
+export LOG_LEVEL=${LOG_LEVEL:-INFO}
 python main.py


### PR DESCRIPTION
## Summary
- ensure console handler only prints INFO level logs
- default run script to INFO logging
- switch container logging to INFO
- update documentation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_686f37ed34f4832bb57b29cbdee6ed7e