### PR TITLE
Post daily prompt in thread

### DIFF
--- a/tests/test_prompt_thread.py
+++ b/tests/test_prompt_thread.py
@@ -1,0 +1,56 @@
+import asyncio
+from types import SimpleNamespace
+import discord
+from discord.ext import commands
+
+from gentlebot.cogs import prompt_cog
+
+
+def test_send_prompt_creates_thread(monkeypatch):
+    async def run_test():
+        intents = discord.Intents.none()
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        cog = prompt_cog.PromptCog(bot)
+
+        monkeypatch.setattr(cog, "fetch_prompt", lambda: "What is your favorite color?")
+
+        class DummyDateTime:
+            @classmethod
+            def now(cls, tz=None):
+                from datetime import datetime as real_datetime
+                return real_datetime(2025, 7, 21, tzinfo=tz)
+
+        monkeypatch.setattr(prompt_cog, "datetime", DummyDateTime)
+
+        added = []
+
+        class DummyThread(SimpleNamespace):
+            async def send(self, msg):
+                self.sent = msg
+            async def add_user(self, member):
+                added.append(member)
+
+        created = []
+
+        async def fake_create_thread(name, auto_archive_duration=None):
+            created.append(name)
+            return DummyThread()
+
+        guild = SimpleNamespace(
+            members=[
+                SimpleNamespace(id=1, bot=False),
+                SimpleNamespace(id=2, bot=False),
+            ]
+        )
+        channel = SimpleNamespace(create_thread=fake_create_thread, guild=guild)
+
+        monkeypatch.setattr(bot, "get_channel", lambda cid: channel)
+        monkeypatch.setattr(prompt_cog.cfg, "DAILY_PING_CHANNEL", 1)
+
+        await cog._send_prompt()
+
+        assert created == ["QOTD Jul 21"]
+        assert added == guild.members
+
+    asyncio.run(run_test())
+


### PR DESCRIPTION
## Summary
- convert the daily-ping prompt into a thread
- add all members to the prompt thread
- name the thread `QOTD %b %d`
- test the thread name

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_6886f14151a0832bafd5b6b1f239f991