### PR TITLE
Update Channel archive table

### DIFF
--- a/db/versions/d24e408ee6dc_expand_channel_table.py
+++ b/db/versions/d24e408ee6dc_expand_channel_table.py
@@ -1,0 +1,38 @@
+"""expand discord.channel table
+
+Revision ID: d24e408ee6dc
+Revises: e7faeab353b9
+Create Date: 2025-09-01 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'd24e408ee6dc'
+down_revision: Union[str, None] = 'e7faeab353b9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('channel', sa.Column('position', sa.Integer), schema='discord')
+    op.add_column('channel', sa.Column('parent_id', sa.BigInteger), schema='discord')
+    op.add_column('channel', sa.Column('topic', sa.Text), schema='discord')
+    op.add_column('channel', sa.Column('nsfw', sa.Boolean), schema='discord')
+    op.add_column('channel', sa.Column('last_message_id', sa.BigInteger), schema='discord')
+    op.add_column('channel', sa.Column('rate_limit_per_user', sa.Integer), schema='discord')
+    op.add_column('channel', sa.Column('bitrate', sa.Integer), schema='discord')
+    op.add_column('channel', sa.Column('user_limit', sa.Integer), schema='discord')
+
+
+def downgrade() -> None:
+    op.drop_column('channel', 'last_message_id', schema='discord')
+    op.drop_column('channel', 'nsfw', schema='discord')
+    op.drop_column('channel', 'topic', schema='discord')
+    op.drop_column('channel', 'parent_id', schema='discord')
+    op.drop_column('channel', 'position', schema='discord')
+    op.drop_column('channel', 'user_limit', schema='discord')
+    op.drop_column('channel', 'bitrate', schema='discord')
+    op.drop_column('channel', 'rate_limit_per_user', schema='discord')

--- a/gentlebot/cogs/message_archive_cog.py
+++ b/gentlebot/cogs/message_archive_cog.py
@@ -116,16 +116,39 @@ class MessageArchiveCog(commands.Cog):
         guild_id = getattr(channel.guild, "id", None)
         inserted = await self.pool.fetchval(
             """
-            INSERT INTO discord.channel (channel_id, guild_id, name, type, created_at, last_message_at)
-            VALUES ($1,$2,$3,$4,$5,$6)
+            INSERT INTO discord.channel (
+                channel_id, guild_id, name, type, position, parent_id,
+                topic, nsfw, rate_limit_per_user, last_message_id,
+                bitrate, user_limit, created_at, last_message_at
+            )
+            VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
             ON CONFLICT (channel_id)
-            DO UPDATE SET name=$3, type=$4, last_message_at=$6
+            DO UPDATE SET
+                name=$3,
+                type=$4,
+                position=$5,
+                parent_id=$6,
+                topic=$7,
+                nsfw=$8,
+                rate_limit_per_user=$9,
+                last_message_id=$10,
+                bitrate=$11,
+                user_limit=$12,
+                last_message_at=$14
             RETURNING xmax = 0
             """,
             channel.id,
             guild_id,
             getattr(channel, "name", None),
             getattr(channel, "type", None).value if hasattr(channel, "type") else None,
+            getattr(channel, "position", None),
+            getattr(channel, "category_id", None),
+            getattr(channel, "topic", None),
+            getattr(channel, "nsfw", None),
+            getattr(channel, "rate_limit_per_user", None),
+            getattr(channel, "last_message_id", None),
+            getattr(channel, "bitrate", None),
+            getattr(channel, "user_limit", None),
             getattr(channel, "created_at", None),
             discord.utils.utcnow(),
         )


### PR DESCRIPTION
## Summary
- extend the `discord.channel` schema to include voice and slowmode columns
- record `rate_limit_per_user`, `bitrate`, and `user_limit` when archiving channels

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_688052744c00832b9451c948479f36e6