### PR TITLE
Fix backfill script invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,8 @@ setup.sh           # install dependencies and create the venv
    alembic upgrade head
    ```
    A backfill of up to 90 days of history is automatically performed
-   after migrations complete. You can re-run `python backfill_archive.py`
-   at any time; inserts use `ON CONFLICT DO NOTHING` so no duplicates are
-   created.
+   after migrations complete. You can re-run `python -m gentlebot.backfill_archive`
+   at any time; inserts use `ON CONFLICT DO NOTHING` so no duplicates are created.
 6. Set `LOG_COMMANDS=1` to record slash command usage. Run the migration
    to create the `command_invocations` table. Historical usage is also
    backfilled automatically after the migration:

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ setup.sh           # install dependencies and create the venv
    ```bash
    alembic upgrade head
    ```
+   You can re-run `python -m gentlebot.backfill_commands` whenever needed;
+   inserts use `ON CONFLICT DO NOTHING` to avoid duplicates.
 7. Run the bot:
    ```bash
    python -m gentlebot

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -18,8 +18,8 @@ if [[ "${SKIP_DB:-0}" != "1" ]]; then
   alembic upgrade head
 
   # Run backfill scripts after migrations
-  python gentlebot/backfill_commands.py --days 90 || true
-  python gentlebot/backfill_archive.py --days 90 || true
+  python -m gentlebot.backfill_commands --days 90 || true
+  python -m gentlebot.backfill_archive --days 90 || true
 else
   echo "SKIP_DB=1 - skipping Postgres availability checks"
 fi


### PR DESCRIPTION
## Summary
- run backfill modules with `-m` in startup script
- document the module invocation for manual backfills

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_687e7df0b7d8832bab730810c524be25