### PR TITLE
Fix message_content warning in backfill utilities

### DIFF
--- a/gentlebot/backfill_commands.py
+++ b/gentlebot/backfill_commands.py
@@ -28,6 +28,7 @@ def _extract_cmd(msg: discord.Message) -> str:
 class BackfillBot(commands.Bot):
     def __init__(self, days: int = 90):
         intents = discord.Intents.default()
+        intents.message_content = True
         super().__init__(command_prefix="!", intents=intents)
         self.days = days
         self.pool: asyncpg.Pool | None = None

--- a/gentlebot/backfill_roles.py
+++ b/gentlebot/backfill_roles.py
@@ -17,6 +17,7 @@ log = logging.getLogger("gentlebot.backfill_roles")
 class BackfillBot(commands.Bot):
     def __init__(self):
         intents = discord.Intents.default()
+        intents.message_content = True
         intents.members = True
         super().__init__(command_prefix="!", intents=intents)
         self.pool: asyncpg.Pool | None = None


### PR DESCRIPTION
## Summary
- enable `message_content` intent in the backfill scripts so running them doesn't trigger warnings

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_687ed22508ec832b954064182384862d