### PR TITLE
Add auto bigdumper update

### DIFF
--- a/gentlebot/cogs/bigdumper_watcher_cog.py
+++ b/gentlebot/cogs/bigdumper_watcher_cog.py
@@ -1,0 +1,75 @@
+"""Automatically post Big Dumper updates when Cal Raleigh homers."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime
+
+import requests
+import discord
+from discord.ext import commands, tasks
+
+from .sports_cog import PLAYER_ID
+from .sports_cog import SportsCog
+from .. import bot_config as cfg
+
+log = logging.getLogger(f"gentlebot.{__name__}")
+
+
+class BigDumperWatcherCog(commands.Cog):
+    """Background task posting `/bigdumper` after new home runs."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self.session = requests.Session()
+        self.last_hr = 0
+        self.check_task.start()
+
+    async def cog_load(self) -> None:
+        try:
+            self.last_hr = await asyncio.to_thread(self._fetch_hr)
+        except Exception as exc:  # pragma: no cover - network
+            log.warning("Failed to fetch initial HR count: %s", exc)
+
+    async def cog_unload(self) -> None:
+        self.check_task.cancel()
+
+    def _fetch_hr(self) -> int:
+        year = datetime.now().year
+        url = f"https://statsapi.mlb.com/api/v1/people/{PLAYER_ID}/stats"
+        params = {"stats": "season", "group": "hitting", "season": year}
+        resp = self.session.get(url, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        return int(data["stats"][0]["splits"][0]["stat"].get("homeRuns", 0))
+
+    @tasks.loop(minutes=10)
+    async def check_task(self) -> None:
+        await self.bot.wait_until_ready()
+        try:
+            hr = await asyncio.to_thread(self._fetch_hr)
+        except Exception as exc:  # pragma: no cover - network
+            log.exception("Failed to fetch HR count: %s", exc)
+            return
+        if hr <= self.last_hr:
+            return
+        self.last_hr = hr
+        sports_cog = self.bot.get_cog("SportsCog")
+        if not isinstance(sports_cog, SportsCog):
+            log.error("SportsCog not loaded; cannot send update")
+            return
+        embed = await sports_cog.build_bigdumper_embed()
+        if embed is None:
+            return
+        channel = self.bot.get_channel(getattr(cfg, "LOBBY_CHANNEL_ID", 0))
+        if not isinstance(channel, discord.TextChannel):
+            log.error("Big Dumper channel not found: %s", getattr(cfg, "LOBBY_CHANNEL_ID", 0))
+            return
+        try:
+            await channel.send(embed=embed)
+        except Exception as exc:  # pragma: no cover - network
+            log.exception("Failed to send Big Dumper update: %s", exc)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(BigDumperWatcherCog(bot))

--- a/tests/test_bigdumper_watcher.py
+++ b/tests/test_bigdumper_watcher.py
@@ -1,0 +1,41 @@
+import asyncio
+from types import SimpleNamespace
+
+import discord
+from discord.ext import commands
+
+from gentlebot.cogs import bigdumper_watcher_cog
+
+
+def test_post_on_new_hr(monkeypatch):
+    async def run_test():
+        intents = discord.Intents.none()
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        cog = bigdumper_watcher_cog.BigDumperWatcherCog(bot)
+        cog.last_hr = 1
+
+        # Patch fetch to return higher HR
+        monkeypatch.setattr(cog, "_fetch_hr", lambda: 2)
+
+        dummy_embed = discord.Embed(title="Big")
+        async def fake_embed():
+            return dummy_embed
+        sports = SimpleNamespace(build_bigdumper_embed=fake_embed)
+        monkeypatch.setattr(bigdumper_watcher_cog, "SportsCog", SimpleNamespace)
+        monkeypatch.setattr(bot, "get_cog", lambda name: sports if name == "SportsCog" else None)
+
+        sent = []
+        class DummyChannel(SimpleNamespace):
+            async def send(self, *, embed=None):
+                sent.append(embed)
+        channel = DummyChannel()
+        monkeypatch.setattr(bot, "get_channel", lambda cid: channel)
+        monkeypatch.setattr(discord, "TextChannel", DummyChannel)
+        async def dummy_wait():
+            return None
+        monkeypatch.setattr(bot, "wait_until_ready", dummy_wait)
+
+        await bigdumper_watcher_cog.BigDumperWatcherCog.check_task.coro(cog)
+        assert sent and sent[0] is dummy_embed
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- allow SportsCog to build a bigdumper embed independently
- add BigdumperWatcherCog that posts an update after every new Cal Raleigh homer
- test the watcher cog
- refine embed layout and rename class to BigDumperWatcherCog

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_688aa4caa070832bb8de9641637530ee