### PR TITLE
Fix reaction_action enum migration

### DIFF
--- a/db/versions/d30dcdd2cd68_reaction_action_enum.py
+++ b/db/versions/d30dcdd2cd68_reaction_action_enum.py
@@ -23,8 +23,8 @@ def upgrade() -> None:
     )
     op.execute(
         "UPDATE discord.reaction_event SET reaction_action = CASE "
-        "WHEN action = 0 THEN 'MESSAGE_REACTION_ADD' "
-        "ELSE 'MESSAGE_REACTION_REMOVE' END"
+        "WHEN action = 0 THEN 'MESSAGE_REACTION_ADD'::reaction_action "
+        "ELSE 'MESSAGE_REACTION_REMOVE'::reaction_action END"
     )
     op.alter_column('reaction_event', 'reaction_action', nullable=False, schema='discord')
     op.drop_constraint('uniq_reaction_event_msg_user_emoji_act_ts', 'reaction_event', schema='discord')


### PR DESCRIPTION
## Summary
- fix `reaction_action` enum migration by casting update strings

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68884d431650832ba8e138cfe653911d