### PR TITLE
Fix QOTD thread visibility

### DIFF
--- a/gentlebot/cogs/prompt_cog.py
+++ b/gentlebot/cogs/prompt_cog.py
@@ -27,6 +27,7 @@ import json
 from pathlib import Path
 from datetime import datetime, timedelta
 from collections import deque
+import discord
 from discord.ext import commands
 from ..util import chan_name, int_env
 from huggingface_hub import InferenceClient
@@ -286,7 +287,11 @@ class PromptCog(commands.Cog):
         prompt = self.fetch_prompt()
         try:
             name = datetime.now(LOCAL_TZ).strftime("QOTD %b %d")
-            thread = await channel.create_thread(name=name, auto_archive_duration=1440)
+            thread = await channel.create_thread(
+                name=name,
+                auto_archive_duration=1440,
+                type=discord.ChannelType.public_thread,
+            )
         except Exception as exc:
             log.error("Failed to create prompt thread: %s", exc)
             return

--- a/tests/test_prompt_thread.py
+++ b/tests/test_prompt_thread.py
@@ -32,8 +32,8 @@ def test_send_prompt_creates_thread(monkeypatch):
 
         created = []
 
-        async def fake_create_thread(name, auto_archive_duration=None):
-            created.append(name)
+        async def fake_create_thread(name, auto_archive_duration=None, type=None):
+            created.append((name, type))
             return DummyThread()
 
         guild = SimpleNamespace(
@@ -49,7 +49,7 @@ def test_send_prompt_creates_thread(monkeypatch):
 
         await cog._send_prompt()
 
-        assert created == ["QOTD Jul 21"]
+        assert created == [("QOTD Jul 21", discord.ChannelType.public_thread)]
         assert added == guild.members
 
     asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- make QOTD threads public
- check thread type in prompt thread test

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_6889a0dbef68832bba44bbd489a69d6c