### PR TITLE
Add role tracking to archive system

### DIFF
--- a/db/versions/32bff6a875bd_add_role_tracking_tables.py
+++ b/db/versions/32bff6a875bd_add_role_tracking_tables.py
@@ -1,0 +1,56 @@
+"""add role tracking tables
+
+Revision ID: 32bff6a875bd
+Revises: 92ffba02de5d
+Create Date: 2025-08-30 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '32bff6a875bd'
+down_revision: Union[str, None] = '92ffba02de5d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'guild_role',
+        sa.Column('role_id', sa.BigInteger, primary_key=True),
+        sa.Column('guild_id', sa.BigInteger, sa.ForeignKey('guild.guild_id', ondelete='CASCADE')),
+        sa.Column('name', sa.Text, nullable=False),
+        sa.Column('color_rgb', sa.Integer),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()')),
+        schema='discord',
+    )
+    op.create_table(
+        'role_assignment',
+        sa.Column('guild_id', sa.BigInteger, nullable=False),
+        sa.Column('role_id', sa.BigInteger, nullable=False),
+        sa.Column('user_id', sa.BigInteger, nullable=False),
+        sa.Column('assigned_at', sa.DateTime(timezone=True), server_default=sa.text('now()')),
+        sa.PrimaryKeyConstraint('guild_id', 'role_id', 'user_id'),
+        schema='discord',
+    )
+    op.create_table(
+        'role_event',
+        sa.Column('event_id', sa.BigInteger, primary_key=True),
+        sa.Column('guild_id', sa.BigInteger, nullable=False),
+        sa.Column('role_id', sa.BigInteger, nullable=False),
+        sa.Column('user_id', sa.BigInteger, nullable=False),
+        sa.Column('action', sa.SmallInteger, nullable=False),
+        sa.Column('event_at', sa.DateTime(timezone=True), server_default=sa.text('now()')),
+        schema='discord',
+    )
+    op.create_index('role_event_ts', 'role_event', ['event_at'], schema='discord')
+    op.create_index('role_event_user', 'role_event', ['user_id', 'event_at'], schema='discord')
+
+
+def downgrade() -> None:
+    op.drop_index('role_event_user', table_name='role_event', schema='discord')
+    op.drop_index('role_event_ts', table_name='role_event', schema='discord')
+    op.drop_table('role_event', schema='discord')
+    op.drop_table('role_assignment', schema='discord')
+    op.drop_table('guild_role', schema='discord')

--- a/gentlebot/backfill_roles.py
+++ b/gentlebot/backfill_roles.py
@@ -1,0 +1,86 @@
+"""Backfill current guild roles and assignments."""
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import asyncpg
+import discord
+from discord.ext import commands
+
+from . import bot_config as cfg
+from .util import build_db_url
+
+log = logging.getLogger("gentlebot.backfill_roles")
+
+
+class BackfillBot(commands.Bot):
+    def __init__(self):
+        intents = discord.Intents.default()
+        intents.members = True
+        super().__init__(command_prefix="!", intents=intents)
+        self.pool: asyncpg.Pool | None = None
+
+    async def setup_hook(self) -> None:
+        url = build_db_url()
+        if not url:
+            log.error("PG_DSN is required for backfill")
+            await self.close()
+            return
+        url = url.replace("postgresql+asyncpg://", "postgresql://")
+
+        async def _init(conn: asyncpg.Connection) -> None:
+            await conn.execute("SET search_path=discord,public")
+
+        self.pool = await asyncpg.create_pool(url, init=_init)
+
+    async def on_ready(self) -> None:
+        log.info("Backfill bot logged in as %s", self.user)
+        assert self.pool
+        for guild in self.guilds:
+            for role in guild.roles:
+                await self.pool.execute(
+                    """
+                    INSERT INTO discord.guild_role (role_id, guild_id, name, color_rgb)
+                    VALUES ($1,$2,$3,$4)
+                    ON CONFLICT (role_id) DO UPDATE SET name=$3, color_rgb=$4
+                    """,
+                    role.id,
+                    guild.id,
+                    role.name,
+                    role.color.value if role.color else None,
+                )
+            for member in guild.members:
+                for role in member.roles:
+                    await self.pool.execute(
+                        """
+                        INSERT INTO discord.role_assignment (guild_id, role_id, user_id)
+                        VALUES ($1,$2,$3)
+                        ON CONFLICT DO NOTHING
+                        """,
+                        guild.id,
+                        role.id,
+                        member.id,
+                    )
+                    await self.pool.execute(
+                        """
+                        INSERT INTO discord.role_event (guild_id, role_id, user_id, action)
+                        VALUES ($1,$2,$3,1)
+                        """,
+                        guild.id,
+                        role.id,
+                        member.id,
+                    )
+        await self.pool.close()
+        await self.close()
+
+
+async def main() -> None:
+    bot = BackfillBot()
+    async with bot:
+        await bot.start(cfg.TOKEN)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(main())

--- a/gentlebot/cogs/role_log_cog.py
+++ b/gentlebot/cogs/role_log_cog.py
@@ -1,0 +1,124 @@
+"""Record role assignments and changes to Postgres."""
+from __future__ import annotations
+
+import logging
+import os
+
+import asyncpg
+import discord
+from discord.ext import commands
+
+from ..util import build_db_url
+
+log = logging.getLogger(f"gentlebot.{__name__}")
+
+
+class RoleLogCog(commands.Cog):
+    """Persist role assignment events to Postgres."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.pool: asyncpg.Pool | None = None
+        self.enabled = os.getenv("LOG_ROLES") == "1"
+
+    async def cog_load(self) -> None:
+        if not self.enabled:
+            return
+        url = build_db_url()
+        if not url:
+            log.warning("LOG_ROLES set but PG_DSN is missing")
+            self.enabled = False
+            return
+        url = url.replace("postgresql+asyncpg://", "postgresql://")
+
+        async def _init(conn: asyncpg.Connection) -> None:
+            await conn.execute("SET search_path=discord,public")
+
+        self.pool = await asyncpg.create_pool(url, init=_init)
+        log.info("Role logging enabled")
+
+    async def cog_unload(self) -> None:
+        if self.pool:
+            await self.pool.close()
+            self.pool = None
+
+    async def _upsert_role(self, role: discord.Role | None) -> None:
+        if not self.pool or role is None:
+            return
+        await self.pool.execute(
+            """
+            INSERT INTO discord.guild_role (role_id, guild_id, name, color_rgb)
+            VALUES ($1,$2,$3,$4)
+            ON CONFLICT (role_id) DO UPDATE SET name=$3, color_rgb=$4
+            """,
+            role.id,
+            role.guild.id,
+            role.name,
+            role.color.value if role.color else None,
+        )
+
+    async def _record_assignment(self, guild_id: int, role_id: int, user_id: int) -> None:
+        if not self.pool:
+            return
+        await self.pool.execute(
+            """
+            INSERT INTO discord.role_assignment (guild_id, role_id, user_id)
+            VALUES ($1,$2,$3)
+            ON CONFLICT DO NOTHING
+            """,
+            guild_id,
+            role_id,
+            user_id,
+        )
+        await self.pool.execute(
+            """
+            INSERT INTO discord.role_event (guild_id, role_id, user_id, action)
+            VALUES ($1,$2,$3,1)
+            """,
+            guild_id,
+            role_id,
+            user_id,
+        )
+
+    async def _record_removal(self, guild_id: int, role_id: int, user_id: int) -> None:
+        if not self.pool:
+            return
+        await self.pool.execute(
+            """
+            DELETE FROM discord.role_assignment
+            WHERE guild_id=$1 AND role_id=$2 AND user_id=$3
+            """,
+            guild_id,
+            role_id,
+            user_id,
+        )
+        await self.pool.execute(
+            """
+            INSERT INTO discord.role_event (guild_id, role_id, user_id, action)
+            VALUES ($1,$2,$3,0)
+            """,
+            guild_id,
+            role_id,
+            user_id,
+        )
+
+    @commands.Cog.listener()
+    async def on_member_update(self, before: discord.Member, after: discord.Member) -> None:
+        if not self.enabled or not self.pool or before.guild != after.guild:
+            return
+        before_ids = {r.id for r in before.roles}
+        after_ids = {r.id for r in after.roles}
+        added = after_ids - before_ids
+        removed = before_ids - after_ids
+        for rid in added:
+            role = after.guild.get_role(rid)
+            await self._upsert_role(role)
+            await self._record_assignment(after.guild.id, rid, after.id)
+        for rid in removed:
+            role = before.guild.get_role(rid)
+            await self._upsert_role(role)
+            await self._record_removal(before.guild.id, rid, after.id)
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(RoleLogCog(bot))

