### PR TITLE
Move archival tables to discord schema

### DIFF
--- a/cogs/message_archive_cog.py
+++ b/cogs/message_archive_cog.py
@@ -28,7 +28,11 @@ class MessageArchiveCog(commands.Cog):
             self.enabled = False
             return
         url = url.replace("postgresql+asyncpg://", "postgresql://")
-        self.pool = await asyncpg.create_pool(url)
+
+        async def _init(conn: asyncpg.Connection) -> None:
+            await conn.execute("SET search_path=discord,public")
+
+        self.pool = await asyncpg.create_pool(url, init=_init)
         log.info("Message archival enabled")
 
     async def cog_unload(self) -> None:

--- a/db/versions/552063e7f5d4_move_archival_tables_to_schema.py
+++ b/db/versions/552063e7f5d4_move_archival_tables_to_schema.py
@@ -1,0 +1,42 @@
+"""move message archival tables to discord schema
+
+Revision ID: 552063e7f5d4
+Revises: bcc44b374343
+Create Date: 2025-08-13 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '552063e7f5d4'
+down_revision: Union[str, None] = 'bcc44b374343'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE SCHEMA IF NOT EXISTS discord")
+    for table in (
+        "channel",
+        "guild",
+        "message",
+        "message_attachment",
+        "reaction_event",
+        "user",
+    ):
+        op.execute(f"ALTER TABLE {table} SET SCHEMA discord")
+
+
+def downgrade() -> None:
+    for table in (
+        "channel",
+        "guild",
+        "message",
+        "message_attachment",
+        "reaction_event",
+        "user",
+    ):
+        op.execute(f"ALTER TABLE discord.{table} SET SCHEMA public")
+    op.execute("DROP SCHEMA IF EXISTS discord")

--- a/postgres_handler.py
+++ b/postgres_handler.py
@@ -17,7 +17,11 @@ class PostgresHandler(logging.Handler):
 
     async def connect(self) -> None:
         url = self.dsn.replace("postgresql+asyncpg://", "postgresql://")
-        self.pool = await asyncpg.create_pool(url)
+
+        async def _init(conn: asyncpg.Connection) -> None:
+            await conn.execute("SET search_path=discord,public")
+
+        self.pool = await asyncpg.create_pool(url, init=_init)
 
     async def aclose(self) -> None:
         if self.pool:

--- a/tests/test_message_archive_cog.py
+++ b/tests/test_message_archive_cog.py
@@ -19,7 +19,7 @@ class DummyPool:
         self.executed.append(query)
 
 
-def fake_create_pool(url):
+def fake_create_pool(url, *args, **kwargs):
     assert url.startswith("postgresql://")
     return DummyPool()
 
@@ -35,7 +35,7 @@ def test_build_db_url_env(monkeypatch):
 def test_on_message(monkeypatch):
     async def run_test():
         pool = DummyPool()
-        async def fake_create_pool(url):
+        async def fake_create_pool(url, *args, **kwargs):
             assert url.startswith("postgresql://")
             return pool
         monkeypatch.setattr(asyncpg, "create_pool", fake_create_pool)
@@ -77,7 +77,7 @@ def test_on_ready_populates(monkeypatch):
     async def run_test():
         pool = DummyPool()
 
-        async def fake_create_pool(url):
+        async def fake_create_pool(url, *args, **kwargs):
             return pool
 
         monkeypatch.setattr(asyncpg, "create_pool", fake_create_pool)

--- a/tests/test_postgres_handler.py
+++ b/tests/test_postgres_handler.py
@@ -10,7 +10,7 @@ class DummyPool:
     async def execute(self, *args, **kwargs):
         self.executed = True
 
-async def fake_create_pool(url):
+async def fake_create_pool(url, *args, **kwargs):
     assert url.startswith("postgresql://")
     return DummyPool()
 


### PR DESCRIPTION
## Summary
- add alembic revision creating a `discord` schema and move archival tables
- set `search_path` when connecting in `PostgresHandler`
- set `search_path` in `MessageArchiveCog`
- update tests for new asyncpg arguments

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_6875c0673504832b97d882dfed543df2