### PR TITLE
Add F1 session thread cog

### DIFF
--- a/db/versions/4a6f2b4f1d5a_update_f1_session_schema.py
+++ b/db/versions/4a6f2b4f1d5a_update_f1_session_schema.py
@@ -1,0 +1,51 @@
+"""update f1_session schema
+
+Revision ID: 4a6f2b4f1d5a
+Revises: f288b9a2c9d3
+Create Date: 2025-10-02 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '4a6f2b4f1d5a'
+down_revision: Union[str, None] = 'f288b9a2c9d3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_index('idx_f1_start_time', table_name='f1_session', schema='discord')
+    op.drop_table('f1_session', schema='discord')
+    op.create_table(
+        'f1_session',
+        sa.Column('id', sa.BigInteger, primary_key=True),
+        sa.Column('country_iso', sa.String(2), nullable=False),
+        sa.Column('year', sa.Integer, nullable=False),
+        sa.Column('gp_name', sa.Text, nullable=False),
+        sa.Column('session', sa.Text, nullable=False),
+        sa.Column('starts_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('thread_id', sa.BigInteger),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()')),
+        sa.UniqueConstraint('year', 'gp_name', 'session', name='uniq_f1_year_gp_session'),
+        schema='discord',
+    )
+    op.create_index('idx_f1_starts_at', 'f1_session', ['starts_at'], schema='discord')
+
+
+def downgrade() -> None:
+    op.drop_index('idx_f1_starts_at', table_name='f1_session', schema='discord')
+    op.drop_table('f1_session', schema='discord')
+    op.create_table(
+        'f1_session',
+        sa.Column('session_id', sa.BigInteger, primary_key=True),
+        sa.Column('round', sa.Text, nullable=False),
+        sa.Column('session', sa.Text, nullable=False),
+        sa.Column('slug', sa.Text, nullable=False),
+        sa.Column('start_time', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('thread_id', sa.BigInteger),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()')),
+        sa.UniqueConstraint('round', 'session', name='uniq_f1_round_session'),
+        schema='discord',
+    )
+    op.create_index('idx_f1_start_time', 'f1_session', ['start_time'], schema='discord')

--- a/db/versions/f288b9a2c9d3_create_f1_session_table.py
+++ b/db/versions/f288b9a2c9d3_create_f1_session_table.py
@@ -1,0 +1,35 @@
+"""create f1_session table
+
+Revision ID: f288b9a2c9d3
+Revises: ed53baa71962
+Create Date: 2025-10-01 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'f288b9a2c9d3'
+down_revision: Union[str, None] = 'ed53baa71962'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'f1_session',
+        sa.Column('session_id', sa.BigInteger, primary_key=True),
+        sa.Column('round', sa.Text, nullable=False),
+        sa.Column('session', sa.Text, nullable=False),
+        sa.Column('slug', sa.Text, nullable=False),
+        sa.Column('start_time', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('thread_id', sa.BigInteger),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()')),
+        sa.UniqueConstraint('round', 'session', name='uniq_f1_round_session'),
+        schema='discord',
+    )
+    op.create_index('idx_f1_start_time', 'f1_session', ['start_time'], schema='discord')
+
+
+def downgrade() -> None:
+    op.drop_index('idx_f1_start_time', table_name='f1_session', schema='discord')
+    op.drop_table('f1_session', schema='discord')

