### PR TITLE
Filter bots from daily hero badge

### DIFF
--- a/tests/test_daily_digest_bot_filter.py
+++ b/tests/test_daily_digest_bot_filter.py
@@ -1,0 +1,35 @@
+import asyncio
+from types import SimpleNamespace
+import discord
+from discord.ext import commands
+from gentlebot.tasks import daily_digest
+
+
+def test_sync_role_skips_bot_member(monkeypatch):
+    async def run_test():
+        bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+        cog = daily_digest.DailyDigestCog(bot)
+        guild = SimpleNamespace(id=1)
+        role = SimpleNamespace(id=42, name="hero", members=[])
+        guild.get_role = lambda rid: role if rid == 42 else None
+
+        human = SimpleNamespace(id=1, bot=False, roles=[], guild=guild)
+        bot_member = SimpleNamespace(id=2, bot=True, roles=[], guild=guild)
+        guild.get_member = lambda uid: {1: human, 2: bot_member}.get(uid)
+
+        added = []
+
+        async def add_roles(self, r, reason=None):
+            added.append(self.id)
+        async def remove_roles(self, r, reason=None):
+            pass
+
+        human.add_roles = add_roles.__get__(human, SimpleNamespace)
+        bot_member.add_roles = add_roles.__get__(bot_member, SimpleNamespace)
+        human.remove_roles = remove_roles.__get__(human, SimpleNamespace)
+        bot_member.remove_roles = remove_roles.__get__(bot_member, SimpleNamespace)
+
+        await cog._sync_role(guild, 42, [1, 2])
+        assert added == [1]
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- avoid awarding engagement roles to bots in daily digest scheduler
- skip bots when syncing role assignments
- regression test for bot exclusion

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_688a8965cca8832b9047560d8f06172a