### PR TITLE
Add package entrypoint with env toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Gentlebot is a modular Discord bot built with **discord.py** v2. Each feature li
 ## Running the bot
 1. Create a virtual environment and install the libraries listed in the README.
 2. Create a `.env` file containing `DISCORD_TOKEN` and other IDs (see `bot_config.py`).
-3. Use `./dev_run.sh` during development for auto‑restart when files change. For production use `./run_bot.sh` or run `python main.py` with `env=PROD`.
+3. Use `./dev_run.sh` during development for auto‑restart when files change. For production use `./run_bot.sh` or run `python -m gentlebot` with `env=PROD`.
 
 ## Adding new features
 - Write each feature as a `commands.Cog` subclass in a new file ending with `_cog.py` under `cogs/`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,6 @@ COPY . .
 # Set default environment to production and limit console logging to INFO
 ENV env=PROD
 ENV LOG_LEVEL=INFO
+ENV PYTHONPATH=/app/src
 
-CMD ["python", "main.py"]
+CMD ["python", "-m", "gentlebot"]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Gentlebot is a modular Discord bot composed of several **cogs** that handle diff
 
 ## Repository Layout
 ```
-main.py            # bot entry point
+src/gentlebot/__main__.py # package entry point
 bot_config.py      # environment configuration and ID constants
 cogs/               # feature cogs
   sports_cog.py     # F1 and baseball commands
@@ -78,6 +78,8 @@ setup.sh           # install dependencies and create the venv
 8. Run the bot:
    ```bash
    ./run_bot.sh
