### PR TITLE
Add retry logic for Big Dumper watcher HR fetch

### DIFF
--- a/tests/test_bigdumper_watcher.py
+++ b/tests/test_bigdumper_watcher.py
@@ -39,3 +39,15 @@ def test_post_on_new_hr(monkeypatch):
         assert sent and sent[0] is dummy_embed
 
     asyncio.run(run_test())
+
+
+def test_session_retries_configured():
+    async def run_test():
+        intents = discord.Intents.none()
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        cog = bigdumper_watcher_cog.BigDumperWatcherCog(bot)
+        adapter = cog.session.get_adapter("https://")
+        assert adapter.max_retries.total >= 3
+        cog.check_task.cancel()
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- add requests Retry+HTTPAdapter to BigDumperWatcherCog
- start check loop on cog_load and close session on unload
- handle request failures as warnings and add regression test for retry config

## Testing
- `python -m pytest -q`
- `python test_harness.py` *(shows uninitialised-client warnings from unrelated cogs)*

------
https://chatgpt.com/codex/tasks/task_e_6892b900944c832bbc211af119996339