### PR TITLE
Fix tiered role limits

### DIFF
--- a/gentlebot/tasks/daily_digest.py
+++ b/gentlebot/tasks/daily_digest.py
@@ -25,9 +25,9 @@ def assign_tiers(rankings: list[int], roles: dict[str, int]) -> dict[int, int]:
 
     result: dict[int, int] = {}
     tiers = (
-        ("gold", 0, 3),   # top 3
-        ("silver", 3, 8), # ranks 4–8
-        ("bronze", 8, 15), # ranks 9–15
+        ("gold", 0, 1),    # top 1
+        ("silver", 1, 2),  # next 1
+        ("bronze", 2, 4),  # next 2
     )
     for name, start, end in tiers:
         role_id = roles.get(name, 0)

--- a/tests/test_roles_cog.py
+++ b/tests/test_roles_cog.py
@@ -218,11 +218,11 @@ def test_tiered_role_refresh(monkeypatch):
 
         await cog.badge_task()
 
-        assert calls[10] == [1, 2, 3]
-        assert calls[20] == [4, 5, 6, 7, 8]
-        assert calls[30] == [9]
-        assert calls[40] == [1, 2, 3]
-        assert calls[50] == [4, 5, 6, 7, 8]
-        assert 60 not in calls
+        assert calls[10] == [1]
+        assert calls[20] == [2]
+        assert calls[30] == [3, 4]
+        assert calls[40] == [1]
+        assert calls[50] == [2]
+        assert calls[60] == [3, 4]
 
     asyncio.run(run_test())

--- a/tests/test_tier_assignment.py
+++ b/tests/test_tier_assignment.py
@@ -5,15 +5,12 @@ def test_assign_tiers():
     rankings = list(range(1, 20))
     roles = {'gold': 100, 'silver': 200, 'bronze': 300}
     mapping = assign_tiers(rankings, roles)
-    # gold for top three users
+    # gold for top user
     assert mapping[1] == 100
-    assert mapping[2] == 100
-    assert mapping[3] == 100
-    # silver for ranks 4-8
-    for uid in range(4, 9):
-        assert mapping[uid] == 200
-    # bronze for ranks 9-15
-    for uid in range(9, 16):
-        assert mapping[uid] == 300
-    # no roles beyond rank 15
-    assert 16 not in mapping
+    # silver for second user
+    assert mapping[2] == 200
+    # bronze for third and fourth
+    assert mapping[3] == 300
+    assert mapping[4] == 300
+    # no roles beyond fourth user
+    assert 5 not in mapping


### PR DESCRIPTION
## Summary
- update `assign_tiers` helper to give 1 🥇, 1 🥈, and 2 🥉 roles
- adjust tests for new tier counts

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_688834165f14832bafd30091d4fbb92f