### PR TITLE
Extend user table fields

### DIFF
--- a/db/versions/a8c180046cea_add_extra_user_fields.py
+++ b/db/versions/a8c180046cea_add_extra_user_fields.py
@@ -1,0 +1,58 @@
+"""add more user fields to match Discord spec
+
+Revision ID: a8c180046cea
+Revises: e7faeab353b9
+Create Date: 2025-09-01 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'a8c180046cea'
+down_revision: Union[str, None] = 'e7faeab353b9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'user',
+        sa.Column('global_name', sa.Text),
+        schema='discord'
+    )
+    op.add_column(
+        'user',
+        sa.Column('banner_hash', sa.Text),
+        schema='discord'
+    )
+    op.add_column(
+        'user',
+        sa.Column('accent_color', sa.Integer),
+        schema='discord'
+    )
+    op.add_column(
+        'user',
+        sa.Column('avatar_decoration_hash', sa.Text),
+        schema='discord'
+    )
+    op.add_column(
+        'user',
+        sa.Column('system', sa.Boolean, server_default=sa.text('false')),
+        schema='discord'
+    )
+    op.add_column(
+        'user',
+        sa.Column('public_flags', sa.Integer),
+        schema='discord'
+    )
+    op.execute('UPDATE discord."user" SET global_name = display_name')
+
+
+def downgrade() -> None:
+    op.drop_column('user', 'public_flags', schema='discord')
+    op.drop_column('user', 'system', schema='discord')
+    op.drop_column('user', 'avatar_decoration_hash', schema='discord')
+    op.drop_column('user', 'accent_color', schema='discord')
+    op.drop_column('user', 'banner_hash', schema='discord')
+    op.drop_column('user', 'global_name', schema='discord')

--- a/gentlebot/cogs/message_archive_cog.py
+++ b/gentlebot/cogs/message_archive_cog.py
@@ -70,9 +70,11 @@ class MessageArchiveCog(commands.Cog):
             """
             INSERT INTO discord."user" (
                 user_id, username, discriminator, avatar_hash, is_bot,
-                display_name, first_seen_at, last_seen_at
+                display_name, global_name, banner_hash, accent_color,
+                avatar_decoration_hash, system, public_flags,
+                first_seen_at, last_seen_at
             )
-            VALUES ($1,$2,$3,$4,$5,$6, now(), now())
+            VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12, now(), now())
             ON CONFLICT (user_id)
             DO UPDATE SET
                 username=$2,
@@ -80,6 +82,12 @@ class MessageArchiveCog(commands.Cog):
                 avatar_hash=$4,
                 is_bot=$5,
                 display_name=$6,
+                global_name=$7,
+                banner_hash=$8,
+                accent_color=$9,
+                avatar_decoration_hash=$10,
+                system=$11,
+                public_flags=$12,
                 last_seen_at=EXCLUDED.last_seen_at
             RETURNING xmax = 0
             """,
@@ -89,6 +97,12 @@ class MessageArchiveCog(commands.Cog):
             getattr(member, "avatar", None) and member.avatar.key,
             getattr(member, "bot", False),
             getattr(member, "display_name", None),
+            getattr(member, "global_name", None),
+            getattr(getattr(member, "banner", None), "key", None),
+            getattr(member, "accent_color", None),
+            getattr(getattr(member, "avatar_decoration", None), "key", None),
+            getattr(member, "system", False),
+            getattr(member, "public_flags", None),
         )
         return int(bool(inserted))
 

--- a/tests/test_message_archive_cog.py
+++ b/tests/test_message_archive_cog.py
@@ -149,10 +149,16 @@ def test_upsert_user(monkeypatch):
             avatar=None,
             bot=False,
             display_name="User Display",
+            global_name="User Global",
+            banner=None,
+            accent_color=None,
+            avatar_decoration=None,
+            system=False,
+            public_flags=None,
         )
         await cog._upsert_user(member)
         assert pool.executed
-        assert "display_name" in pool.executed[0]
+        assert "global_name" in pool.executed[0]
 
     asyncio.run(run_test())
 


### PR DESCRIPTION
## Summary
- track additional User fields to match Discord's spec
- update message archival query
- test new parameters for `_upsert_user`
- add alembic migration for the new columns

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_6880512190e0832b8ffdff26aa643645