### PR TITLE
Add unique constraint for command invocation backfills

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ setup.sh           # install dependencies and create the venv
 6. Set `LOG_COMMANDS=1` to record slash command usage. Run the migration
    to create the `command_invocations` table. Historical usage is also
    backfilled automatically after the migration using the same
-   `BACKFILL_DAYS` value:
+   `BACKFILL_DAYS` value. Inserts are deduplicated via a unique
+   constraint so the backfill can be safely re-run:
    ```bash
    alembic upgrade head
    ```

--- a/db/versions/0d9af2321b54_add_unique_command_invocation_constraint.py
+++ b/db/versions/0d9af2321b54_add_unique_command_invocation_constraint.py
@@ -1,0 +1,32 @@
+"""add unique constraint to command_invocations
+
+Revision ID: 0d9af2321b54
+Revises: 32bff6a875bd
+Create Date: 2025-07-22 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '0d9af2321b54'
+down_revision: Union[str, None] = '32bff6a875bd'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_unique_constraint(
+        'uniq_cmd_inv_guild_chan_user_cmd_ts',
+        'command_invocations',
+        ['guild_id', 'channel_id', 'user_id', 'command', 'created_at'],
+        schema='discord',
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        'uniq_cmd_inv_guild_chan_user_cmd_ts',
+        'command_invocations',
+        schema='discord',
+    )

--- a/gentlebot/backfill_commands.py
+++ b/gentlebot/backfill_commands.py
@@ -75,7 +75,7 @@ class BackfillBot(commands.Bot):
                                 """INSERT INTO discord.command_invocations (
                                         guild_id, channel_id, user_id, command, created_at
                                     ) VALUES ($1,$2,$3,$4,$5)
-                                    ON CONFLICT DO NOTHING""",
+                                    ON CONFLICT ON CONSTRAINT uniq_cmd_inv_guild_chan_user_cmd_ts DO NOTHING""",
                                 guild.id,
                                 channel.id,
                                 msg.author.id,

--- a/gentlebot/cogs/command_log_cog.py
+++ b/gentlebot/cogs/command_log_cog.py
@@ -55,6 +55,7 @@ class CommandLogCog(commands.Cog):
             INSERT INTO discord.command_invocations (
                 guild_id, channel_id, user_id, command, args_json
             ) VALUES ($1,$2,$3,$4,$5)
+            ON CONFLICT ON CONSTRAINT uniq_cmd_inv_guild_chan_user_cmd_ts DO NOTHING
             """,
             interaction.guild_id,
             interaction.channel_id,


### PR DESCRIPTION
## Summary
- keep command_invocations table deduplicated with a unique constraint
- skip duplicates in command_log and backfill scripts
- document how backfill remains safe to run repeatedly

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_687ee1cfce9c832bb60f8c0ddbadaa96