### PR TITLE
Stop adding members to public QOTD thread

### DIFF
--- a/gentlebot/cogs/prompt_cog.py
+++ b/gentlebot/cogs/prompt_cog.py
@@ -286,7 +286,9 @@ class PromptCog(commands.Cog):
             return
         prompt = self.fetch_prompt()
         try:
-            name = datetime.now(LOCAL_TZ).strftime("QOTD %b %d")
+            name = datetime.now(LOCAL_TZ).strftime(
+                "Ping for Your Thoughts (%b %d)"
+            )
             thread = await channel.create_thread(
                 name=name,
                 auto_archive_duration=1440,
@@ -296,14 +298,7 @@ class PromptCog(commands.Cog):
             log.error("Failed to create prompt thread: %s", exc)
             return
         await thread.send(f"{prompt}")
-        guild = getattr(channel, "guild", None)
-        if guild:
-            members = [m for m in guild.members if not m.bot]
-            tasks = [thread.add_user(m) for m in members]
-            results = await asyncio.gather(*tasks, return_exceptions=True)
-            for member, result in zip(members, results):
-                if isinstance(result, Exception):  # pragma: no cover - join failure is ok
-                    log.warning("Failed to add %s to prompt thread: %s", member.id, result)
+        # The thread is public, so we no longer add members individually.
 
     async def _scheduler(self):
         await self.bot.wait_until_ready()

--- a/tests/test_prompt_thread.py
+++ b/tests/test_prompt_thread.py
@@ -49,8 +49,11 @@ def test_send_prompt_creates_thread(monkeypatch):
 
         await cog._send_prompt()
 
-        assert created == [("QOTD Jul 21", discord.ChannelType.public_thread)]
-        assert added == guild.members
+        assert created == [(
+            "Ping for Your Thoughts (Jul 21)",
+            discord.ChannelType.public_thread,
+        )]
+        assert added == []
 
     asyncio.run(run_test())
 


### PR DESCRIPTION
## Summary
- simplify prompt thread creation
- update prompt thread test
- rename threads to 'Ping for Your Thoughts (Jul 30)'

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_688a893633e8832b97a371b80862a6b2