### PR TITLE
Refactor db url builder

### DIFF
--- a/cogs/message_archive_cog.py
+++ b/cogs/message_archive_cog.py
@@ -7,6 +7,7 @@ import os
 import asyncpg
 import discord
 from discord.ext import commands
+from util import build_db_url
 
 log = logging.getLogger(f"gentlebot.{__name__}")
 
@@ -60,15 +61,7 @@ class MessageArchiveCog(commands.Cog):
 
     @staticmethod
     def _build_db_url() -> str | None:
-        url = os.getenv("DATABASE_URL")
-        if url:
-            return url
-        user = os.getenv("PG_USER")
-        pwd = os.getenv("PG_PASSWORD")
-        db = os.getenv("PG_DB")
-        if user and pwd and db:
-            return f"postgresql+asyncpg://{user}:{pwd}@db:5432/{db}"
-        return None
+        return build_db_url()
 
     async def _upsert_user(self, member: discord.abc.User) -> None:
         if not self.pool:

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from discord.ext import commands
 
 import bot_config as cfg
 from postgres_handler import PostgresHandler
+from util import build_db_url
 
 # ─── Logging Setup ─────────────────────────────────────────────────────────
 logger = logging.getLogger("gentlebot")
@@ -78,20 +79,8 @@ async def on_app_command_error(interaction: discord.Interaction, exc: discord.ap
     else:
         await interaction.response.send_message("An error occurred.", ephemeral=True)
 
-def _build_db_url() -> str | None:
-    url = os.getenv("DATABASE_URL")
-    if url:
-        return url
-    user = os.getenv("PG_USER")
-    pwd = os.getenv("PG_PASSWORD")
-    db = os.getenv("PG_DB")
-    if user and pwd and db:
-        return f"postgresql+asyncpg://{user}:{pwd}@db:5432/{db}"
-    return None
-
-
 async def main():
-    db_url = _build_db_url()
+    db_url = build_db_url()
     db_handler = None
     file_handler = None
     if db_url:

--- a/tests/test_message_archive_cog.py
+++ b/tests/test_message_archive_cog.py
@@ -6,6 +6,7 @@ from discord.ext import commands
 import asyncpg
 
 from cogs.message_archive_cog import MessageArchiveCog
+from util import build_db_url
 
 
 class DummyPool:
@@ -29,7 +30,7 @@ def test_build_db_url_env(monkeypatch):
     monkeypatch.setenv("PG_USER", "u")
     monkeypatch.setenv("PG_PASSWORD", "p")
     monkeypatch.setenv("PG_DB", "db")
-    assert MessageArchiveCog._build_db_url() == "postgresql+asyncpg://u:p@db:5432/db"
+    assert build_db_url() == "postgresql+asyncpg://u:p@db:5432/db"
 
 
 def test_on_message(monkeypatch):

--- a/util.py
+++ b/util.py
@@ -1,4 +1,17 @@
+import os
 import discord
+
+def build_db_url() -> str | None:
+    """Return a Postgres DSN built from env vars."""
+    url = os.getenv("DATABASE_URL")
+    if url:
+        return url
+    user = os.getenv("PG_USER")
+    pwd = os.getenv("PG_PASSWORD")
+    db = os.getenv("PG_DB")
+    if user and pwd and db:
+        return f"postgresql+asyncpg://{user}:{pwd}@db:5432/{db}"
+    return None
 
 def chan_name(channel: discord.abc.Connectable | None) -> str:
     """Return a readable channel name or fallback to ID."""


### PR DESCRIPTION
## Summary
- consolidate duplicate database url logic in `util.build_db_url`
- use the new helper in `main` and `MessageArchiveCog`
- adjust tests for new helper

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_6875d804a9c0832ba58359b47a4c9919