### PR TITLE
Check for bets before posting results

### DIFF
--- a/gentlebot/cogs/market_cog.py
+++ b/gentlebot/cogs/market_cog.py
@@ -294,6 +294,15 @@ class MarketCog(commands.Cog):
         conn.close()
         return winners, leaderboard
 
+    def _bets_exist(self, week: str) -> bool:
+        """Return True if any bets exist for the given week."""
+        conn = self._connect()
+        cur = conn.cursor()
+        cur.execute(f"SELECT 1 FROM {SCHEMA}.bets WHERE week=? LIMIT 1", (week,))
+        row = cur.fetchone()
+        conn.close()
+        return row is not None
+
     # ─── Fetch Helpers ───────────────────────────────────────────────────
     async def _quote_pct(self, symbol: str) -> Optional[float]:
         try:
@@ -487,6 +496,8 @@ class MarketCog(commands.Cog):
         if now.weekday() != 4:
             return
         week = _week_start(now).date().isoformat()
+        if not self._bets_exist(week):
+            return
         monday_open, friday_close = await self._week_open_close()
         if monday_open is None or friday_close is None:
             return

--- a/tests/test_market_cog.py
+++ b/tests/test_market_cog.py
@@ -1,0 +1,21 @@
+import asyncio
+import discord
+from discord.ext import commands
+from gentlebot.cogs import market_cog
+
+
+def test_bets_exist(monkeypatch, tmp_path):
+    async def run_test():
+        db = tmp_path / "marketbet.db"
+        monkeypatch.setattr(market_cog, "DB_PATH", str(db))
+        intents = discord.Intents.none()
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        cog = market_cog.MarketCog(bot)
+        cog.summary_task.cancel()
+        cog.reminder_task.cancel()
+        week = "2023-01-02"
+        assert not cog._bets_exist(week)
+        assert cog._place_bet(1, week, "bullish", 50)
+        assert cog._bets_exist(week)
+        await cog.bot.close()
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- prevent MarketCog from posting weekly results when no bets exist
- add a helper `_bets_exist`
- test bet storage for MarketCog

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_688aa29f0a58832b9f18585f5b41aefb