### PR TITLE
Support DATABASE_URL environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,8 @@ PG_PASSWORD=your-db-password
 PG_DB=gentlebot
 # or provide an explicit connection URL
 PG_DSN=postgresql+asyncpg://gentlebot:your-db-password@db:5432/gentlebot
+# or common host-provided variable
+DATABASE_URL=
 # enable pruning of old Docker images when the container starts
 DOCKER_PRUNE=1
 # skip Postgres wait-loop and migrations (useful for CI)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ setup.sh           # install dependencies and create the venv
    # or provide an explicit async connection URL
    PG_DSN=postgresql+asyncpg://gentlebot:<pg_password>@db:5432/gentlebot
    # PostgresHandler converts this to ``postgresql://`` when using ``asyncpg``
+   # DATABASE_URL can also be used for hosts that provide it
    ```
 4. If using Postgres logging, run the Alembic migration to create the
    `bot_logs` table. Database logging only stores **INFO** and above so

--- a/db/env.py
+++ b/db/env.py
@@ -9,7 +9,7 @@ from alembic import context
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
-url = os.getenv("PG_DSN")
+url = os.getenv("PG_DSN") or os.getenv("DATABASE_URL")
 if not url:
     user = os.getenv("PG_USER")
     pwd = os.getenv("PG_PASSWORD")

--- a/tests/test_message_archive_cog.py
+++ b/tests/test_message_archive_cog.py
@@ -36,6 +36,15 @@ def test_build_db_url_env(monkeypatch):
     assert build_db_url() == "postgresql+asyncpg://u:p@db:5432/db"
 
 
+def test_build_db_url_database_url(monkeypatch):
+    monkeypatch.delenv("PG_DSN", raising=False)
+    monkeypatch.delenv("PG_USER", raising=False)
+    monkeypatch.delenv("PG_PASSWORD", raising=False)
+    monkeypatch.delenv("PG_DB", raising=False)
+    monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://u:p@db:5432/db")
+    assert build_db_url() == "postgresql+asyncpg://u:p@db:5432/db"
+
+
 def test_on_message(monkeypatch):
     async def run_test():
         pool = DummyPool()

--- a/util.py
+++ b/util.py
@@ -4,7 +4,7 @@ import discord
 
 def build_db_url() -> str | None:
     """Return a Postgres DSN built from env vars."""
-    url = os.getenv("PG_DSN")
+    url = os.getenv("PG_DSN") or os.getenv("DATABASE_URL")
     if url:
         return url
     user = os.getenv("PG_USER")


### PR DESCRIPTION
## Summary
- allow `DATABASE_URL` as a fallback for DB configuration
- document the new variable in `.env.example` and README
- test fallback logic

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_6879043a98fc832ba944a7693a6be9fe