### PR TITLE
Fix alembic head error

### DIFF
--- a/db/versions/a19f6ae0c2d3_merge_heads.py
+++ b/db/versions/a19f6ae0c2d3_merge_heads.py
@@ -1,0 +1,25 @@
+"""merge heads
+
+Revision ID: a19f6ae0c2d3
+Revises: f288b9a2c9d3, f72b0b402bbc
+Create Date: 2025-10-02 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'a19f6ae0c2d3'
+down_revision: Union[str, None] = ('f288b9a2c9d3', 'f72b0b402bbc')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- merge diverging migrations so `alembic upgrade head` works again

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_6887d962e9fc832ba4df6656629a8965