### PR TITLE
fix: update daily prompt message counts

### DIFF
--- a/gentlebot/cogs/prompt_cog.py
+++ b/gentlebot/cogs/prompt_cog.py
@@ -264,9 +264,14 @@ class PromptCog(commands.Cog):
         try:
             await self.pool.execute(
                 """
-                INSERT INTO discord.daily_prompt (prompt, category, thread_channel_id)
-                VALUES ($1,$2,$3)
-                ON CONFLICT (prompt) DO NOTHING
+                INSERT INTO discord.daily_prompt
+                    (prompt, category, thread_channel_id, message_count)
+                VALUES ($1, $2, $3, 0)
+                ON CONFLICT (prompt) DO UPDATE SET
+                    category = EXCLUDED.category,
+                    thread_channel_id = EXCLUDED.thread_channel_id,
+                    message_count = 0,
+                    created_at = NOW()
                 """,
                 prompt,
                 category,


### PR DESCRIPTION
## Summary
- ensure daily prompt rows update when prompts repeat and reset message counts
- cover duplicate prompt behavior with a unit test

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_6892c2efc64c832b8dcc482c96a2c9fe