### PR TITLE
Add admin /gentlebot slash command

### DIFF
--- a/gentlebot/cogs/gentlebot_cog.py
+++ b/gentlebot/cogs/gentlebot_cog.py
@@ -1,0 +1,43 @@
+"""Admin slash command to echo text in a channel.
+
+Provides an ephemeral `/gentlebot` command allowing administrators to send
+arbitrary messages as the bot.
+"""
+from __future__ import annotations
+
+import logging
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from ..util import chan_name
+
+log = logging.getLogger(f"gentlebot.{__name__}")
+
+
+class GentlebotCog(commands.Cog):
+    """Cog implementing the admin-only `/gentlebot` command."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @app_commands.command(name="gentlebot", description="Send a message as Gentlebot")
+    @app_commands.describe(say="Text for Gentlebot to echo")
+    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.default_permissions(administrator=True)
+    async def gentlebot(self, interaction: discord.Interaction, say: str):
+        """Echo the supplied text into the current channel."""
+        log.info(
+            "/gentlebot invoked by %s in %s: %s",
+            interaction.user.id,
+            chan_name(interaction.channel),
+            say,
+        )
+        await interaction.response.defer(thinking=True, ephemeral=True)
+        await interaction.channel.send(say[:1900])
+        await interaction.followup.send("Message sent.", ephemeral=True)
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(GentlebotCog(bot))

--- a/tests/test_gentlebot_cog.py
+++ b/tests/test_gentlebot_cog.py
@@ -1,0 +1,43 @@
+import asyncio
+from types import SimpleNamespace
+
+import discord
+from discord.ext import commands
+
+from gentlebot.cogs import gentlebot_cog
+
+
+def test_gentlebot_sends_message():
+    async def run_test():
+        intents = discord.Intents.none()
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        cog = gentlebot_cog.GentlebotCog(bot)
+
+        sent: list[str] = []
+
+        async def fake_send(content: str):
+            sent.append(content)
+
+        channel = SimpleNamespace(id=1, name="chan", send=fake_send)
+        user = SimpleNamespace(id=123)
+
+        async def fake_defer(*args, **kwargs):
+            pass
+
+        async def fake_followup_send(*args, **kwargs):
+            pass
+
+        interaction = SimpleNamespace(
+            user=user,
+            channel=channel,
+            response=SimpleNamespace(defer=fake_defer),
+            followup=SimpleNamespace(send=fake_followup_send),
+        )
+
+        command = cog.gentlebot
+        await command.callback(cog, interaction, say="hello world")
+
+        assert sent == ["hello world"]
+        assert command.default_permissions.administrator
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- add admin-only `/gentlebot` slash command that relays provided text via required `say` argument
- test command messaging and permission setup

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68918552f754832b9f0db401d1050137