### PR TITLE
Use explicit reaction_action enum

### DIFF
--- a/db/versions/44efb18fc3d4_merge_heads.py
+++ b/db/versions/44efb18fc3d4_merge_heads.py
@@ -1,0 +1,26 @@
+"""merge heads
+
+Revision ID: 44efb18fc3d4
+Revises: 0621c7d3e3d7, 4c66285ed784, d30dcdd2cd68
+Create Date: 2025-08-31 00:00:01.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '44efb18fc3d4'
+down_revision: Union[str, None] = (
+    '0621c7d3e3d7',
+    '4c66285ed784',
+    'd30dcdd2cd68',
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/db/versions/d30dcdd2cd68_reaction_action_enum.py
+++ b/db/versions/d30dcdd2cd68_reaction_action_enum.py
@@ -1,0 +1,55 @@
+"""rename action column to reaction_action enum
+
+Revision ID: d30dcdd2cd68
+Revises: f72b0b402bbc
+Create Date: 2025-08-31 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'd30dcdd2cd68'
+down_revision: Union[str, None] = 'f72b0b402bbc'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE TYPE reaction_action AS ENUM ('MESSAGE_REACTION_ADD', 'MESSAGE_REACTION_REMOVE')")
+    op.add_column(
+        'reaction_event',
+        sa.Column('reaction_action', sa.Enum('MESSAGE_REACTION_ADD', 'MESSAGE_REACTION_REMOVE', name='reaction_action'), nullable=True),
+        schema='discord',
+    )
+    op.execute(
+        "UPDATE discord.reaction_event SET reaction_action = CASE "
+        "WHEN action = 0 THEN 'MESSAGE_REACTION_ADD' "
+        "ELSE 'MESSAGE_REACTION_REMOVE' END"
+    )
+    op.alter_column('reaction_event', 'reaction_action', nullable=False, schema='discord')
+    op.drop_constraint('uniq_reaction_event_msg_user_emoji_act_ts', 'reaction_event', schema='discord')
+    op.create_unique_constraint(
+        'uniq_reaction_event_msg_user_emoji_act_ts',
+        'reaction_event',
+        ['message_id', 'user_id', 'emoji', 'reaction_action', 'event_at'],
+        schema='discord',
+    )
+    op.drop_column('reaction_event', 'action', schema='discord')
+
+
+def downgrade() -> None:
+    op.add_column('reaction_event', sa.Column('action', sa.SmallInteger, nullable=False), schema='discord')
+    op.execute(
+        "UPDATE discord.reaction_event SET action = CASE "
+        "WHEN reaction_action = 'MESSAGE_REACTION_ADD' THEN 0 "
+        "ELSE 1 END"
+    )
+    op.drop_constraint('uniq_reaction_event_msg_user_emoji_act_ts', 'reaction_event', schema='discord')
+    op.create_unique_constraint(
+        'uniq_reaction_event_msg_user_emoji_act_ts',
+        'reaction_event',
+        ['message_id', 'user_id', 'emoji', 'action', 'event_at'],
+        schema='discord',
+    )
+    op.drop_column('reaction_event', 'reaction_action', schema='discord')
+    op.execute('DROP TYPE reaction_action')

--- a/gentlebot/backfill_reactions.py
+++ b/gentlebot/backfill_reactions.py
@@ -12,7 +12,7 @@ import discord
 from discord.ext import commands
 
 from gentlebot import bot_config as cfg
-from gentlebot.util import build_db_url, chan_name, rows_from_tag
+from gentlebot.util import build_db_url, chan_name, rows_from_tag, ReactionAction
 
 log = logging.getLogger("gentlebot.backfill_reactions")
 
@@ -71,14 +71,14 @@ class BackfillBot(commands.Bot):
                                 tag = await self.pool.execute(
                                     """
                                     INSERT INTO discord.reaction_event (
-                                        message_id, user_id, emoji, action, event_at
+                                        message_id, user_id, emoji, reaction_action, event_at
                                     ) VALUES ($1,$2,$3,$4,$5)
                                     ON CONFLICT ON CONSTRAINT uniq_reaction_event_msg_user_emoji_act_ts DO NOTHING
                                     """,
                                     msg.id,
                                     user.id,
                                     str(reaction.emoji),
-                                    0,
+                                    ReactionAction.MESSAGE_REACTION_ADD.name,
                                     msg.created_at,
                                 )
                                 self.inserted += rows_from_tag(tag)

--- a/gentlebot/tasks/daily_digest.py
+++ b/gentlebot/tasks/daily_digest.py
@@ -12,7 +12,7 @@ import discord
 from discord.ext import commands
 
 from .. import bot_config as cfg
-from ..util import build_db_url
+from ..util import build_db_url, ReactionAction
 
 log = logging.getLogger(f"gentlebot.{__name__}")
 
@@ -98,7 +98,7 @@ class DailyDigestCog(commands.Cog):
                    MAX(r.event_at) AS last_ts
             FROM discord.reaction_event r
             JOIN discord.message m ON m.message_id = r.message_id
-            WHERE r.action = 1 AND r.event_at >= now() - $1::interval
+            WHERE r.reaction_action = 'MESSAGE_REACTION_ADD' AND r.event_at >= now() - $1::interval
             GROUP BY m.author_id
             HAVING COUNT(*) >= $2
             ORDER BY c DESC, last_ts ASC

--- a/gentlebot/util.py
+++ b/gentlebot/util.py
@@ -1,6 +1,14 @@
 import os
 import logging
+from enum import IntEnum
 import discord
+
+
+class ReactionAction(IntEnum):
+    """Values matching Discord's reaction gateway events."""
+
+    MESSAGE_REACTION_ADD = 0
+    MESSAGE_REACTION_REMOVE = 1
 
 def build_db_url() -> str | None:
     """Return a Postgres DSN built from env vars."""

--- a/tests/test_message_archive_cog.py
+++ b/tests/test_message_archive_cog.py
@@ -6,7 +6,7 @@ from discord.ext import commands
 import asyncpg
 
 from gentlebot.cogs.message_archive_cog import MessageArchiveCog
-from gentlebot.util import build_db_url
+from gentlebot.util import build_db_url, ReactionAction
 
 
 class DummyPool:
@@ -106,8 +106,8 @@ def test_log_reaction_on_conflict(monkeypatch):
                 self.__dict__.update(kw)
 
         payload = Dummy(message_id=1, user_id=2, emoji="😀")
-        await cog._log_reaction(payload, 0)
-        await cog._log_reaction(payload, 0)
+        await cog._log_reaction(payload, ReactionAction.MESSAGE_REACTION_ADD)
+        await cog._log_reaction(payload, ReactionAction.MESSAGE_REACTION_ADD)
         assert any("ON CONFLICT ON CONSTRAINT uniq_reaction_event_msg_user_emoji_act_ts" in q for q in pool.executed)
 
     asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- introduce `ReactionAction` IntEnum
- log reactions with enum names instead of numeric codes
- track reactions in `reaction_action` enum column
- migrate existing records
- merge alembic heads so a single head revision remains

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_688841dbf564832bbbe7aabe9f9d8dff