### PR TITLE
Update prompt scheduling to 12:30pm PT

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Gentlebot is a modular Discord bot composed of several **cogs** that handle diff
   Admins can still run `/refreshroles` to fetch 14 days of history and refresh
   roles manually. Ensure the bot's role is above these vanity roles and has the
   **Manage Roles** permission so it can assign and remove them.
-- **PromptCog** – Posts a daily prompt generated via the Hugging Face API.
-  Categories rotate randomly without repeating recent types, and the
-  rotation state persists in `prompt_state.json` so redeployments keep
-  things fresh.
+- **PromptCog** – Posts a daily prompt generated via the Hugging Face API at
+  12:30 pm Pacific time by default. Categories rotate randomly without
+  repeating recent types, and the rotation state persists in
+  `prompt_state.json` so redeployments keep things fresh.
 - **HuggingFaceCog** – Adds AI conversation and emoji reactions using Hugging Face models.
 - **StatsCog** – `/engagement` now replies "Working on it..." and then gathers
   unlimited history in the background before posting the stats and optional

--- a/tests/test_prompt_schedule.py
+++ b/tests/test_prompt_schedule.py
@@ -1,0 +1,20 @@
+from datetime import datetime, timedelta
+from gentlebot.cogs import prompt_cog
+
+
+def test_next_run_time_before_schedule():
+    tz = prompt_cog.LOCAL_TZ
+    now = datetime(2023, 1, 1, 10, 0, tzinfo=tz)
+    next_run = prompt_cog.PromptCog(None)._next_run_time(now)
+    assert next_run.date() == now.date()
+    assert next_run.hour == prompt_cog.SCHEDULE_HOUR
+    assert next_run.minute == prompt_cog.SCHEDULE_MINUTE
+
+
+def test_next_run_time_after_schedule():
+    tz = prompt_cog.LOCAL_TZ
+    now = datetime(2023, 1, 1, 13, 0, tzinfo=tz)
+    next_run = prompt_cog.PromptCog(None)._next_run_time(now)
+    assert next_run.date() == now.date() + timedelta(days=1)
+    assert next_run.hour == prompt_cog.SCHEDULE_HOUR
+    assert next_run.minute == prompt_cog.SCHEDULE_MINUTE


### PR DESCRIPTION
## Summary
- adjust default schedule to run at 12:30pm Pacific
- support `PROMPT_SCHEDULE_MINUTE` for finer control
- document new default in README
- test next-run calculation

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_687f199c3978832ba35679f64838f4a4