### PR TITLE
Add message archival support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ setup.sh           # install dependencies and create the venv
    PG_USER=gentlebot
    PG_PASSWORD=<pg_password>
    PG_DB=gentlebot
+   # enable message archival tables
+   ARCHIVE_MESSAGES=1
    # or provide an explicit async connection URL
    DATABASE_URL=postgresql+asyncpg://gentlebot:<pg_password>@db:5432/gentlebot
    # PostgresHandler converts this to ``postgresql://`` when using ``asyncpg``
@@ -61,7 +63,12 @@ setup.sh           # install dependencies and create the venv
    ```bash
    alembic upgrade head
    ```
-5. Run the bot:
+5. Set `ARCHIVE_MESSAGES=1` to enable message archival. Run the migration
+   again to create the new tables used by the archive cog.
+   ```bash
+   alembic upgrade head
+   ```
+6. Run the bot:
    ```bash
    ./run_bot.sh
    ```

--- a/cogs/message_archive_cog.py
+++ b/cogs/message_archive_cog.py
@@ -1,0 +1,196 @@
+"""Archive Discord messages and reactions to Postgres."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import asyncpg
+import discord
+from discord.ext import commands
+
+log = logging.getLogger(f"gentlebot.{__name__}")
+
+
+class MessageArchiveCog(commands.Cog):
+    """Persist messages and reaction events to Postgres."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.pool: asyncpg.Pool | None = None
+        self.enabled = os.getenv("ARCHIVE_MESSAGES") == "1"
+
+    async def cog_load(self) -> None:
+        if not self.enabled:
+            return
+        url = self._build_db_url()
+        if not url:
+            log.warning("ARCHIVE_MESSAGES set but DATABASE_URL is missing")
+            self.enabled = False
+            return
+        url = url.replace("postgresql+asyncpg://", "postgresql://")
+        self.pool = await asyncpg.create_pool(url)
+        log.info("Message archival enabled")
+
+    async def cog_unload(self) -> None:
+        if self.pool:
+            await self.pool.close()
+            self.pool = None
+
+    @staticmethod
+    def _build_db_url() -> str | None:
+        url = os.getenv("DATABASE_URL")
+        if url:
+            return url
+        user = os.getenv("PG_USER")
+        pwd = os.getenv("PG_PASSWORD")
+        db = os.getenv("PG_DB")
+        if user and pwd and db:
+            return f"postgresql+asyncpg://{user}:{pwd}@db:5432/{db}"
+        return None
+
+    async def _upsert_user(self, member: discord.abc.User) -> None:
+        if not self.pool:
+            return
+        await self.pool.execute(
+            """
+            INSERT INTO "user" (user_id, username, discriminator, avatar_hash, is_bot, first_seen_at, last_seen_at)
+            VALUES ($1,$2,$3,$4,$5, now(), now())
+            ON CONFLICT (user_id)
+            DO UPDATE SET username=$2, discriminator=$3, avatar_hash=$4, is_bot=$5, last_seen_at=EXCLUDED.last_seen_at
+            """,
+            member.id,
+            member.name,
+            getattr(member, "discriminator", None),
+            getattr(member, "avatar", None) and member.avatar.key,
+            getattr(member, "bot", False),
+        )
+
+    async def _upsert_guild(self, guild: discord.Guild) -> None:
+        if not self.pool:
+            return
+        await self.pool.execute(
+            """
+            INSERT INTO guild (guild_id, name, owner_id, created_at)
+            VALUES ($1,$2,$3,$4)
+            ON CONFLICT (guild_id)
+            DO UPDATE SET name=$2, owner_id=$3, updated_at=now()
+            """,
+            guild.id,
+            guild.name,
+            getattr(guild.owner, "id", None),
+            guild.created_at,
+        )
+
+    async def _upsert_channel(self, channel: discord.abc.GuildChannel) -> None:
+        if not self.pool:
+            return
+        guild_id = getattr(channel.guild, "id", None)
+        await self.pool.execute(
+            """
+            INSERT INTO channel (channel_id, guild_id, name, type, created_at, last_message_at)
+            VALUES ($1,$2,$3,$4,$5,$6)
+            ON CONFLICT (channel_id)
+            DO UPDATE SET name=$3, type=$4, last_message_at=$6
+            """,
+            channel.id,
+            guild_id,
+            getattr(channel, "name", None),
+            getattr(channel, "type", None).value if hasattr(channel, "type") else None,
+            getattr(channel, "created_at", None),
+            discord.utils.utcnow(),
+        )
+
+    async def _insert_message(self, message: discord.Message) -> None:
+        if not self.pool:
+            return
+        payload = json.loads(message.to_json()) if hasattr(message, "to_json") else {}
+        await self.pool.execute(
+            """
+            INSERT INTO message (
+                message_id, guild_id, channel_id, author_id, reply_to_id,
+                content, created_at, edited_at, pinned, tts, type, raw_payload)
+            VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+            ON CONFLICT DO NOTHING
+            """,
+            message.id,
+            getattr(message.guild, "id", None),
+            message.channel.id,
+            message.author.id,
+            getattr(message.reference, "message_id", None),
+            message.content,
+            message.created_at,
+            message.edited_at,
+            message.pinned,
+            message.tts,
+            int(message.type.value),
+            payload,
+        )
+        for idx, att in enumerate(message.attachments):
+            await self.pool.execute(
+                """
+                INSERT INTO message_attachment (
+                    message_id, attachment_id, filename, content_type, size_bytes, url, proxy_url)
+                VALUES ($1,$2,$3,$4,$5,$6,$7)
+                ON CONFLICT DO NOTHING
+                """,
+                message.id,
+                idx,
+                att.filename,
+                att.content_type,
+                att.size,
+                att.url,
+                att.proxy_url,
+            )
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message) -> None:
+        if not self.enabled or message.guild is None:
+            return
+        await self._upsert_user(message.author)
+        await self._upsert_guild(message.guild)
+        await self._upsert_channel(message.channel)
+        await self._insert_message(message)
+
+    @commands.Cog.listener()
+    async def on_message_edit(self, before: discord.Message, after: discord.Message) -> None:
+        if not self.enabled or after.guild is None or not self.pool:
+            return
+        await self.pool.execute(
+            """UPDATE message SET content=$1, edited_at=$2, raw_payload=$3 WHERE message_id=$4""",
+            after.content,
+            after.edited_at,
+            json.loads(after.to_json()) if hasattr(after, "to_json") else {},
+            after.id,
+        )
+
+    async def _log_reaction(self, payload: discord.RawReactionActionEvent, action: int) -> None:
+        if not self.pool:
+            return
+        await self.pool.execute(
+            """
+            INSERT INTO reaction_event (message_id, user_id, emoji, action, event_at)
+            VALUES ($1,$2,$3,$4,$5)
+            """,
+            payload.message_id,
+            payload.user_id,
+            str(payload.emoji),
+            action,
+            discord.utils.utcnow(),
+        )
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent) -> None:
+        if not self.enabled:
+            return
+        await self._log_reaction(payload, 0)
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_remove(self, payload: discord.RawReactionActionEvent) -> None:
+        if not self.enabled:
+            return
+        await self._log_reaction(payload, 1)
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(MessageArchiveCog(bot))
+

