### PR TITLE
Use env file for compose credentials

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,21 +3,14 @@ services:
   db:
     image: postgres:15
     environment:
-      POSTGRES_DB: gentlebot
-      POSTGRES_USER: gentlebot
-      POSTGRES_PASSWORD: example
+      POSTGRES_DB: ${PG_DB}
+      POSTGRES_USER: ${PG_USER}
+      POSTGRES_PASSWORD: ${PG_PASSWORD}
     volumes:
       - db-data:/var/lib/postgresql/data
   bot:
     build: .
     env_file: .env
-    environment:
-      DOCKER_PRUNE: '1'
-      PG_HOST: db
-      PG_PORT: '5432'
-      PG_USER: gentlebot
-      PG_PASSWORD: example
-      PG_DB: gentlebot
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     depends_on:


### PR DESCRIPTION
## Summary
- rely on `.env` values for database credentials by default
- remove overrides in `docker-compose.yml`

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_68785b3cfc7c832ba8dc381955af17f5