### PR TITLE
Log Discord presence updates

### DIFF
--- a/db/versions/21f8d03f7509_create_presence_update_table.py
+++ b/db/versions/21f8d03f7509_create_presence_update_table.py
@@ -1,0 +1,42 @@
+"""create presence_update table"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = '21f8d03f7509'
+down_revision: Union[str, None] = '0621c7d3e3d7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+
+def upgrade() -> None:
+    op.create_table(
+        'presence_update',
+        sa.Column('event_id', sa.BigInteger, primary_key=True),
+        sa.Column('guild_id', sa.BigInteger, nullable=False),
+        sa.Column('user_id', sa.BigInteger, nullable=False),
+        sa.Column('status', sa.Text, nullable=False),
+        sa.Column('activities', sa.JSON),
+        sa.Column('client_status', sa.JSON),
+        sa.Column(
+            'event_at',
+            sa.DateTime(timezone=True),
+            server_default=sa.text('now()'),
+            nullable=False,
+        ),
+        schema='discord',
+    )
+    op.create_index(
+        'presence_update_guild_user',
+        'presence_update',
+        ['guild_id', 'user_id', 'event_at'],
+        schema='discord',
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('presence_update_guild_user', table_name='presence_update', schema='discord')
+    op.drop_table('presence_update', schema='discord')

--- a/gentlebot/__main__.py
+++ b/gentlebot/__main__.py
@@ -39,6 +39,7 @@ logger.info(
 intents = discord.Intents.default()
 intents.message_content = True
 intents.members = True  # RoleCog needs this
+intents.presences = True
 
 class GentleBot(commands.Bot):
     async def setup_hook(self) -> None:

--- a/gentlebot/cogs/presence_archive_cog.py
+++ b/gentlebot/cogs/presence_archive_cog.py
@@ -1,0 +1,80 @@
+"""Archive Discord presence updates to Postgres."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+import asyncpg
+import discord
+from discord.ext import commands
+
+from ..util import build_db_url
+
+log = logging.getLogger(f"gentlebot.{__name__}")
+
+
+class PresenceArchiveCog(commands.Cog):
+    """Persist presence update events to Postgres."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.pool: asyncpg.Pool | None = None
+        self.enabled = os.getenv("ARCHIVE_PRESENCE") == "1"
+
+    async def cog_load(self) -> None:
+        if not self.enabled:
+            return
+        url = build_db_url()
+        if not url:
+            log.warning("ARCHIVE_PRESENCE set but PG_DSN is missing")
+            self.enabled = False
+            return
+        url = url.replace("postgresql+asyncpg://", "postgresql://")
+
+        async def _init(conn: asyncpg.Connection) -> None:
+            await conn.execute("SET search_path=discord,public")
+
+        self.pool = await asyncpg.create_pool(url, init=_init)
+        log.info("Presence archival enabled")
+
+    async def cog_unload(self) -> None:
+        if self.pool:
+            await self.pool.close()
+            self.pool = None
+
+    @commands.Cog.listener()
+    async def on_presence_update(self, before: discord.Member, after: discord.Member) -> None:
+        if not self.enabled or not self.pool:
+            return
+        guild_id = getattr(after.guild, "id", None)
+        if guild_id is None:
+            return
+        activities = [getattr(a, "to_dict", lambda: {})() for a in after.activities]
+        client_status = {
+            k: v.value
+            for k, v in {
+                "desktop": after.desktop_status,
+                "mobile": after.mobile_status,
+                "web": after.web_status,
+            }.items()
+            if v and v is not discord.Status.offline
+        }
+        await self.pool.execute(
+            """
+            INSERT INTO discord.presence_update (
+                guild_id, user_id, status, activities, client_status, event_at
+            )
+            VALUES ($1,$2,$3,$4,$5,$6)
+            """,
+            guild_id,
+            after.id,
+            after.raw_status,
+            json.dumps(activities),
+            json.dumps(client_status) if client_status else None,
+            discord.utils.utcnow(),
+        )
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(PresenceArchiveCog(bot))

--- a/tests/test_presence_archive_cog.py
+++ b/tests/test_presence_archive_cog.py
@@ -1,0 +1,66 @@
+import asyncio
+import asyncpg
+import asyncio
+import asyncpg
+import discord
+from discord.ext import commands
+
+from gentlebot.cogs.presence_archive_cog import PresenceArchiveCog
+
+
+class DummyPool:
+    def __init__(self):
+        self.executed = []
+
+    async def close(self):
+        pass
+
+    async def execute(self, query, *args):
+        self.executed.append((query, args))
+
+
+async def fake_create_pool(url, *args, **kwargs):
+    assert url.startswith("postgresql://")
+    return DummyPool()
+
+
+def test_presence_logged(monkeypatch):
+    async def run_test():
+        monkeypatch.setattr(asyncpg, "create_pool", fake_create_pool)
+        monkeypatch.setenv("ARCHIVE_PRESENCE", "1")
+        monkeypatch.setenv("PG_DSN", "postgresql+asyncpg://u:p@localhost/db")
+        intents = discord.Intents.default()
+        intents.members = True
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        cog = PresenceArchiveCog(bot)
+        await cog.cog_load()
+        pool = cog.pool
+        class DummyActivity:
+            def to_dict(self):
+                return {"name": "a"}
+        guild = type("G", (), {"id": 1})()
+        before = type("M", (), {
+            "guild": guild,
+            "id": 2,
+            "activities": [],
+            "raw_status": "offline",
+            "desktop_status": discord.Status.offline,
+            "mobile_status": discord.Status.offline,
+            "web_status": discord.Status.offline,
+        })()
+        after = type("M", (), {
+            "guild": guild,
+            "id": 2,
+            "activities": [DummyActivity()],
+            "raw_status": "online",
+            "desktop_status": discord.Status.online,
+            "mobile_status": discord.Status.offline,
+            "web_status": discord.Status.online,
+        })()
+        await cog.on_presence_update(before, after)
+        assert pool.executed
+        query, args = pool.executed[0]
+        assert "INSERT INTO discord.presence_update" in query
+        assert args[0] == 1
+        assert args[1] == 2
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- enable presence intent for tracking presence updates
- add PresenceArchiveCog to record presence changes in Postgres
- create `presence_update` table and test coverage

## Testing
- `pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_689180833cdc832b80bcb14dfc2ef6ef