--- a/tests/test_role_log_cog.py
+++ b/tests/test_role_log_cog.py
@@ -1,0 +1,41 @@
+import discord
+from discord.ext import commands
+import asyncpg
+
+from gentlebot.cogs.role_log_cog import RoleLogCog
+
+
+class DummyPool:
+    def __init__(self):
+        self.executed = []
+
+    async def close(self):
+        pass
+
+    async def execute(self, query, *args):
+        self.executed.append((query, args))
+
+
+async def fake_create_pool(url, *args, **kwargs):
+    assert url.startswith("postgresql://")
+    return DummyPool()
+
+
+def test_role_add_logged(monkeypatch):
+    async def run_test():
+        monkeypatch.setattr(asyncpg, "create_pool", fake_create_pool)
+        monkeypatch.setenv("LOG_ROLES", "1")
+        monkeypatch.setenv("PG_DSN", "postgresql+asyncpg://u:p@localhost/db")
+        intents = discord.Intents.default()
+        intents.members = True
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        cog = RoleLogCog(bot)
+        await cog.cog_load()
+        pool = cog.pool
+        guild = type("G", (), {"id": 1, "get_role": lambda self, rid: type("R", (), {"id": rid, "guild": self, "name": "r", "color": discord.Colour.default()})()})()
+        before = type("M", (), {"id": 10, "guild": guild, "roles": []})()
+        after = type("M", (), {"id": 10, "guild": guild, "roles": [guild.get_role(5)]})()
+        await cog.on_member_update(before, after)
+        assert pool.executed
+    import asyncio
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- capture role changes in a new `role_log_cog`
- support backfilling guild roles via `backfill_roles.py`
- add Alembic migration for role tracking tables
- test role logging

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_687e83b1f3e0832b8b1bf86c61de68b8