### PR TITLE
feat: add /catchup command for conversation summaries

### DIFF
--- a/gentlebot/cogs/catchup_cog.py
+++ b/gentlebot/cogs/catchup_cog.py
@@ -1,0 +1,162 @@
+"""Summarize missed conversations for returning users."""
+from __future__ import annotations
+
+import logging
+import os
+from datetime import timedelta
+
+import asyncpg
+import discord
+from discord import app_commands
+from discord.ext import commands
+from huggingface_hub import InferenceClient
+
+from ..util import build_db_url, int_env
+
+log = logging.getLogger(f"gentlebot.{__name__}")
+
+
+class CatchupCog(commands.Cog):
+    """Provide a `/catchup` slash command."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.hf_api_key = os.getenv("HF_API_TOKEN")
+        if not self.hf_api_key:
+            raise RuntimeError("HF_API_TOKEN is not set in environment")
+
+        self.model_id = os.getenv(
+            "HF_MODEL", "meta-llama/Meta-Llama-3-8B-Instruct"
+        )
+        self.max_tokens = int_env("HF_MAX_TOKENS", 200)
+        self.temperature = float(os.getenv("HF_TEMPERATURE", 0.6))
+        self.top_p = float(os.getenv("HF_TOP_P", 0.9))
+        self.hf_client = InferenceClient(api_key=self.hf_api_key, provider="together")
+        self.pool: asyncpg.Pool | None = None
+
+    async def cog_load(self) -> None:
+        url = build_db_url()
+        if not url:
+            log.warning("CatchupCog disabled due to missing database URL")
+            return
+        url = url.replace("postgresql+asyncpg://", "postgresql://")
+
+        async def _init(conn: asyncpg.Connection) -> None:
+            await conn.execute("SET search_path=discord,public")
+
+        self.pool = await asyncpg.create_pool(url, init=_init)
+
+    async def cog_unload(self) -> None:
+        if self.pool:
+            await self.pool.close()
+            self.pool = None
+
+    async def _collect_messages(
+        self, interaction: discord.Interaction, scope: str
+    ) -> list[str]:
+        if not self.pool:
+            return []
+        user = interaction.user
+        row = await self.pool.fetchrow(
+            'SELECT last_seen_at FROM discord."user" WHERE user_id=$1',
+            user.id,
+        )
+        last_seen = row["last_seen_at"] if row and row["last_seen_at"] else None
+        if last_seen is None:
+            last_seen = discord.utils.utcnow() - timedelta(days=1)
+
+        params: list[object] = [last_seen, user.id]
+        query = (
+            "SELECT m.content, m.channel_id, c.name AS channel_name, u.display_name "
+            "FROM discord.message m "
+            "JOIN discord.channel c ON m.channel_id = c.channel_id "
+            "JOIN discord.\"user\" u ON m.author_id = u.user_id "
+            "WHERE m.created_at >= $1 AND m.author_id <> $2"
+        )
+        idx = 3
+        if scope == "channel":
+            channel_id = getattr(interaction.channel, "id", None)
+            if channel_id is None:
+                return []
+            query += f" AND m.channel_id = ${idx}"
+            params.append(channel_id)
+            idx += 1
+        elif scope == "mentions":
+            query += f" AND m.mentions::jsonb @> to_jsonb(array[${idx}]::bigint[])"
+            params.append(user.id)
+            idx += 1
+        query += " ORDER BY m.created_at ASC LIMIT 100"
+        rows = await self.pool.fetch(query, *params)
+        prefix = scope != "channel"
+        messages = []
+        for r in rows:
+            author = r["display_name"] or "?"
+            content = r["content"] or ""
+            channel_name = r["channel_name"] or str(r["channel_id"])
+            if prefix:
+                messages.append(f"[#{channel_name}] {author}: {content}")
+            else:
+                messages.append(f"{author}: {content}")
+        return messages
+
+    async def _summarize(self, messages: list[str], style: str | None) -> str:
+        convo = "\n".join(messages)
+        system = "Summarize the following messages for a user who has been away. Be concise."
+        if style:
+            system += f" Use the following style or tone: {style}."
+        data = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": convo},
+        ]
+        completion = self.hf_client.chat.completions.create(
+            model=self.model_id,
+            messages=data,
+            max_tokens=self.max_tokens,
+            temperature=self.temperature,
+            top_p=self.top_p,
+        )
+        return getattr(completion.choices[0].message, "content", "").strip()
+
+    @app_commands.command(name="catchup", description="Summarize conversations since you were last online.")
+    @app_commands.describe(
+        visibility="Who should see the summary",
+        scope="Which messages to summarize",
+        style="Optional style or tone for the summary",
+    )
+    @app_commands.choices(
+        visibility=[
+            app_commands.Choice(name="only me", value="only me"),
+            app_commands.Choice(name="everyone", value="everyone"),
+        ],
+        scope=[
+            app_commands.Choice(name="all", value="all"),
+            app_commands.Choice(name="channel", value="channel"),
+            app_commands.Choice(name="mentions", value="mentions"),
+        ],
+    )
+    async def catchup(
+        self,
+        interaction: discord.Interaction,
+        visibility: str = "everyone",
+        scope: str = "all",
+        style: str | None = None,
+    ) -> None:
+        """Summarize recent messages for the invoking user."""
+        ephemeral = visibility == "only me"
+        messages = await self._collect_messages(interaction, scope)
+        if not messages:
+            await interaction.response.send_message(
+                "No new messages to summarize.", ephemeral=ephemeral
+            )
+            return
+        try:
+            summary = await self._summarize(messages, style)
+        except Exception as exc:
+            log.exception("HF summarization failed: %s", exc)
+            summary = "⚠️ Unable to generate summary at this time."
+        await interaction.response.send_message(summary[:1900], ephemeral=ephemeral)
+
+
+async def setup(bot: commands.Bot) -> None:
+    """Load the cog."""
+    await bot.add_cog(CatchupCog(bot))

--- a/tests/test_catchup_cog.py
+++ b/tests/test_catchup_cog.py
@@ -1,0 +1,63 @@
+import asyncio
+import discord
+from discord.ext import commands
+from gentlebot.cogs.catchup_cog import CatchupCog
+from types import SimpleNamespace
+
+
+class DummyPool:
+    async def fetchrow(self, query, *args):
+        assert "last_seen_at" in query
+        return {"last_seen_at": None}
+
+    async def fetch(self, query, *args):
+        assert "FROM discord.message" in query
+        return [
+            {
+                "content": "hi",
+                "channel_id": 1,
+                "channel_name": "general",
+                "display_name": "Bob",
+            }
+        ]
+
+
+def test_catchup_command_registration(monkeypatch):
+    async def run():
+        monkeypatch.setenv("HF_API_TOKEN", "test")
+        intents = discord.Intents.none()
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        cog = CatchupCog(bot)
+        await bot.add_cog(cog)
+        cmd = bot.tree.get_command("catchup")
+        assert cmd is not None
+        params = {p.name: p for p in cmd.parameters}
+        vis = params["visibility"]
+        assert vis.default == "everyone"
+        assert [c.value for c in vis.choices] == ["only me", "everyone"]
+        scope = params["scope"]
+        assert scope.default == "all"
+        assert [c.value for c in scope.choices] == ["all", "channel", "mentions"]
+        style = params["style"]
+        assert style.default is None
+        assert style.required is False
+        await bot.close()
+    asyncio.run(run())
+
+
+def test_collect_messages_uses_archive(monkeypatch):
+    async def run():
+        monkeypatch.setenv("HF_API_TOKEN", "x")
+        bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+        cog = CatchupCog(bot)
+        await bot.add_cog(cog)
+        cog.pool = DummyPool()
+        interaction = SimpleNamespace(
+            user=SimpleNamespace(id=123),
+            channel=SimpleNamespace(id=1),
+        )
+        msgs = await cog._collect_messages(interaction, "channel")
+        assert msgs == ["Bob: hi"]
+        await bot.close()
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- add new CatchupCog with `/catchup` slash command powered by HuggingFace
- support visibility, scope and style options
- load messages from archived tables instead of live Discord API
- cover command registration and archive query path with unit tests

## Testing
- `pytest -q`
- `python test_harness.py` *(fails: Client has not been properly initialised; CatchupCog disabled due to missing database URL)*


------
https://chatgpt.com/codex/tasks/task_e_68918a723ca4832b9efa01527a1eec0e