### PR TITLE
Restrict bot activity in role rotation

### DIFF
--- a/tests/test_roles_cog.py
+++ b/tests/test_roles_cog.py
@@ -65,6 +65,34 @@ def test_lurker_skip_if_many_messages(monkeypatch):
     asyncio.run(run_test())
 
 
+def test_assign_skips_bot_member(monkeypatch):
+    async def run_test():
+        monkeypatch.setattr(roles_cog.RoleCog.badge_task, "start", lambda self: None)
+        intents = discord.Intents.none()
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        cog = roles_cog.RoleCog(bot)
+
+        role_id = 42
+        role = SimpleNamespace(id=role_id, name="test")
+
+        guild = SimpleNamespace(id=1)
+        guild.get_role = lambda rid: role if rid == role_id else None
+
+        member = SimpleNamespace(id=99, guild=guild, roles=[], bot=True)
+        added: list[int] = []
+
+        async def fake_add_roles(r, reason=None):
+            added.append(r.id)
+
+        member.add_roles = fake_add_roles
+
+        await cog._assign(member, role_id)
+
+        assert added == []
+
+    asyncio.run(run_test())
+
+
 def test_npc_assigned_if_no_other_flag(monkeypatch):
     async def run_test():
         monkeypatch.setattr(roles_cog.RoleCog.badge_task, "start", lambda self: None)
@@ -134,7 +162,7 @@ def test_npc_removed_when_assigning_other_role(monkeypatch):
         guild = SimpleNamespace(id=1)
         guild.get_role = lambda rid: npc_role if rid == npc_id else other_role if rid == other_id else None
 
-        member = SimpleNamespace(id=1, guild=guild, roles=[npc_role])
+        member = SimpleNamespace(id=1, guild=guild, roles=[npc_role], bot=False)
 
         removed = []
         added = []
@@ -224,5 +252,68 @@ def test_tiered_role_refresh(monkeypatch):
         assert calls[40] == [1]
         assert calls[50] == [2]
         assert calls[60] == [3, 4]
+
+    asyncio.run(run_test())
+
+
+def test_badge_task_ignores_bot_messages(monkeypatch):
+    async def run_test():
+        monkeypatch.setattr(roles_cog.RoleCog.badge_task, "start", lambda self: None)
+        intents = discord.Intents.none()
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        cog = roles_cog.RoleCog(bot)
+
+        human = SimpleNamespace(id=1, bot=False, roles=[], guild=None)
+        bot_member = SimpleNamespace(id=2, bot=True, roles=[], guild=None)
+
+        guild = SimpleNamespace(id=1)
+        guild.members = [human, bot_member]
+        guild.get_role = lambda rid: SimpleNamespace(id=rid, name=str(rid))
+        monkeypatch.setattr(bot, "get_guild", lambda gid: guild)
+        monkeypatch.setattr(bot, "wait_until_ready", lambda: asyncio.sleep(0))
+
+        winner: int | None = None
+
+        async def fake_single(g, rid, uid):
+            nonlocal winner
+            if rid == roles_cog.ROLE_TOP_POSTER and uid is not None:
+                winner = uid
+
+        async def fake_sync(*args, **kwargs):
+            return None
+
+        monkeypatch.setattr(cog, "_rotate_single", fake_single)
+        monkeypatch.setattr(cog, "_sync_role", fake_sync)
+        monkeypatch.setattr(
+            cfg,
+            "TIERED_BADGES",
+            {
+                "top_poster": {"threshold": 100, "roles": {}},
+                "reaction_magnet": {"threshold": 100, "roles": {}},
+            },
+            raising=False,
+        )
+        async def fake_assign_flag(*a, **k):
+            return None
+
+        monkeypatch.setattr(cog, "_assign_flag", fake_assign_flag)
+
+        human.guild = guild
+        bot_member.guild = guild
+
+        now = discord.utils.utcnow()
+        # many bot messages, few human messages
+        cog.messages = [
+            {"author": bot_member.id, "ts": now, "id": i, "len": 1, "words": 1, "rich": False, "mentions": 0, "mention_ids": [], "reply_to": None}
+            for i in range(10)
+        ] + [
+            {"author": human.id, "ts": now, "id": 100 + i, "len": 1, "words": 1, "rich": False, "mentions": 0, "mention_ids": [], "reply_to": None}
+            for i in range(2)
+        ]
+        cog.reactions = []
+        cog.last_online = {human.id: now, bot_member.id: now}
+
+        await cog.badge_task()
+        assert winner == human.id
 
     asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- filter out bot messages and reactions before computing badges
- test that badge_task ignores bot messages when determining Top Poster

## Testing
- `python -m pytest -q`
- `python test_harness.py` (errors from background tasks are expected during offline loading)


------
https://chatgpt.com/codex/tasks/task_e_688a600f034c832b9fe0ddca7f289435