### PR TITLE
Add row count logging to backfills

### DIFF
--- a/gentlebot/backfill_archive.py
+++ b/gentlebot/backfill_archive.py
@@ -24,6 +24,13 @@ class BackfillBot(commands.Bot):
         super().__init__(command_prefix="!", intents=intents)
         self.archive = MessageArchiveCog(self)
         self.days = days
+        self.counts = {
+            "guild": 0,
+            "channel": 0,
+            "user": 0,
+            "message": 0,
+            "attachment": 0,
+        }
 
     async def setup_hook(self) -> None:
         await self.archive.cog_load()
@@ -31,6 +38,14 @@ class BackfillBot(commands.Bot):
     async def on_ready(self) -> None:
         log.info("Backfill bot logged in as %s", self.user)
         await self.backfill_history(self.days)
+        log.info(
+            "Inserted %d guilds, %d channels, %d users, %d messages, %d attachments",
+            self.counts["guild"],
+            self.counts["channel"],
+            self.counts["user"],
+            self.counts["message"],
+            self.counts["attachment"],
+        )
         await self.archive.cog_unload()
         await self.close()
 
@@ -41,21 +56,23 @@ class BackfillBot(commands.Bot):
         cutoff = discord.utils.utcnow() - timedelta(days=days)
         for guild in self.guilds:
             try:
-                await self.archive._upsert_guild(guild)
+                self.counts["guild"] += await self.archive._upsert_guild(guild)
             except Exception as exc:
                 log.exception("Failed to record guild %s: %s", guild.name, exc)
                 continue
             for channel in guild.text_channels:
                 try:
-                    await self.archive._upsert_channel(channel)
+                    self.counts["channel"] += await self.archive._upsert_channel(channel)
                 except Exception as exc:
                     log.exception("Failed to record channel %s: %s", channel.name, exc)
                     continue
                 try:
                     async for msg in channel.history(limit=None, after=cutoff):
                         try:
-                            await self.archive._upsert_user(msg.author)
-                            await self.archive._insert_message(msg)
+                            self.counts["user"] += await self.archive._upsert_user(msg.author)
+                            msg_count, att_count = await self.archive._insert_message(msg)
+                            self.counts["message"] += msg_count
+                            self.counts["attachment"] += att_count
                         except Exception as msg_exc:
                             log.exception("Failed to record message %s: %s", msg.id, msg_exc)
                 except discord.Forbidden as exc:

--- a/gentlebot/util.py
+++ b/gentlebot/util.py
@@ -37,3 +37,11 @@ def int_env(var: str, default: int = 0) -> int:
             "Invalid integer for %s: %s; using %s", var, value, default
         )
         return default
+
+
+def rows_from_tag(tag: str) -> int:
+    """Return the affected row count from an asyncpg status tag."""
+    try:
+        return int(str(tag).split()[-1])
+    except (IndexError, ValueError):
+        return 0

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,12 @@
+import pytest
+
+from gentlebot.util import rows_from_tag
+
+@pytest.mark.parametrize("tag,expected", [
+    ("INSERT 0 1", 1),
+    ("INSERT 0 0", 0),
+    ("UPDATE 5", 5),
+    ("bogus", 0),
+])
+def test_rows_from_tag(tag, expected):
+    assert rows_from_tag(tag) == expected


### PR DESCRIPTION
## Summary
- add `rows_from_tag` helper for parsing asyncpg status
- update message archive helpers to return inserted counts
- log inserted row counts in `backfill_archive.py`
- log inserted row counts in `backfill_commands.py`
- log inserted row counts in `backfill_roles.py`
- test `rows_from_tag`

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_687ef69d0c84832b91b12453cfaa6249