### PR TITLE
Log daily hero DM message

### DIFF
--- a/gentlebot/tasks/daily_hero_dm.py
+++ b/gentlebot/tasks/daily_hero_dm.py
@@ -102,6 +102,11 @@ class DailyHeroDMCog(commands.Cog):
             message = await self._generate_message(member.display_name)
             try:
                 await member.send(message)
+                log.info(
+                    "Sent Daily Hero DM to %s: %s",
+                    member.display_name,
+                    message,
+                )
             except discord.HTTPException:
                 log.warning("Failed to DM Daily Hero %s", member)
 

--- a/tests/test_daily_hero_dm.py
+++ b/tests/test_daily_hero_dm.py
@@ -1,11 +1,14 @@
 """Tests for the DailyHeroDMCog message generation."""
 import os
 import asyncio
+import logging
+from types import SimpleNamespace
 
 import pytest
 import discord
 from discord.ext import commands
 
+from gentlebot import bot_config as cfg
 from gentlebot.tasks.daily_hero_dm import DailyHeroDMCog
 
 
@@ -34,3 +37,39 @@ def test_generate_message_success(cog, monkeypatch):
     monkeypatch.setattr(cog.hf_client, "text_generation", fake_gen)
     msg = asyncio.run(cog._generate_message("Tester"))
     assert msg == sample
+
+
+def test_send_dm_logged(cog, monkeypatch, caplog):
+    async def run_test():
+        async def dummy_wait():
+            return None
+
+        monkeypatch.setattr(cog.bot, "wait_until_ready", dummy_wait)
+        monkeypatch.setattr(cfg, "GUILD_ID", 1, raising=False)
+        monkeypatch.setattr(cfg, "ROLE_DAILY_HERO", 2, raising=False)
+
+        sent = []
+
+        class DummyMember(SimpleNamespace):
+            display_name = "Tester"
+
+            async def send(self, message):
+                sent.append(message)
+
+        member = DummyMember()
+        role = SimpleNamespace(members=[member])
+        guild = SimpleNamespace(get_role=lambda _id: role)
+        monkeypatch.setattr(cog.bot, "get_guild", lambda _id: guild)
+
+        async def fake_generate(name):
+            return "Hello Hero"
+
+        monkeypatch.setattr(cog, "_generate_message", fake_generate)
+
+        caplog.set_level(logging.INFO)
+        await cog._send_dm()
+
+        assert sent == ["Hello Hero"]
+        assert any("Sent Daily Hero DM to Tester: Hello Hero" in r.message for r in caplog.records)
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- log the DM message sent to the Daily Hero for visibility
- add coverage to ensure DailyHeroDMCog logs the message

## Testing
- `python -m pytest -q`
- `python test_harness.py` *(fails: Client has not been properly initialised, Loaded 20 cogs successfully)*

------
https://chatgpt.com/codex/tasks/task_e_68918dbaeee8832bbb3012bba41cfb1d