### PR TITLE
Expand backfill window

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ setup.sh           # install dependencies and create the venv
    ```bash
    alembic upgrade head
    ```
-   A backfill of up to 90 days of history is automatically performed
+   A backfill of up to 360 days of history is automatically performed
    after migrations complete. Set `BACKFILL_DAYS` to override the default
    number of days. You can re-run `python backfill_archive.py --days N`
    at any time; inserts use `ON CONFLICT DO NOTHING` so no duplicates are

--- a/gentlebot/backfill_archive.py
+++ b/gentlebot/backfill_archive.py
@@ -17,7 +17,7 @@ log = logging.getLogger("gentlebot.backfill")
 
 
 class BackfillBot(commands.Bot):
-    def __init__(self, days: int = 90):
+    def __init__(self, days: int = 360):
         intents = discord.Intents.default()
         intents.message_content = True
         intents.members = True
@@ -69,7 +69,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--days",
         type=int,
-        default=int(os.getenv("BACKFILL_DAYS", "90")),
+        default=int(os.getenv("BACKFILL_DAYS", "360")),
         help="Number of days of history to fetch",
     )
     return parser.parse_args()

--- a/gentlebot/backfill_commands.py
+++ b/gentlebot/backfill_commands.py
@@ -33,7 +33,7 @@ def _extract_cmd(msg: discord.Message) -> str | None:
 
 
 class BackfillBot(commands.Bot):
-    def __init__(self, days: int = 90):
+    def __init__(self, days: int = 360):
         intents = discord.Intents.default()
         intents.message_content = True
         super().__init__(command_prefix="!", intents=intents)
@@ -91,7 +91,7 @@ class BackfillBot(commands.Bot):
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Backfill command log")
     parser.add_argument(
-        "--days", type=int, default=int(os.getenv("BACKFILL_DAYS", "90")), help="Number of days of history to fetch"
+        "--days", type=int, default=int(os.getenv("BACKFILL_DAYS", "360")), help="Number of days of history to fetch"
     )
     return parser.parse_args()
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -18,7 +18,7 @@ if [[ "${SKIP_DB:-0}" != "1" ]]; then
   alembic upgrade head
 
   # Run backfill scripts after migrations
-  BACKFILL_DAYS=${BACKFILL_DAYS:-90}
+  BACKFILL_DAYS=${BACKFILL_DAYS:-360}
   python -m gentlebot.backfill_commands --days "$BACKFILL_DAYS" || true
   python -m gentlebot.backfill_archive --days "$BACKFILL_DAYS" || true
 else


### PR DESCRIPTION
## Summary
- default to 360 days of history when backfilling
- update script defaults
- document new backfill timeframe

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_687edfd0adc0832b98a8013928384b8a