### PR TITLE
Fix PostgresHandler closing logic

### DIFF
--- a/postgres_handler.py
+++ b/postgres_handler.py
@@ -50,9 +50,10 @@ class PostgresHandler(logging.Handler):
     def close(self) -> None:
         if self.pool:
             try:
-                asyncio.run(self.pool.close())
-            except RuntimeError:
                 loop = asyncio.get_running_loop()
+            except RuntimeError:
+                asyncio.run(self.pool.close())
+            else:
                 loop.create_task(self.pool.close())
             self.pool = None
         super().close()


### PR DESCRIPTION
## Summary
- fix PostgresHandler.close to check for running loop before closing

## Testing
- `pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_6879c3cdb0c8832bb87d3a304eced002