### PR TITLE
Add SKIP_DB flag for CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,5 @@ PG_DB=gentlebot
 PG_DSN=postgresql+asyncpg://gentlebot:your-db-password@db:5432/gentlebot
 # enable pruning of old Docker images when the container starts
 DOCKER_PRUNE=1
+# skip Postgres wait-loop and migrations (useful for CI)
+SKIP_DB=0

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           cp .env.example .env
           docker build -t gentlebot:test .
-          docker run --env-file .env --rm gentlebot:test --help
+          docker run --env-file .env -e SKIP_DB=1 --rm gentlebot:test --help
 
       - uses: docker/setup-qemu-action@v3
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ BOT_OFFLINE=1 python test_harness.py
 You can also run the bot inside a container on a Raspberry Pi. A `Dockerfile`
 and `docker-compose.yml` are provided. Build the image and pass your `.env` file
 at runtime. The container entrypoint waits for Postgres, applies migrations and
-can prune old images if `DOCKER_PRUNE=1`:
+can prune old images if `DOCKER_PRUNE=1`. Set `SKIP_DB=1` to bypass the
+wait-loop and migrations:
 
 ```bash
 docker compose up -d --build
@@ -109,7 +110,7 @@ You can pull and run the prebuilt container instead of building locally:
 
 ```bash
 docker pull ghcr.io/<owner>/<repo>:latest
-docker run --env-file .env --rm ghcr.io/<owner>/<repo>:latest
+docker run --env-file .env -e SKIP_DB=1 --rm ghcr.io/<owner>/<repo>:latest
 ```
 
 The container sets `LOG_LEVEL=INFO` so console output is less verbose by default.

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,19 +1,24 @@
 #!/usr/bin/env bash
 set -e
 
-# Wait for Postgres to accept connections
-PG_HOST=${PG_HOST:-db}
-PG_PORT=${PG_PORT:-5432}
-PG_USER=${PG_USER:-postgres}
-PG_DB=${PG_DB:-postgres}
+# Skip Postgres checks when running in CI
+if [[ "${SKIP_DB:-0}" != "1" ]]; then
+  # Wait for Postgres to accept connections
+  PG_HOST=${PG_HOST:-db}
+  PG_PORT=${PG_PORT:-5432}
+  PG_USER=${PG_USER:-postgres}
+  PG_DB=${PG_DB:-postgres}
 
-until pg_isready -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" >/dev/null 2>&1; do
-  echo "Waiting for Postgres at $PG_HOST:$PG_PORT..."
-  sleep 2
-done
+  until pg_isready -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" >/dev/null 2>&1; do
+    echo "Waiting for Postgres at $PG_HOST:$PG_PORT..."
+    sleep 2
+  done
 
-# Apply migrations
-alembic upgrade head
+  # Apply migrations
+  alembic upgrade head
+else
+  echo "SKIP_DB=1 - skipping Postgres availability checks"
+fi
 
 # Optionally prune dangling Docker images older than 24h
 if [[ "${DOCKER_PRUNE:-0}" == "1" ]] && [[ -S /var/run/docker.sock ]]; then


### PR DESCRIPTION
## Summary
- allow skipping Postgres wait-loop and migrations via `SKIP_DB` in `scripts/start.sh`
- set `SKIP_DB=1` when running the Docker image in CI
- document the flag in README and `.env.example`

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_687840f9d194832baacdd98c98e72c0b