### PR TITLE
Fix alembic multiple heads

### DIFF
--- a/db/versions/4c66285ed784_merge_heads.py
+++ b/db/versions/4c66285ed784_merge_heads.py
@@ -1,0 +1,26 @@
+"""merge heads
+
+Revision ID: 4c66285ed784
+Revises: a19f6ae0c2d3, 4a6f2b4f1d5a
+Create Date: 2025-07-28 20:49:15.413151
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '4c66285ed784'
+down_revision: Union[str, None] = ('a19f6ae0c2d3', '4a6f2b4f1d5a')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- merge alembic heads to solve migration conflicts

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_6887e1a22d98832b8f57739275944962