--- a/gentlebot/cogs/f1_thread_cog.py
+++ b/gentlebot/cogs/f1_thread_cog.py
@@ -1,0 +1,174 @@
+"""Create threads for F1 sessions stored in Postgres."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import asyncpg
+import discord
+from discord.ext import commands, tasks
+
+from ..util import build_db_url
+from .. import bot_config as cfg
+
+log = logging.getLogger(f"gentlebot.{__name__}")
+
+# Los Angeles timezone for thread titles/messages
+LA_TZ = ZoneInfo("America/Los_Angeles")
+
+
+def iso_to_flag(iso: str) -> str:
+    """Return the emoji flag for a 2-letter ISO country code."""
+    return chr(0x1F1E6 + ord(iso[0].upper()) - 65) + chr(0x1F1E6 + ord(iso[1].upper()) - 65)
+
+
+class F1ThreadCog(commands.Cog):
+    """Background task that opens and deletes F1 session threads."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.pool: asyncpg.Pool | None = None
+        self.session_task.start()
+
+    async def cog_load(self) -> None:
+        url = build_db_url()
+        if not url:
+            log.warning("PG_DSN required for F1ThreadCog")
+            return
+        url = url.replace("postgresql+asyncpg://", "postgresql://")
+
+        async def _init(conn: asyncpg.Connection) -> None:
+            await conn.execute("SET search_path=discord,public")
+
+        self.pool = await asyncpg.create_pool(url, init=_init)
+        await self._refresh_schedule()
+
+    async def cog_unload(self) -> None:
+        self.session_task.cancel()
+        if self.pool:
+            await self.pool.close()
+            self.pool = None
+
+    async def _refresh_schedule(self) -> None:
+        """Fetch sessions and insert any new ones."""
+        try:
+            sessions = self.fetch_schedule()
+        except Exception:  # pragma: no cover - network
+            log.exception("Failed to fetch F1 schedule")
+            return
+        if not self.pool:
+            return
+        for s in sessions:
+            await self.pool.execute(
+                """
+                INSERT INTO discord.f1_session (country_iso, year, gp_name, session, starts_at)
+                VALUES ($1, $2, $3, $4, $5)
+                ON CONFLICT (year, gp_name, session) DO NOTHING
+                """,
+                s["country_iso"],
+                s["year"],
+                s["gp_name"],
+                s["session"],
+                s["starts_at"],
+            )
+
+    def fetch_schedule(self) -> list[dict]:
+        from .sports_cog import SportsCog  # local import to avoid cycle
+
+        return SportsCog.fetch_f1_schedule(self)  # type: ignore[arg-type]
+
+    async def _due_sessions(self) -> list[asyncpg.Record]:
+        if not self.pool:
+            return []
+        return await self.pool.fetch(
+            """
+            SELECT id, country_iso, year, gp_name, session, starts_at
+            FROM discord.f1_session
+            WHERE session IN ('QUALI','RACE')
+              AND starts_at >= now()
+              AND starts_at <= now() + interval '2 hours'
+              AND thread_id IS NULL
+            ORDER BY starts_at
+            LIMIT 5
+            """
+        )
+
+    def _make_title(self, row: asyncpg.Record) -> str:
+        flag = iso_to_flag(row["country_iso"])
+        session_word = "Qualifying" if row["session"] == "QUALI" else "Grand Prix"
+        local = row["starts_at"].astimezone(LA_TZ).strftime("%a %H:%M %Z")
+        title = f"{flag} {row['year']} {row['gp_name']} GP | {session_word} — {local}"
+        return title[:90]
+
+    def _make_message(self, row: asyncpg.Record) -> str:
+        flag = iso_to_flag(row["country_iso"])
+        session_word = "Qualifying" if row["session"] == "QUALI" else "Grand Prix"
+        local = row["starts_at"].astimezone(LA_TZ).strftime("%a %H:%M %Z")
+        flagline = (
+            "Green light (Q1) at the time above." if row["session"] == "QUALI" else "Lights out at the time above."
+        )
+        return (
+            f"**{flag} {row['year']} {row['gp_name']} GP – {session_word}**\n\n"
+            f"⏱ **Session start:** {local}\n"
+            f"🏁 {flagline}\n\n"
+            "**Quick links**\n"
+            "• Live timing — https://f1live.com\n"
+            "• `/f1standings` — driver & constructor tables\n"
+            "• Session schedule — https://f1tv.formula1.com/schedule\n\n"
+            "> Watching on delay? Mute this thread to stay spoiler‑free."
+        )
+
+    async def _mark_started(self, session_id: int, thread_id: int) -> None:
+        if not self.pool:
+            return
+        await self.pool.execute(
+            "UPDATE discord.f1_session SET thread_id=$1 WHERE id=$2",
+            thread_id,
+            session_id,
+        )
+
+    async def _delete_after(self, thread: discord.Thread, session_id: int, delay: float = 86400) -> None:
+        await asyncio.sleep(delay)
+        try:
+            await thread.delete()
+        except Exception as exc:  # pragma: no cover - delete failure is ok
+            log.warning("Failed to delete thread %s: %s", thread.id, exc)
+        if self.pool:
+            await self.pool.execute(
+                "UPDATE discord.f1_session SET thread_id=NULL WHERE id=$1",
+                session_id,
+            )
+
+    @tasks.loop(minutes=5)
+    async def session_task(self) -> None:
+        await self.bot.wait_until_ready()
+        await self._refresh_schedule()
+        await self._open_threads()
+
+    async def _open_threads(self) -> None:
+        sessions = await self._due_sessions()
+        if not sessions:
+            return
+        channel = self.bot.get_channel(cfg.F1_DISCORD_CHANNEL_ID)
+        if not isinstance(channel, discord.TextChannel):
+            log.error("F1 channel not found")
+            return
+        for row in sessions:
+            title = self._make_title(row)
+            try:
+                thread = await channel.create_thread(name=title, auto_archive_duration=1440)
+            except Exception:
+                log.exception("Failed to create thread %s", title)
+                continue
+            try:
+                await thread.send(self._make_message(row))
+            except Exception:
+                log.exception("Failed to send opening message for %s", title)
+            await self._mark_started(row["id"], thread.id)
+            self.bot.loop.create_task(self._delete_after(thread, row["id"]))
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(F1ThreadCog(bot))

