### PR TITLE
Fix missing migration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,12 @@ setup.sh           # install dependencies and create the venv
    DATABASE_URL=postgresql+asyncpg://gentlebot:<pg_password>@db:5432/gentlebot
    # PostgresHandler converts this to ``postgresql://`` when using ``asyncpg``
    ```
-4. Run the bot:
+4. If using Postgres logging, run the Alembic migration to create the
+   `bot_logs` table:
+   ```bash
+   alembic upgrade head
+   ```
+5. Run the bot:
    ```bash
    ./run_bot.sh
    ```

--- a/db/env.py
+++ b/db/env.py
@@ -67,8 +67,13 @@ def run_migrations_online() -> None:
     and associate a connection with the context.
 
     """
+    section = config.get_section(config.config_ini_section, {}).copy()
+    url = section.get("sqlalchemy.url")
+    if url and url.startswith("postgresql+asyncpg://"):
+        section["sqlalchemy.url"] = url.replace("postgresql+asyncpg://", "postgresql://", 1)
+
     connectable = engine_from_config(
-        config.get_section(config.config_ini_section, {}),
+        section,
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
     )


### PR DESCRIPTION
## Summary
- mention running `alembic upgrade head` when enabling Postgres logging
- convert asyncpg URLs in Alembic env to sync for migrations

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_6875157afd78832bb6aa925c1069509d