### PR TITLE
Implement slash command logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ setup.sh           # install dependencies and create the venv
    ```bash
    alembic upgrade head
    ```
+6. Set `LOG_COMMANDS=1` to record slash command usage. Run the migration
+   to create the `command_invocations` table and optionally backfill
+   recent history:
+   ```bash
+   alembic upgrade head
+   python backfill_commands.py --days 90  # optional
+   ```
 7. Optionally backfill up to 90 days of history before starting the bot:
    ```bash
    python backfill_archive.py --days 90

--- a/db/versions/92ffba02de5d_add_command_invocations_table.py
+++ b/db/versions/92ffba02de5d_add_command_invocations_table.py
@@ -1,0 +1,66 @@
+"""add command_invocations table
+
+Revision ID: 92ffba02de5d
+Revises: 415493c2f0a9
+Create Date: 2025-08-20 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '92ffba02de5d'
+down_revision: Union[str, None] = '415493c2f0a9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'command_invocations',
+        sa.Column('id', sa.BigInteger, primary_key=True),
+        sa.Column('guild_id', sa.BigInteger, nullable=False),
+        sa.Column('channel_id', sa.BigInteger, nullable=False),
+        sa.Column('user_id', sa.BigInteger, nullable=False),
+        sa.Column('command', sa.Text, nullable=False),
+        sa.Column(
+            'args_json',
+            sa.JSON,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            'created_at',
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text('now()'),
+        ),
+        schema='discord',
+    )
+    op.create_index(
+        'idx_command_inv_created_at',
+        'command_invocations',
+        ['created_at'],
+        schema='discord',
+    )
+    op.create_index(
+        'idx_command_inv_cmd',
+        'command_invocations',
+        ['command'],
+        schema='discord',
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        'idx_command_inv_cmd',
+        table_name='command_invocations',
+        schema='discord',
+    )
+    op.drop_index(
+        'idx_command_inv_created_at',
+        table_name='command_invocations',
+        schema='discord',
+    )
+    op.drop_table('command_invocations', schema='discord')
+

--- a/gentlebot/backfill_commands.py
+++ b/gentlebot/backfill_commands.py
@@ -1,0 +1,89 @@
+"""Backfill command_invocations from channel history."""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from datetime import timedelta
+
+import asyncpg
+import discord
+from discord.ext import commands
+
+from . import bot_config as cfg
+from .util import build_db_url
+
+log = logging.getLogger("gentlebot.backfill_commands")
+
+
+class BackfillBot(commands.Bot):
+    def __init__(self, days: int = 90):
+        intents = discord.Intents.default()
+        super().__init__(command_prefix="!", intents=intents)
+        self.days = days
+        self.pool: asyncpg.Pool | None = None
+
+    async def setup_hook(self) -> None:
+        url = build_db_url()
+        if not url:
+            log.error("PG_DSN is required for backfill")
+            await self.close()
+            return
+        url = url.replace("postgresql+asyncpg://", "postgresql://")
+
+        async def _init(conn: asyncpg.Connection) -> None:
+            await conn.execute("SET search_path=discord,public")
+
+        self.pool = await asyncpg.create_pool(url, init=_init)
+
+    async def on_ready(self) -> None:
+        log.info("Backfill bot logged in as %s", self.user)
+        if self.pool:
+            await self.backfill_history(self.days)
+            await self.pool.close()
+        await self.close()
+
+    async def backfill_history(self, days: int) -> None:
+        cutoff = discord.utils.utcnow() - timedelta(days=days)
+        assert self.pool
+        for guild in self.guilds:
+            for channel in guild.text_channels:
+                try:
+                    async for msg in channel.history(limit=None, after=cutoff):
+                        if msg.type is discord.MessageType.chat_input_command:
+                            cmd = msg.content.split()[0].lstrip("/")
+                            await self.pool.execute(
+                                """INSERT INTO discord.command_invocations (
+                                        guild_id, channel_id, user_id, command, created_at
+                                    ) VALUES ($1,$2,$3,$4,$5)
+                                    ON CONFLICT DO NOTHING""",
+                                guild.id,
+                                channel.id,
+                                msg.author.id,
+                                cmd,
+                                msg.created_at,
+                            )
+                except discord.Forbidden:
+                    log.warning("History fetch forbidden for %s", channel)
+                except Exception as exc:  # pragma: no cover - logging only
+                    log.exception("History fetch failed for %s: %s", channel, exc)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Backfill command log")
+    parser.add_argument(
+        "--days", type=int, default=90, help="Number of days of history to fetch"
+    )
+    return parser.parse_args()
+
+
+async def main() -> None:
+    args = parse_args()
+    bot = BackfillBot(days=args.days)
+    async with bot:
+        await bot.start(cfg.TOKEN)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(main())

--- a/gentlebot/cogs/command_log_cog.py
+++ b/gentlebot/cogs/command_log_cog.py
@@ -1,0 +1,68 @@
+"""Log slash command invocations to Postgres."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+import asyncpg
+import discord
+from discord.ext import commands
+
+from ..util import build_db_url
+
+log = logging.getLogger(f"gentlebot.{__name__}")
+
+
+class CommandLogCog(commands.Cog):
+    """Persist slash command usage statistics."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.pool: asyncpg.Pool | None = None
+        self.enabled = os.getenv("LOG_COMMANDS") == "1"
+
+    async def cog_load(self) -> None:
+        if not self.enabled:
+            return
+        url = build_db_url()
+        if not url:
+            log.warning("LOG_COMMANDS set but PG_DSN is missing")
+            self.enabled = False
+            return
+        url = url.replace("postgresql+asyncpg://", "postgresql://")
+
+        async def _init(conn: asyncpg.Connection) -> None:
+            await conn.execute("SET search_path=discord,public")
+
+        self.pool = await asyncpg.create_pool(url, init=_init)
+        log.info("Command logging enabled")
+
+    async def cog_unload(self) -> None:
+        if self.pool:
+            await self.pool.close()
+            self.pool = None
+
+    @commands.Cog.listener()
+    async def on_app_command_completion(
+        self, interaction: discord.Interaction, command: discord.app_commands.Command
+    ) -> None:
+        if not self.enabled or not self.pool:
+            return
+        opts = interaction.data.get("options", []) if interaction.data else []
+        await self.pool.execute(
+            """
+            INSERT INTO discord.command_invocations (
+                guild_id, channel_id, user_id, command, args_json
+            ) VALUES ($1,$2,$3,$4,$5)
+            """,
+            interaction.guild_id,
+            interaction.channel_id,
+            interaction.user.id,
+            command.name,
+            json.dumps(opts),
+        )
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(CommandLogCog(bot))

--- a/tests/test_command_log_cog.py
+++ b/tests/test_command_log_cog.py
@@ -1,0 +1,51 @@
+import asyncio
+import json
+
+import discord
+from discord.ext import commands
+import asyncpg
+
+from gentlebot.cogs.command_log_cog import CommandLogCog
+
+
+class DummyPool:
+    def __init__(self):
+        self.executed = []
+
+    async def close(self):
+        pass
+
+    async def execute(self, query, *args):
+        self.executed.append((query, args))
+
+
+async def fake_create_pool(url, *args, **kwargs):
+    assert url.startswith("postgresql://")
+    return DummyPool()
+
+
+def test_command_logged(monkeypatch):
+    async def run_test():
+        monkeypatch.setattr(asyncpg, "create_pool", fake_create_pool)
+        monkeypatch.setenv("LOG_COMMANDS", "1")
+        monkeypatch.setenv("PG_DSN", "postgresql+asyncpg://u:p@localhost/db")
+
+        intents = discord.Intents.default()
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        cog = CommandLogCog(bot)
+        await cog.cog_load()
+        pool = cog.pool
+
+        class DummyInteraction:
+            guild_id = 1
+            channel_id = 2
+            user = type("U", (), {"id": 3})()
+            data = {"options": ["foo"]}
+
+        cmd = type("Cmd", (), {"name": "test"})()
+        await cog.on_app_command_completion(DummyInteraction(), cmd)
+
+        assert pool.executed
+
+    asyncio.run(run_test())
+


### PR DESCRIPTION
## Summary
- create `command_invocations` table via alembic
- log slash command completions in new cog
- add script to backfill command history
- document how to enable and migrate command logging
- test the new cog

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_687dbf417364832b9d2291fda6bf1637