### PR TITLE
Ensure channel metadata updates when archiving messages

### DIFF
--- a/gentlebot/cogs/message_archive_cog.py
+++ b/gentlebot/cogs/message_archive_cog.py
@@ -232,6 +232,13 @@ class MessageArchiveCog(commands.Cog):
                 att.proxy_url,
             )
             att_count += rows_from_tag(att_tag)
+
+        await self.pool.execute(
+            "UPDATE discord.channel SET last_message_id=$1, last_message_at=$2 WHERE channel_id=$3",
+            message.id,
+            message.created_at,
+            message.channel.id,
+        )
         return msg_count, att_count
 
     @commands.Cog.listener()


### PR DESCRIPTION
## Summary
- update message archival logic to record `last_message_id` and `last_message_at`
- test that `_insert_message` issues an update to the `channel` table

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_68805796cf2c832ba24d608f3ebba4db