### PR TITLE
Fix Lurker assignment check

### DIFF
--- a/cogs/roles_cog.py
+++ b/cogs/roles_cog.py
@@ -481,7 +481,10 @@ class RoleCog(commands.Cog):
             if msgs14 == 0 and (mentions30 > 0 or recv30 > 0):
                 await self._assign_flag(guild, member, ROLE_SHADOW_FLAG)
                 continue
-            if 1 <= msgs14 <= 5 or 1 <= reacts14 <= 15:
+            if 1 <= msgs14 <= 5:
+                await self._assign_flag(guild, member, ROLE_LURKER_FLAG)
+                continue
+            if msgs14 == 0 and 1 <= reacts14 <= 15:
                 await self._assign_flag(guild, member, ROLE_LURKER_FLAG)
                 continue
             if now - last <= timedelta(days=30) and long_msgs30[member.id] == 0 and rich_msgs30[member.id] == 0:

--- a/tests/test_roles_cog.py
+++ b/tests/test_roles_cog.py
@@ -1,0 +1,58 @@
+import asyncio
+from types import SimpleNamespace
+
+import discord
+from discord.ext import commands
+
+import bot_config as cfg
+from cogs import roles_cog
+
+
+def test_lurker_skip_if_many_messages(monkeypatch):
+    async def run_test():
+        monkeypatch.setattr(roles_cog.RoleCog.badge_task, "start", lambda self: None)
+        intents = discord.Intents.none()
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        cog = roles_cog.RoleCog(bot)
+
+        guild = SimpleNamespace(id=1)
+        guild.members = [
+            SimpleNamespace(id=1, bot=False, roles=[]),
+            SimpleNamespace(id=2, bot=False, roles=[]),
+        ]
+        guild.get_role = lambda rid: SimpleNamespace(id=rid, name=str(rid))
+        monkeypatch.setattr(bot, "get_guild", lambda gid: guild)
+        monkeypatch.setattr(bot, "wait_until_ready", lambda: asyncio.sleep(0))
+
+        async def fake_rotate_single(*args, **kwargs):
+            return None
+
+        monkeypatch.setattr(cog, "_rotate_single", fake_rotate_single)
+
+        assigned = {}
+
+        async def fake_assign_flag(g, member, role_id):
+            assigned[member.id] = role_id
+
+        monkeypatch.setattr(cog, "_assign_flag", fake_assign_flag)
+        monkeypatch.setattr(roles_cog, "ROLE_LURKER_FLAG", 1)
+        monkeypatch.setattr(cfg, "ROLE_LURKER_FLAG", 1)
+        now = discord.utils.utcnow()
+        cog.messages = [
+            {"author": 1, "ts": now, "id": i, "len": 10, "words": 2, "rich": False, "mentions": 0, "mention_ids": [], "reply_to": None}
+            for i in range(6)
+        ]
+        cog.messages += [
+            {"author": 2, "ts": now, "id": 100 + i, "len": 10, "words": 2, "rich": False, "mentions": 0, "mention_ids": [], "reply_to": None}
+            for i in range(2)
+        ]
+        cog.reactions = [
+            {"ts": now, "msg": 200 + i, "msg_author": 99, "emoji": "👍", "creator": None, "user": 1}
+            for i in range(10)
+        ]
+        cog.last_online = {1: now, 2: now}
+        await cog.badge_task()
+        assert assigned[1] != roles_cog.ROLE_LURKER_FLAG
+        assert assigned[2] == roles_cog.ROLE_LURKER_FLAG
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- update Lurker flag logic so users with >5 messages never get the flag
- add regression test for Lurker logic

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_6875ca438ebc832bbd14a09740ffacdd