--- a/db/versions/bcc44b374343_add_message_archival_tables.py
+++ b/db/versions/bcc44b374343_add_message_archival_tables.py
@@ -1,0 +1,134 @@
+"""add message archival tables
+
+Revision ID: bcc44b374343
+Revises: 1e7784a88d64
+Create Date: 2025-07-14 17:57:55.235165
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'bcc44b374343'
+down_revision: Union[str, None] = '1e7784a88d64'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "guild",
+        sa.Column("guild_id", sa.BigInteger, primary_key=True),
+        sa.Column("name", sa.Text, nullable=False),
+        sa.Column("owner_id", sa.BigInteger),
+        sa.Column("created_at", sa.DateTime(timezone=True)),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_table(
+        "user",
+        sa.Column("user_id", sa.BigInteger, primary_key=True),
+        sa.Column("username", sa.Text, nullable=False),
+        sa.Column("discriminator", sa.Text),
+        sa.Column("avatar_hash", sa.Text),
+        sa.Column("is_bot", sa.Boolean, server_default=sa.text("false")),
+        sa.Column(
+            "first_seen_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_table(
+        "channel",
+        sa.Column("channel_id", sa.BigInteger, primary_key=True),
+        sa.Column(
+            "guild_id",
+            sa.BigInteger,
+            sa.ForeignKey("guild.guild_id", ondelete="CASCADE"),
+        ),
+        sa.Column("name", sa.Text),
+        sa.Column("type", sa.SmallInteger, nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True)),
+        sa.Column("last_message_at", sa.DateTime(timezone=True)),
+    )
+    op.create_table(
+        "message",
+        sa.Column("message_id", sa.BigInteger, primary_key=True),
+        sa.Column(
+            "guild_id",
+            sa.BigInteger,
+            sa.ForeignKey("guild.guild_id", ondelete="CASCADE"),
+        ),
+        sa.Column(
+            "channel_id",
+            sa.BigInteger,
+            sa.ForeignKey("channel.channel_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "author_id",
+            sa.BigInteger,
+            sa.ForeignKey("user.user_id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "reply_to_id",
+            sa.BigInteger,
+            sa.ForeignKey("message.message_id", deferrable=True, initially="DEFERRED"),
+        ),
+        sa.Column("content", sa.Text),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("edited_at", sa.DateTime(timezone=True)),
+        sa.Column("pinned", sa.Boolean, server_default=sa.text("false")),
+        sa.Column("tts", sa.Boolean, server_default=sa.text("false")),
+        sa.Column("type", sa.SmallInteger, nullable=False),
+        sa.Column("raw_payload", sa.JSON, nullable=False),
+    )
+    op.create_index("msg_channel_ts", "message", ["channel_id", "created_at"])
+    op.create_index("msg_author_ts", "message", ["author_id", "created_at"])
+    op.create_table(
+        "message_attachment",
+        sa.Column(
+            "message_id",
+            sa.BigInteger,
+            sa.ForeignKey("message.message_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("attachment_id", sa.Integer, nullable=False),
+        sa.Column("filename", sa.Text, nullable=False),
+        sa.Column("content_type", sa.Text),
+        sa.Column("size_bytes", sa.Integer),
+        sa.Column("url", sa.Text, nullable=False),
+        sa.Column("proxy_url", sa.Text),
+        sa.PrimaryKeyConstraint("message_id", "attachment_id"),
+    )
+    op.create_table(
+        "reaction_event",
+        sa.Column("event_id", sa.BigInteger, primary_key=True),
+        sa.Column(
+            "message_id",
+            sa.BigInteger,
+            sa.ForeignKey("message.message_id", ondelete="CASCADE"),
+        ),
+        sa.Column("user_id", sa.BigInteger, sa.ForeignKey("user.user_id")),
+        sa.Column("emoji", sa.Text, nullable=False),
+        sa.Column("action", sa.SmallInteger, nullable=False),
+        sa.Column("event_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("reaction_event")
+    op.drop_table("message_attachment")
+    op.drop_index("msg_author_ts", table_name="message")
+    op.drop_index("msg_channel_ts", table_name="message")
+    op.drop_table("message")
+    op.drop_table("channel")
+    op.drop_table("user")
+    op.drop_table("guild")

--- a/tests/test_message_archive_cog.py
+++ b/tests/test_message_archive_cog.py
@@ -1,0 +1,75 @@
+import asyncio
+import os
+
+import discord
+from discord.ext import commands
+import asyncpg
+
+from cogs.message_archive_cog import MessageArchiveCog
+
+
+class DummyPool:
+    def __init__(self):
+        self.executed = []
+
+    async def close(self):
+        pass
+
+    async def execute(self, query, *args):
+        self.executed.append(query)
+
+
+def fake_create_pool(url):
+    assert url.startswith("postgresql://")
+    return DummyPool()
+
+
+def test_build_db_url_env(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("PG_USER", "u")
+    monkeypatch.setenv("PG_PASSWORD", "p")
+    monkeypatch.setenv("PG_DB", "db")
+    assert MessageArchiveCog._build_db_url() == "postgresql+asyncpg://u:p@db:5432/db"
+
+
+def test_on_message(monkeypatch):
+    async def run_test():
+        pool = DummyPool()
+        async def fake_create_pool(url):
+            assert url.startswith("postgresql://")
+            return pool
+        monkeypatch.setattr(asyncpg, "create_pool", fake_create_pool)
+        monkeypatch.setenv("ARCHIVE_MESSAGES", "1")
+        monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://u:p@localhost/db")
+        intents = discord.Intents.default()
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        cog = MessageArchiveCog(bot)
+        await cog.cog_load()
+
+        class Dummy:
+            def __init__(self, **kwargs):
+                self.__dict__.update(kwargs)
+
+        guild = Dummy(id=1, name="g", owner=Dummy(id=2), created_at=None)
+        channel = Dummy(id=10, guild=guild, name="chan", type=discord.ChannelType.text, created_at=None)
+        author = Dummy(id=4, name="a", discriminator="1234", avatar=None, bot=False)
+        message = Dummy(
+            id=123,
+            guild=guild,
+            channel=channel,
+            author=author,
+            content="hi",
+            created_at=discord.utils.utcnow(),
+            edited_at=None,
+            pinned=False,
+            tts=False,
+            type=discord.MessageType.default,
+            attachments=[],
+            reference=None,
+            to_json=lambda: "{}",
+        )
+        await cog.on_message(message)
+        assert pool.executed
+
+    asyncio.run(run_test())
+


### PR DESCRIPTION
## Summary
- add Alembic migration for new guild/user/message tables
- create `MessageArchiveCog` to store messages and reactions
- document new `ARCHIVE_MESSAGES` option
- test message archival cog

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68754415f7ec832b9f56c37d6e691de2