### PR TITLE
Add display name support

### DIFF
--- a/cogs/message_archive_cog.py
+++ b/cogs/message_archive_cog.py
@@ -75,16 +75,26 @@ class MessageArchiveCog(commands.Cog):
             return
         await self.pool.execute(
             """
-            INSERT INTO "user" (user_id, username, discriminator, avatar_hash, is_bot, first_seen_at, last_seen_at)
-            VALUES ($1,$2,$3,$4,$5, now(), now())
+            INSERT INTO "user" (
+                user_id, username, discriminator, avatar_hash, is_bot,
+                display_name, first_seen_at, last_seen_at
+            )
+            VALUES ($1,$2,$3,$4,$5,$6, now(), now())
             ON CONFLICT (user_id)
-            DO UPDATE SET username=$2, discriminator=$3, avatar_hash=$4, is_bot=$5, last_seen_at=EXCLUDED.last_seen_at
+            DO UPDATE SET
+                username=$2,
+                discriminator=$3,
+                avatar_hash=$4,
+                is_bot=$5,
+                display_name=$6,
+                last_seen_at=EXCLUDED.last_seen_at
             """,
             member.id,
             member.name,
             getattr(member, "discriminator", None),
             getattr(member, "avatar", None) and member.avatar.key,
             getattr(member, "bot", False),
+            getattr(member, "display_name", None),
         )
 
     async def _upsert_guild(self, guild: discord.Guild) -> None:

--- a/db/versions/415493c2f0a9_add_display_name_to_user.py
+++ b/db/versions/415493c2f0a9_add_display_name_to_user.py
@@ -1,0 +1,27 @@
+"""add display_name column to user table
+
+Revision ID: 415493c2f0a9
+Revises: 552063e7f5d4
+Create Date: 2025-07-15 03:22:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '415493c2f0a9'
+down_revision: Union[str, None] = '552063e7f5d4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'user',
+        sa.Column('display_name', sa.Text),
+        schema='discord'
+    )
+    op.execute('UPDATE discord."user" SET display_name = username')
+
+
+def downgrade() -> None:
+    op.drop_column('user', 'display_name', schema='discord')

--- a/tests/test_message_archive_cog.py
+++ b/tests/test_message_archive_cog.py
@@ -114,3 +114,30 @@ def test_on_ready_populates(monkeypatch):
         assert called == ["g", "c"]
 
     asyncio.run(run_test())
+
+
+def test_upsert_user(monkeypatch):
+    async def run_test():
+        pool = DummyPool()
+        intents = discord.Intents.default()
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        cog = MessageArchiveCog(bot)
+        cog.pool = pool
+
+        class Dummy:
+            def __init__(self, **kw):
+                self.__dict__.update(kw)
+
+        member = Dummy(
+            id=1,
+            name="user",
+            discriminator="0001",
+            avatar=None,
+            bot=False,
+            display_name="User Display",
+        )
+        await cog._upsert_user(member)
+        assert pool.executed
+        assert "display_name" in pool.executed[0]
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- track user display names in Postgres
- include display names in user upsert logic
- test the upsert function

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_6875c8324bc4832baf7685bf362c2b7c