### PR TITLE
Include prompt text in daily ping thread name

### DIFF
--- a/gentlebot/cogs/prompt_cog.py
+++ b/gentlebot/cogs/prompt_cog.py
@@ -286,9 +286,11 @@ class PromptCog(commands.Cog):
             return
         prompt = self.fetch_prompt()
         try:
-            name = datetime.now(LOCAL_TZ).strftime(
-                "Ping for Your Thoughts (%b %d)"
-            )
+            date = datetime.now(LOCAL_TZ).strftime("%b %d")
+            prompt_single = prompt.replace("\n", " ").strip()
+            name = f"({date}) {prompt_single}"
+            if len(name) > 100:
+                name = name[:97] + "..."
             thread = await channel.create_thread(
                 name=name,
                 auto_archive_duration=1440,

--- a/tests/test_prompt_thread.py
+++ b/tests/test_prompt_thread.py
@@ -50,10 +50,52 @@ def test_send_prompt_creates_thread(monkeypatch):
         await cog._send_prompt()
 
         assert created == [(
-            "Ping for Your Thoughts (Jul 21)",
+            "(Jul 21) What is your favorite color?",
             discord.ChannelType.public_thread,
         )]
         assert added == []
+
+    asyncio.run(run_test())
+
+
+def test_thread_name_truncates(monkeypatch):
+    async def run_test():
+        intents = discord.Intents.none()
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        cog = prompt_cog.PromptCog(bot)
+
+        long_prompt = "A" * 200
+        monkeypatch.setattr(cog, "fetch_prompt", lambda: long_prompt)
+
+        class DummyDateTime:
+            @classmethod
+            def now(cls, tz=None):
+                from datetime import datetime as real_datetime
+                return real_datetime(2025, 7, 21, tzinfo=tz)
+
+        monkeypatch.setattr(prompt_cog, "datetime", DummyDateTime)
+
+        class DummyThread(SimpleNamespace):
+            async def send(self, msg):
+                pass
+
+        created = []
+
+        async def fake_create_thread(name, auto_archive_duration=None, type=None):
+            created.append(name)
+            return DummyThread()
+
+        channel = SimpleNamespace(create_thread=fake_create_thread, guild=None)
+
+        monkeypatch.setattr(bot, "get_channel", lambda cid: channel)
+        monkeypatch.setattr(prompt_cog.cfg, "DAILY_PING_CHANNEL", 1)
+
+        await cog._send_prompt()
+
+        assert created
+        assert created[0].startswith("(Jul 21) AAA")
+        assert created[0].endswith("...")
+        assert len(created[0]) == 100
 
     asyncio.run(run_test())
 


### PR DESCRIPTION
## Summary
- Name daily ping threads with date and question text, trimming to 100 characters
- Cover the new thread naming format and truncation logic with tests

## Testing
- `python -m pytest -q`
- `python test_harness.py > /tmp/harness.log && nl -ba /tmp/harness.log | tail -n 10`


------
https://chatgpt.com/codex/tasks/task_e_688d79ddf228832ba4b14f16177ca7e8