--- a/tests/test_f1_thread_cog.py
+++ b/tests/test_f1_thread_cog.py
@@ -1,0 +1,69 @@
+from types import SimpleNamespace
+import asyncio
+import discord
+from discord.ext import commands
+
+from datetime import datetime, timezone
+from gentlebot.cogs.f1_thread_cog import F1ThreadCog, iso_to_flag
+
+
+class DummyThread(SimpleNamespace):
+    async def delete(self):
+        self.deleted = True
+
+
+def test_open_threads(monkeypatch):
+    async def run_test():
+        intents = discord.Intents.none()
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        cog = F1ThreadCog(bot)
+        monkeypatch.setattr(cog, "_refresh_schedule", lambda: None)
+        monkeypatch.setattr(cog, "session_task", SimpleNamespace(start=lambda: None))
+        monkeypatch.setattr(bot, "loop", SimpleNamespace(create_task=lambda c: None))
+        
+        session = {
+            "id": 1,
+            "country_iso": "HU",
+            "year": 2025,
+            "gp_name": "Hungarian",
+            "session": "QUALI",
+            "starts_at": datetime(2025, 7, 26, 14, 0, tzinfo=timezone.utc),
+        }
+
+        async def fake_due_sessions():
+            return [session]
+
+        monkeypatch.setattr(cog, "_due_sessions", fake_due_sessions)
+
+        created = []
+
+        async def fake_create_thread(name, auto_archive_duration=None):
+            t = DummyThread(id=123, name=name, deleted=False, sent=[])
+            created.append(name)
+            return t
+
+        class DummyChannel(SimpleNamespace):
+            create_thread = staticmethod(fake_create_thread)
+
+        sent = []
+        DummyThread.send = lambda self, msg: sent.append(msg)
+        channel = DummyChannel()
+        monkeypatch.setattr(bot, "get_channel", lambda cid: channel)
+        monkeypatch.setattr(discord, "TextChannel", DummyChannel)
+        marked = []
+
+        async def fake_mark(session_id, thread_id):
+            marked.append((session_id, thread_id))
+
+        monkeypatch.setattr(cog, "_mark_started", fake_mark)
+        monkeypatch.setattr(cog, "_delete_after", lambda *a, **k: None)
+        monkeypatch.setattr(bot.loop, "create_task", lambda coro: None)
+
+        await cog._open_threads()
+        flag = iso_to_flag("HU")
+        expected_title = f"{flag} 2025 Hungarian GP | Qualifying — Sat 07:00 PDT"
+        assert created == [expected_title]
+        assert marked == [(1, 123)]
+        assert sent[0].startswith(f"**{flag} 2025 Hungarian GP – Qualifying**")
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- redesign `f1_session` table to store ISO code, year, GP name and start time
- update `F1ThreadCog` to open race threads two hours before the session and delete them after a day
- add tests for thread title and message formatting

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_6886a6255734832b8db7f87004cc4ef3