### PR TITLE
Fix backfill crash on empty command messages

### DIFF
--- a/tests/test_backfill_commands.py
+++ b/tests/test_backfill_commands.py
@@ -12,3 +12,8 @@ def test_extract_cmd_interaction_metadata():
 def test_extract_cmd_fallback():
     msg = types.SimpleNamespace(content="/bar baz", interaction=None)
     assert _extract_cmd(msg) == "bar"
+
+
+def test_extract_cmd_empty():
+    msg = types.SimpleNamespace(content="", interaction=None)
+    assert _extract_cmd(msg) is None


### PR DESCRIPTION
## Summary
- avoid IndexError in `_extract_cmd` by returning `None` for empty messages
- skip history records with no extracted command
- test command extraction with empty content

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_687ed8399e84832bbd69fae8d4467998