+   # or manually via Python
+   python -m gentlebot
    ```
 During development you can use `./dev_run.sh` for automatic restarts when files change. The `watchfiles` and `watchdog` packages are installed from `requirements.txt`, so autoreload works out of the box. Logs are written to `logs/bot.log` unless a Postgres connection is configured, in which case they are archived to the `bot_logs` table instead.
 Pass `--offline` to `dev_run.sh` (or set `BOT_OFFLINE=1`) to run the bundled `test_harness.py` instead, which loads all cogs without connecting to Discord.

--- a/bot_config.py
+++ b/bot_config.py
@@ -8,7 +8,7 @@ Guild first, then flip the ENV var when you deploy.
 Usage
 -----
 $ export BOT_ENV=TEST  # or PROD (default PROD)
-$ python main.py
+$ python -m gentlebot
 
 * .env (git‑ignored) keeps only TOKEN values*
 DISCORD_TOKEN_TEST=xxx

--- a/dev_run.sh
+++ b/dev_run.sh
@@ -50,7 +50,8 @@ if ! python -c "import discord" >/dev/null 2>&1; then
     exit 1
 fi
 
-cmd="python main.py"
+export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}src"
+cmd="python -m gentlebot"
 
 if command -v watchmedo >/dev/null 2>&1; then
     watchmedo auto-restart \

--- a/run_bot.sh
+++ b/run_bot.sh
@@ -3,4 +3,5 @@ source venv/bin/activate
 export env=PROD
 # Console output defaults to INFO; override via LOG_LEVEL if needed
 export LOG_LEVEL=${LOG_LEVEL:-INFO}
-python main.py
+export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}src"
+python -m gentlebot

--- a/src/gentlebot/__main__.py
+++ b/src/gentlebot/__main__.py
@@ -1,0 +1,119 @@
+import asyncio
+import logging
+import os
+from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
+
+import discord
+from discord.ext import commands
+
+import bot_config as cfg
+from postgres_handler import PostgresHandler
+from util import build_db_url
+
+# ─── Logging Setup ─────────────────────────────────────────────────────────
+logger = logging.getLogger("gentlebot")
+level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+level = getattr(logging, level_name, logging.INFO)
+logger.setLevel(level)
+log_format = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+
+console_handler = logging.StreamHandler()
+console_handler.setFormatter(log_format)
+# Limit console output to INFO and above even when file logging is DEBUG
+console_handler.setLevel(logging.INFO)
+
+root_logger = logging.getLogger()
+root_logger.setLevel(level)
+root_logger.addHandler(console_handler)
+
+logger.info(
+    "Starting GentleBot in %s environment with level %s",
+    getattr(cfg, "env", "PROD"),
+    level_name,
+)
+
+intents = discord.Intents.default()
+intents.message_content = True
+intents.members = True  # RoleCog needs this
+
+class GentleBot(commands.Bot):
+    async def setup_hook(self):
+        # __main__ lives under src/gentlebot whereas the cogs folder sits at the
+        # repository root next to main.py.  Walk one directory up to find it so
+        # that loading works when running the package entry point.
+        cog_dir = Path(__file__).resolve().parent.parent / "cogs"
+        for file in cog_dir.glob("*_cog.py"):
+            if file.stem == "test_logging_cog" and not cfg.IS_TEST:
+                continue
+            await self.load_extension(f"cogs.{file.stem}")
+
+
+bot = GentleBot(command_prefix="!", intents=intents)
+
+_synced = False
+
+@bot.event
+async def on_ready():
+    global _synced
+    logger.info("%s is now online in this guild", bot.user)
+    if not _synced:
+        try:
+            cmds = await bot.tree.sync()
+            logger.info("Synced %d commands.", len(cmds))
+        except Exception as e:
+            logger.exception("Failed to sync commands: %s", e)
+        _synced = True
+
+@bot.event
+async def on_error(event: str, *args, **kwargs):
+    logger.exception("Unhandled exception in event %s", event)
+
+@bot.event
+async def on_command_error(ctx: commands.Context, exc: commands.CommandError):
+    logger.exception("Error in command '%s'", getattr(ctx.command, 'name', 'unknown'), exc_info=exc)
+
+@bot.tree.error
+async def on_app_command_error(interaction: discord.Interaction, exc: discord.app_commands.AppCommandError):
+    cmd_name = getattr(interaction.command, "name", "unknown")
+    logger.exception("Error in slash command '%s'", cmd_name, exc_info=exc)
+    if interaction.response.is_done():
+        await interaction.followup.send("An error occurred.", ephemeral=True)
+    else:
+        await interaction.response.send_message("An error occurred.", ephemeral=True)
+
+async def main():
+    db_url = build_db_url()
+    db_handler = None
+    file_handler = None
+    if db_url:
+        db_handler = PostgresHandler(db_url)
+        await db_handler.connect()
+        root_logger.addHandler(db_handler)
+        logger.info("Postgres logging enabled; file logging disabled")
+    else:
+        log_dir = Path("logs")
+        log_dir.mkdir(exist_ok=True)
+        file_handler = TimedRotatingFileHandler(
+            log_dir / "bot.log", when="midnight", backupCount=90
+        )
+        file_handler.setFormatter(log_format)
+        root_logger.addHandler(file_handler)
+
+    try:
+        async with bot:
+            await bot.start(cfg.TOKEN)
+    finally:
+        if db_handler:
+            await db_handler.aclose()
+        if file_handler:
+            file_handler.close()
+
+if __name__ == "__main__":
+    if os.getenv("USE_PKG_ENTRY"):
+        asyncio.run(main())
+    else:
+        from importlib import import_module
+
+        legacy = import_module("main")
+        asyncio.run(legacy.main())


### PR DESCRIPTION
## Summary
- expose bot as package entrypoint `gentlebot.__main__`
- allow switching with `USE_PKG_ENTRY` env var
- update run scripts and Dockerfile to use `python -m gentlebot`
- document new command in README, config guide, and AGENTS instructions
- fix path to cogs when launching via package entrypoint

## Testing
- `python -m pytest -q`
- `python test_harness.py` (errors from async tasks were expected)


------
https://chatgpt.com/codex/tasks/task_e_687720db6c24832b97148d094a30984d