### PR TITLE
Fix schema migration quoting

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ setup.sh           # install dependencies and create the venv
    ```bash
    alembic upgrade head
    ```
+   The migrations create tables in the `discord` schema. Connections should
+   use `SET search_path=discord,public` as done by the bot's database helpers.
 5. Set `ARCHIVE_MESSAGES=1` to enable message archival. The archive cog
    records all existing guilds and channels on startup and then logs new
    messages and reactions. Run the migration again to create the tables

--- a/db/versions/552063e7f5d4_move_archival_tables_to_schema.py
+++ b/db/versions/552063e7f5d4_move_archival_tables_to_schema.py
@@ -26,7 +26,7 @@ def upgrade() -> None:
         "reaction_event",
         "user",
     ):
-        op.execute(f"ALTER TABLE {table} SET SCHEMA discord")
+        op.execute(f'ALTER TABLE "{table}" SET SCHEMA discord')
 
 
 def downgrade() -> None:
@@ -38,5 +38,5 @@ def downgrade() -> None:
         "reaction_event",
         "user",
     ):
-        op.execute(f"ALTER TABLE discord.{table} SET SCHEMA public")
+        op.execute(f'ALTER TABLE discord."{table}" SET SCHEMA public')
     op.execute("DROP SCHEMA IF EXISTS discord")


### PR DESCRIPTION
## Summary
- quote table names in schema migration
- document use of `discord` schema in README

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_6875c5416f38832bae7f1fafd6b3686d