### PR TITLE
Add Docker entrypoint script with migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libjpeg-dev \
     libopenjp2-7 \
     libtiff6 \
+    postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -26,10 +27,11 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy source code
 COPY . .
+RUN chmod +x docker_start.sh
 
 # Set default environment to production and limit console logging to INFO
 ENV env=PROD
 ENV LOG_LEVEL=INFO
 ENV PYTHONPATH=/app/src
 
-CMD ["python", "-m", "gentlebot"]
+ENTRYPOINT ["/app/docker_start.sh"]

--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ Pass `--offline` to `dev_run.sh` (or set `BOT_OFFLINE=1`) to run the bundled `te
 
 ## Docker
 You can also run the bot inside a container on a Raspberry Pi. A `Dockerfile`
-is provided. Build the image and pass your `.env` file at runtime:
+is provided. Build the image and pass your `.env` file at runtime. The container
+entrypoint waits for Postgres to accept connections, runs `alembic upgrade head`
+and prunes dangling images before launching the bot:
 
 ```bash
 docker build -t gentlebot .

--- a/docker_start.sh
+++ b/docker_start.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+
+# docker_start.sh - wait for Postgres, run migrations, prune images, start bot
+
+PGHOST=${PGHOST:-db}
+PGPORT=${PGPORT:-5432}
+PGUSER=${PG_USER:-${PGUSER:-postgres}}
+PGDATABASE=${PG_DB:-${PGDATABASE:-postgres}}
+
+# Wait for Postgres to accept connections
+until pg_isready -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDATABASE" >/dev/null 2>&1; do
+  echo "Waiting for Postgres at $PGHOST:$PGPORT..."
+  sleep 2
+done
+
+# Run database migrations
+alembic upgrade head
+
+# Prune dangling Docker images to save disk space
+if command -v docker >/dev/null 2>&1; then
+  docker image prune -f >/dev/null 2>&1 || true
+fi
+
+# Launch the bot
+exec python -m gentlebot


### PR DESCRIPTION
## Summary
- add `docker_start.sh` for container startup
- install `postgresql-client` and use entrypoint in Dockerfile
- mention the startup behavior in README

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_687726ea6a9c832b9ee3e40b2cce4415