### PR TITLE
Add BACKFILL_DAYS override

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,14 @@ setup.sh           # install dependencies and create the venv
    alembic upgrade head
    ```
    A backfill of up to 90 days of history is automatically performed
-   after migrations complete. You can re-run `python backfill_archive.py`
+   after migrations complete. Set `BACKFILL_DAYS` to override the default
+   number of days. You can re-run `python backfill_archive.py --days N`
    at any time; inserts use `ON CONFLICT DO NOTHING` so no duplicates are
    created.
 6. Set `LOG_COMMANDS=1` to record slash command usage. Run the migration
    to create the `command_invocations` table. Historical usage is also
-   backfilled automatically after the migration:
+   backfilled automatically after the migration using the same
+   `BACKFILL_DAYS` value:
    ```bash
    alembic upgrade head
    ```

--- a/gentlebot/backfill_archive.py
+++ b/gentlebot/backfill_archive.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+import os
 from datetime import timedelta
 
 import discord
@@ -68,7 +69,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--days",
         type=int,
-        default=90,
+        default=int(os.getenv("BACKFILL_DAYS", "90")),
         help="Number of days of history to fetch",
     )
     return parser.parse_args()

--- a/gentlebot/backfill_commands.py
+++ b/gentlebot/backfill_commands.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+import os
 from datetime import timedelta
 
 import asyncpg
@@ -72,7 +73,7 @@ class BackfillBot(commands.Bot):
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Backfill command log")
     parser.add_argument(
-        "--days", type=int, default=90, help="Number of days of history to fetch"
+        "--days", type=int, default=int(os.getenv("BACKFILL_DAYS", "90")), help="Number of days of history to fetch"
     )
     return parser.parse_args()
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -18,8 +18,9 @@ if [[ "${SKIP_DB:-0}" != "1" ]]; then
   alembic upgrade head
 
   # Run backfill scripts after migrations
-  python gentlebot/backfill_commands.py --days 90 || true
-  python gentlebot/backfill_archive.py --days 90 || true
+  BACKFILL_DAYS=${BACKFILL_DAYS:-90}
+  python gentlebot/backfill_commands.py --days "$BACKFILL_DAYS" || true
+  python gentlebot/backfill_archive.py --days "$BACKFILL_DAYS" || true
 else
   echo "SKIP_DB=1 - skipping Postgres availability checks"
 fi


### PR DESCRIPTION
## Summary
- allow selecting the backfill window via `BACKFILL_DAYS`
- pass the value through container startup
- document the environment variable

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_687e7cde895c832b94b1b934eb95f9d0