### PR TITLE
Avoid DEBUG logs in Postgres handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ setup.sh           # install dependencies and create the venv
    # PostgresHandler converts this to ``postgresql://`` when using ``asyncpg``
    ```
 4. If using Postgres logging, run the Alembic migration to create the
-   `bot_logs` table:
+   `bot_logs` table. The handler logs only **INFO** and above, so DEBUG
+   messages stay in your local files:
    ```bash
    alembic upgrade head
    ```

--- a/postgres_handler.py
+++ b/postgres_handler.py
@@ -12,6 +12,8 @@ class PostgresHandler(logging.Handler):
         self.dsn = dsn
         self.table = table
         self.pool: asyncpg.Pool | None = None
+        # Ignore DEBUG records so they are not written to the database
+        self.setLevel(logging.INFO)
 
     async def connect(self) -> None:
         url = self.dsn.replace("postgresql+asyncpg://", "postgresql://")

--- a/tests/test_postgres_handler.py
+++ b/tests/test_postgres_handler.py
@@ -1,10 +1,14 @@
 import asyncio
+import logging
 import asyncpg
 from postgres_handler import PostgresHandler
 
 class DummyPool:
     async def close(self):
         pass
+
+    async def execute(self, *args, **kwargs):
+        self.executed = True
 
 async def fake_create_pool(url):
     assert url.startswith("postgresql://")
@@ -16,5 +20,21 @@ def test_dsn_conversion(monkeypatch):
         handler = PostgresHandler("postgresql+asyncpg://u:p@localhost/db")
         await handler.connect()
         await handler.aclose()
+
+    asyncio.run(run_test())
+
+
+def test_debug_logs_filtered(monkeypatch):
+    async def run_test():
+        pool = DummyPool()
+        handler = PostgresHandler("postgresql+asyncpg://u:p@localhost/db")
+        handler.pool = pool
+        logger = logging.getLogger("gentlebot.test")
+        logger.setLevel(logging.DEBUG)
+        logger.addHandler(handler)
+        logger.debug("debug message")
+        logger.removeHandler(handler)
+        await asyncio.sleep(0)
+        assert not getattr(pool, "executed", False)
 
     asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- filter DEBUG-level messages out of PostgresHandler
- document INFO-only behavior in README
- test that PostgresHandler ignores DEBUG records

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68753483a4cc832ba4ba4688a20cfa32