### PR TITLE
Fix QOTD thread visibility

### DIFF
--- a/tests/test_prompt_thread.py
+++ b/tests/test_prompt_thread.py
@@ -32,8 +32,8 @@ def test_send_prompt_creates_thread(monkeypatch):
 
         created = []
 
-        async def fake_create_thread(name, auto_archive_duration=None):
-            created.append(name)
+        async def fake_create_thread(name, auto_archive_duration=None, type=None):
+            created.append((name, type))
             return DummyThread()
 
         guild = SimpleNamespace(
@@ -49,7 +49,7 @@ def test_send_prompt_creates_thread(monkeypatch):
 
         await cog._send_prompt()
 
-        assert created == ["QOTD Jul 21"]
+        assert created == [("QOTD Jul 21", discord.ChannelType.public_thread)]
         assert added == guild.members
 
     asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- make QOTD threads public
- add all members to the thread with `asyncio.gather`
- check thread type in prompt thread test

## Testing
- `pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_6889a0dbef68832bba44bbd489a69d6c