### PR TITLE
Fix DSN handling and shutdown for Postgres logger

### DIFF
--- a/main.py
+++ b/main.py
@@ -112,7 +112,7 @@ async def main():
             await bot.start(cfg.TOKEN)
     finally:
         if db_handler:
-            await db_handler.close()
+            await db_handler.aclose()
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- handle SQLAlchemy style DSNs for Postgres logging
- provide sync close for PostgresHandler and use new `aclose()` in main

## Testing
- `pip install -r requirements.txt`
- `pip install huggingface_hub`
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68750a971598832b95b31a18be8f3541