### PR TITLE
Improve slash command sync speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ docker compose up -d bot
  - The Hugging Face cogs require an API key in `HF_API_TOKEN` and optionally `HF_MODEL`.
    You can provide a backup key in `HF_API_TOKEN_ALT` which will be used if the
    primary token hits a billing error.
- - Set `PG_DSN` (or PG_* creds) to enable writing bot logs to a Postgres database.
+- Set `PG_DSN` (or PG_* creds) to enable writing bot logs to a Postgres database.
+- Slash commands are registered via a single bulk request on startup to avoid rate limits.
 
 ## Contributing
 Each cog is self-contained. Add a new `*_cog.py` file under `cogs/` and it will be loaded automatically.

--- a/src/gentlebot/__main__.py
+++ b/src/gentlebot/__main__.py
@@ -62,8 +62,9 @@ async def on_ready():
     logger.info("%s is now online in this guild", bot.user)
     if not _synced:
         try:
-            cmds = await bot.tree.sync()
-            logger.info("Synced %d commands.", len(cmds))
+            payload = [cmd.to_dict() for cmd in bot.tree.get_commands()]
+            cmds = await bot.http.bulk_upsert_global_commands(bot.application_id, payload)
+            logger.info("Bulk synced %d commands.", len(cmds))
         except Exception as e:
             logger.exception("Failed to sync commands: %s", e)
         _synced = True


### PR DESCRIPTION
## Summary
- use `bulk_upsert_global_commands` when syncing slash commands
- document bulk command sync in README

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_6879c4aeb0f8832baa86c4231305db29