### PR TITLE
Rename guild_role table to role

### DIFF
--- a/db/versions/ed53baa71962_expand_role_table.py
+++ b/db/versions/ed53baa71962_expand_role_table.py
@@ -1,0 +1,35 @@
+"""rename guild_role table to role and store full Role data"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'ed53baa71962'
+down_revision: Union[str, None] = '5db745141237'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.rename_table('guild_role', 'role', schema='discord')
+    op.add_column('role', sa.Column('permissions', sa.BigInteger), schema='discord')
+    op.add_column('role', sa.Column('position', sa.Integer), schema='discord')
+    op.add_column('role', sa.Column('hoist', sa.Boolean, server_default=sa.text('false')), schema='discord')
+    op.add_column('role', sa.Column('mentionable', sa.Boolean, server_default=sa.text('false')), schema='discord')
+    op.add_column('role', sa.Column('managed', sa.Boolean, server_default=sa.text('false')), schema='discord')
+    op.add_column('role', sa.Column('icon_hash', sa.Text), schema='discord')
+    op.add_column('role', sa.Column('unicode_emoji', sa.Text), schema='discord')
+    op.add_column('role', sa.Column('flags', sa.Integer), schema='discord')
+    op.add_column('role', sa.Column('tags', sa.JSON, server_default='{}'), schema='discord')
+
+
+def downgrade() -> None:
+    op.drop_column('role', 'tags', schema='discord')
+    op.drop_column('role', 'flags', schema='discord')
+    op.drop_column('role', 'unicode_emoji', schema='discord')
+    op.drop_column('role', 'icon_hash', schema='discord')
+    op.drop_column('role', 'managed', schema='discord')
+    op.drop_column('role', 'mentionable', schema='discord')
+    op.drop_column('role', 'hoist', schema='discord')
+    op.drop_column('role', 'position', schema='discord')
+    op.drop_column('role', 'permissions', schema='discord')
+    op.rename_table('role', 'guild_role', schema='discord')

--- a/gentlebot/cogs/role_log_cog.py
+++ b/gentlebot/cogs/role_log_cog.py
@@ -57,17 +57,39 @@ class RoleLogCog(commands.Cog):
     async def _upsert_role(self, role: discord.Role | None) -> None:
         if not self.pool or role is None:
             return
+        tag_dict = (
+            {s: getattr(role.tags, s, None) for s in role.tags.__slots__}
+            if role.tags is not None
+            else None
+        )
         await self.pool.execute(
             """
-            INSERT INTO discord.guild_role (role_id, guild_id, name, color_rgb, description)
-            VALUES ($1,$2,$3,$4,$5)
-            ON CONFLICT (role_id) DO UPDATE SET name=$3, color_rgb=$4, description=$5
+            INSERT INTO discord.role (
+                role_id, guild_id, name, color_rgb, description,
+                position, permissions, hoist, mentionable, managed,
+                icon_hash, unicode_emoji, flags, tags
+            )
+            VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
+            ON CONFLICT (role_id) DO UPDATE SET
+                name=$3, color_rgb=$4, description=$5,
+                position=$6, permissions=$7, hoist=$8,
+                mentionable=$9, managed=$10, icon_hash=$11,
+                unicode_emoji=$12, flags=$13, tags=$14
             """,
             role.id,
             role.guild.id,
             role.name,
             role.color.value if role.color else None,
             self._describe(role),
+            role.position,
+            role.permissions.value,
+            role.hoist,
+            role.mentionable,
+            role.managed,
+            getattr(role.icon, "key", None) if role.icon else None,
+            role.unicode_emoji,
+            role.flags.value,
+            tag_dict,
         )
 
     async def _record_assignment(self, guild_id: int, role_id: int, user_id: int) -> None:

--- a/tests/test_role_log_cog.py
+++ b/tests/test_role_log_cog.py
@@ -32,7 +32,32 @@ def test_role_add_logged(monkeypatch):
         cog = RoleLogCog(bot)
         await cog.cog_load()
         pool = cog.pool
-        guild = type("G", (), {"id": 1, "get_role": lambda self, rid: type("R", (), {"id": rid, "guild": self, "name": "r", "color": discord.Colour.default()})()})()
+        guild = type(
+            "G",
+            (),
+            {
+                "id": 1,
+                "get_role": lambda self, rid: type(
+                    "R",
+                    (),
+                    {
+                        "id": rid,
+                        "guild": self,
+                        "name": "r",
+                        "color": discord.Colour.default(),
+                        "tags": None,
+                        "permissions": discord.Permissions.none(),
+                        "hoist": False,
+                        "mentionable": False,
+                        "managed": False,
+                        "icon": None,
+                        "unicode_emoji": None,
+                        "flags": discord.RoleFlags(),
+                        "position": 0,
+                    },
+                )(),
+            },
+        )()
         before = type("M", (), {"id": 10, "guild": guild, "roles": []})()
         after = type("M", (), {"id": 10, "guild": guild, "roles": [guild.get_role(5)]})()
         await cog.on_member_update(before, after)


### PR DESCRIPTION
## Summary
- rename table `guild_role` to `role`
- store full `discord.Role` attributes in new columns
- update role backfill and logging to use the new schema
- adjust tests for new role fields

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68805cef2808832ba3e59d08bb1758b6