### PR TITLE
Fix backfill script imports

### DIFF
--- a/gentlebot/backfill_archive.py
+++ b/gentlebot/backfill_archive.py
@@ -10,8 +10,8 @@ from datetime import timedelta
 import discord
 from discord.ext import commands
 
-from . import bot_config as cfg
-from .cogs.message_archive_cog import MessageArchiveCog
+from gentlebot import bot_config as cfg
+from gentlebot.cogs.message_archive_cog import MessageArchiveCog
 
 log = logging.getLogger("gentlebot.backfill")
 

--- a/gentlebot/backfill_commands.py
+++ b/gentlebot/backfill_commands.py
@@ -11,8 +11,8 @@ import asyncpg
 import discord
 from discord.ext import commands
 
-from . import bot_config as cfg
-from .util import build_db_url
+from gentlebot import bot_config as cfg
+from gentlebot.util import build_db_url
 
 log = logging.getLogger("gentlebot.backfill_commands")
 

--- a/gentlebot/backfill_roles.py
+++ b/gentlebot/backfill_roles.py
@@ -8,8 +8,8 @@ import asyncpg
 import discord
 from discord.ext import commands
 
-from . import bot_config as cfg
-from .util import build_db_url
+from gentlebot import bot_config as cfg
+from gentlebot.util import build_db_url
 
 log = logging.getLogger("gentlebot.backfill_roles")
 


### PR DESCRIPTION
## Summary
- fix absolute imports in backfill scripts so they run standalone

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_687e85c2d368832b83bd266942fe0d13