### PR TITLE
Update backfill to use interaction_metadata

### DIFF
--- a/gentlebot/backfill_commands.py
+++ b/gentlebot/backfill_commands.py
@@ -20,7 +20,7 @@ log = logging.getLogger("gentlebot.backfill_commands")
 def _extract_cmd(msg: discord.Message) -> str:
     """Return slash command name from a history message."""
     return (
-        getattr(getattr(msg, "interaction", None), "name", None)
+        getattr(getattr(msg, "interaction_metadata", None), "name", None)
         or msg.content.split()[0].lstrip("/")
     )
 

--- a/tests/test_backfill_commands.py
+++ b/tests/test_backfill_commands.py
@@ -4,8 +4,8 @@ import discord
 from gentlebot.backfill_commands import _extract_cmd
 
 
-def test_extract_cmd_interaction():
-    msg = types.SimpleNamespace(content="irrelevant", interaction=types.SimpleNamespace(name="foo"))
+def test_extract_cmd_interaction_metadata():
+    msg = types.SimpleNamespace(content="irrelevant", interaction_metadata=types.SimpleNamespace(name="foo"))
     assert _extract_cmd(msg) == "foo"
 
 


### PR DESCRIPTION
## Summary
- switch backfill logic to use `interaction_metadata`
- update tests for new attribute

## Testing
- `pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_687ed265fa60832bb30dc6fa9dceca24