### PR TITLE
Fix duplicate reaction events

### DIFF
--- a/db/versions/0621c7d3e3d7_add_unique_reaction_event_constraint.py
+++ b/db/versions/0621c7d3e3d7_add_unique_reaction_event_constraint.py
@@ -1,0 +1,42 @@
+"""add unique constraint to reaction_event"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '0621c7d3e3d7'
+down_revision: Union[str, None] = 'f72b0b402bbc'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DELETE FROM discord.reaction_event
+        WHERE event_id IN (
+            SELECT event_id FROM (
+                SELECT event_id,
+                    row_number() OVER (
+                        PARTITION BY message_id, user_id, emoji, action, event_at
+                        ORDER BY event_id
+                    ) AS rn
+                FROM discord.reaction_event
+            ) dup
+            WHERE dup.rn > 1
+        )
+        """
+    )
+    op.create_unique_constraint(
+        'uniq_reaction_event_msg_user_emoji_act_ts',
+        'reaction_event',
+        ['message_id', 'user_id', 'emoji', 'action', 'event_at'],
+        schema='discord',
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        'uniq_reaction_event_msg_user_emoji_act_ts',
+        'reaction_event',
+        schema='discord',
+    )

--- a/gentlebot/backfill_reactions.py
+++ b/gentlebot/backfill_reactions.py
@@ -73,6 +73,7 @@ class BackfillBot(commands.Bot):
                                     INSERT INTO discord.reaction_event (
                                         message_id, user_id, emoji, action, event_at
                                     ) VALUES ($1,$2,$3,$4,$5)
+                                    ON CONFLICT ON CONSTRAINT uniq_reaction_event_msg_user_emoji_act_ts DO NOTHING
                                     """,
                                     msg.id,
                                     user.id,

--- a/gentlebot/cogs/message_archive_cog.py
+++ b/gentlebot/cogs/message_archive_cog.py
@@ -283,6 +283,7 @@ class MessageArchiveCog(commands.Cog):
             """
             INSERT INTO discord.reaction_event (message_id, user_id, emoji, action, event_at)
             VALUES ($1,$2,$3,$4,$5)
+            ON CONFLICT ON CONSTRAINT uniq_reaction_event_msg_user_emoji_act_ts DO NOTHING
             """,
             payload.message_id,
             payload.user_id,

--- a/tests/test_message_archive_cog.py
+++ b/tests/test_message_archive_cog.py
@@ -93,6 +93,26 @@ def test_on_message(monkeypatch):
     asyncio.run(run_test())
 
 
+def test_log_reaction_on_conflict(monkeypatch):
+    async def run_test():
+        pool = DummyPool()
+        intents = discord.Intents.default()
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        cog = MessageArchiveCog(bot)
+        cog.pool = pool
+
+        class Dummy:
+            def __init__(self, **kw):
+                self.__dict__.update(kw)
+
+        payload = Dummy(message_id=1, user_id=2, emoji="😀")
+        await cog._log_reaction(payload, 0)
+        await cog._log_reaction(payload, 0)
+        assert any("ON CONFLICT ON CONSTRAINT uniq_reaction_event_msg_user_emoji_act_ts" in q for q in pool.executed)
+
+    asyncio.run(run_test())
+
+
 def test_insert_message_updates_channel(monkeypatch):
     async def run_test():
         pool = DummyPool()


### PR DESCRIPTION
## Summary
- prevent duplicate reaction logs with a unique database constraint
- ignore conflicts when inserting reaction events
- test the new constraint logic

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_688840dade68832bb4557e2fa141b989