### PR TITLE
Track last user presence time

### DIFF
--- a/tests/test_presence_archive_cog.py
+++ b/tests/test_presence_archive_cog.py
@@ -1,7 +1,5 @@
 import asyncio
 import asyncpg
-import asyncio
-import asyncpg
 import discord
 from discord.ext import commands
 
@@ -58,9 +56,12 @@ def test_presence_logged(monkeypatch):
             "web_status": discord.Status.online,
         })()
         await cog.on_presence_update(before, after)
-        assert pool.executed
-        query, args = pool.executed[0]
-        assert "INSERT INTO discord.presence_update" in query
-        assert args[0] == 1
-        assert args[1] == 2
+        assert len(pool.executed) == 2
+        insert_query, insert_args = pool.executed[0]
+        assert "INSERT INTO discord.presence_update" in insert_query
+        assert insert_args[0] == 1
+        assert insert_args[1] == 2
+        update_query, update_args = pool.executed[1]
+        assert "UPDATE discord.\"user\" SET last_seen_at" in update_query
+        assert update_args[0] == 2
     asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- Update presence archiver to write `last_seen_at` when users appear online
- Cover presence tracking with new unit test

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_689186d54930832bb30b0bbdbb42b594