### PR TITLE
Fix command backfill name parsing

### DIFF
--- a/tests/test_backfill_commands.py
+++ b/tests/test_backfill_commands.py
@@ -1,0 +1,14 @@
+import types
+import discord
+
+from gentlebot.backfill_commands import _extract_cmd
+
+
+def test_extract_cmd_interaction():
+    msg = types.SimpleNamespace(content="irrelevant", interaction=types.SimpleNamespace(name="foo"))
+    assert _extract_cmd(msg) == "foo"
+
+
+def test_extract_cmd_fallback():
+    msg = types.SimpleNamespace(content="/bar baz", interaction=None)
+    assert _extract_cmd(msg) == "bar"


### PR DESCRIPTION
## Summary
- improve command extraction when backfilling slash commands
- add unit tests for backfill helper

## Testing
- `pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_687ebbbc9108832b805a03fe61bd194d