### PR TITLE
Fix Alembic schema search path

### DIFF
--- a/db/env.py
+++ b/db/env.py
@@ -2,7 +2,7 @@ import os
 from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config
-from sqlalchemy import pool
+from sqlalchemy import pool, text
 
 from alembic import context
 
@@ -79,6 +79,7 @@ def run_migrations_online() -> None:
     )
 
     with connectable.connect() as connection:
+        connection.execute(text("SET search_path=discord,public"))
         context.configure(
             connection=connection, target_metadata=target_metadata
         )


### PR DESCRIPTION
## Summary
- ensure migrations set the Postgres search path

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_687e961ffca0832bad119ef4371c8c92