### PR TITLE
feat: refresh daily prompts with analytics

### DIFF
--- a/db/versions/13a7e7c7add3_create_daily_prompt_table.py
+++ b/db/versions/13a7e7c7add3_create_daily_prompt_table.py
@@ -1,0 +1,30 @@
+"""create daily_prompt table"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '13a7e7c7add3'
+down_revision: Union[str, None] = 'f72b0b402bbc'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+def upgrade() -> None:
+    op.create_table(
+        'daily_prompt',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column(
+            'created_at',
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text('now()'),
+        ),
+        sa.Column('prompt', sa.Text, nullable=False, unique=True),
+        sa.Column('category', sa.Text, nullable=False),
+        sa.Column('thread_channel_id', sa.BigInteger, nullable=False),
+        sa.Column('message_count', sa.Integer, nullable=False, server_default='0'),
+        schema='discord',
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('daily_prompt', schema='discord')

--- a/tests/test_prompt_cog.py
+++ b/tests/test_prompt_cog.py
@@ -1,12 +1,22 @@
 import types
+import asyncio
 from gentlebot.cogs import prompt_cog
 
 
-def test_personal_snapshot_category_and_fallback(monkeypatch):
-    assert any("Personal Snapshot" in t for t in prompt_cog.PROMPT_TYPES)
+def test_engagement_bait_category_and_fallback(monkeypatch):
+    assert "Engagement Bait" in prompt_cog.PROMPT_CATEGORIES
 
     monkeypatch.setenv("HF_API_TOKEN", "")
-    monkeypatch.setattr(prompt_cog, "FALLBACK_PROMPTS", ["What's your screen time today?"])
+    monkeypatch.setattr(prompt_cog, "FALLBACK_PROMPTS", ["React with an emoji!"])
+
+    def fake_choice(seq):
+        if seq == prompt_cog.PROMPT_CATEGORIES:
+            return "Engagement Bait"
+        return seq[0]
+
+    monkeypatch.setattr(prompt_cog.random, "choice", fake_choice)
+
     cog = prompt_cog.PromptCog(bot=types.SimpleNamespace())
-    prompt = cog.fetch_prompt()
-    assert prompt == "What's your screen time today?"
+    prompt = asyncio.run(cog.fetch_prompt())
+    assert prompt == "React with an emoji!"
+    assert cog.last_category == "Engagement Bait"

--- a/tests/test_prompt_thread.py
+++ b/tests/test_prompt_thread.py
@@ -12,7 +12,11 @@ def test_send_prompt_creates_thread(monkeypatch):
         bot = commands.Bot(command_prefix="!", intents=intents)
         cog = prompt_cog.PromptCog(bot)
 
-        monkeypatch.setattr(cog, "fetch_prompt", lambda: "What is your favorite color?")
+        async def fake_fetch():
+            cog.last_category = "Engagement Bait"
+            return "What is your favorite color?"
+
+        monkeypatch.setattr(cog, "fetch_prompt", fake_fetch)
 
         class DummyDateTime:
             @classmethod
@@ -25,8 +29,11 @@ def test_send_prompt_creates_thread(monkeypatch):
         added = []
 
         class DummyThread(SimpleNamespace):
+            id = 1
+
             async def send(self, msg):
                 self.sent = msg
+
             async def add_user(self, member):
                 added.append(member)
 
@@ -65,7 +72,12 @@ def test_thread_name_truncates(monkeypatch):
         cog = prompt_cog.PromptCog(bot)
 
         long_prompt = "A" * 200
-        monkeypatch.setattr(cog, "fetch_prompt", lambda: long_prompt)
+
+        async def fake_fetch_long():
+            cog.last_category = "Engagement Bait"
+            return long_prompt
+
+        monkeypatch.setattr(cog, "fetch_prompt", fake_fetch_long)
 
         class DummyDateTime:
             @classmethod
@@ -76,6 +88,8 @@ def test_thread_name_truncates(monkeypatch):
         monkeypatch.setattr(prompt_cog, "datetime", DummyDateTime)
 
         class DummyThread(SimpleNamespace):
+            id = 1
+
             async def send(self, msg):
                 pass
 


### PR DESCRIPTION
## Summary
- replace prompt rotation with random category selection using original fallback prompts
- simplify system prompt, set HF max_tokens to 75, and refine news summarization
- update thread message counting to verify channel exists in archive

## Testing
- `pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_689176259814832b970b48a24425930d