### PR TITLE
Fix PublicUserFlags storage

### DIFF
--- a/gentlebot/cogs/message_archive_cog.py
+++ b/gentlebot/cogs/message_archive_cog.py
@@ -66,6 +66,8 @@ class MessageArchiveCog(commands.Cog):
     async def _upsert_user(self, member: discord.abc.User) -> int:
         if not self.pool:
             return 0
+        flags = getattr(member, "public_flags", None)
+        flags_value = getattr(flags, "value", None) if flags is not None else None
         inserted = await self.pool.fetchval(
             """
             INSERT INTO discord."user" (
@@ -102,7 +104,7 @@ class MessageArchiveCog(commands.Cog):
             getattr(member, "accent_color", None),
             getattr(getattr(member, "avatar_decoration", None), "key", None),
             getattr(member, "system", False),
-            getattr(member, "public_flags", None),
+            flags_value,
         )
         return int(bool(inserted))
 

--- a/tests/test_message_archive_cog.py
+++ b/tests/test_message_archive_cog.py
@@ -163,6 +163,38 @@ def test_upsert_user(monkeypatch):
     asyncio.run(run_test())
 
 
+def test_upsert_user_flags(monkeypatch):
+    async def run_test():
+        pool = DummyPool()
+        intents = discord.Intents.default()
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        cog = MessageArchiveCog(bot)
+        cog.pool = pool
+
+        class Dummy:
+            def __init__(self, **kw):
+                self.__dict__.update(kw)
+
+        member = Dummy(
+            id=1,
+            name="user",
+            discriminator="0001",
+            avatar=None,
+            bot=False,
+            display_name="User Display",
+            global_name="User Global",
+            banner=None,
+            accent_color=None,
+            avatar_decoration=None,
+            system=False,
+            public_flags=discord.PublicUserFlags._from_value(8),
+        )
+        await cog._upsert_user(member)
+        assert pool.executed
+
+    asyncio.run(run_test())
+
+
 def test_reply_to_missing(monkeypatch):
     async def run_test():
         pool = DummyPool()


### PR DESCRIPTION
## Summary
- handle discord `PublicUserFlags` when archiving users
- add regression test for storing user flags

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_6880558d8730832ba1883574550f44f5