### PR TITLE
Use chat completions for Daily Hero message

### DIFF
--- a/gentlebot/tasks/daily_hero_dm.py
+++ b/gentlebot/tasks/daily_hero_dm.py
@@ -70,15 +70,14 @@ class DailyHeroDMCog(commands.Cog):
     async def _generate_message(self, display_name: str) -> str:
         prompt = self._build_prompt(display_name)
         try:
-            response = self.hf_client.text_generation(
-                prompt,
+            completion = self.hf_client.chat.completions.create(
                 model=self.model_id,
-                max_new_tokens=60,
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=60,
                 temperature=0.7,
                 top_p=0.9,
-                repetition_penalty=1.2,
             )
-            text = response.strip().replace("\n", " ")
+            text = getattr(completion.choices[0].message, "content", "").strip().replace("\n", " ")
         except Exception as e:
             log.exception("HF generation failed: %s", e)
             return self._fallback(display_name)

--- a/tests/test_daily_hero_dm.py
+++ b/tests/test_daily_hero_dm.py
@@ -21,9 +21,11 @@ def cog(monkeypatch):
 
 
 def test_generate_message_fallback(cog, monkeypatch):
-    def fake_gen(prompt, **kwargs):
-        return "Hello there"
-    monkeypatch.setattr(cog.hf_client, "text_generation", fake_gen)
+    def fake_gen(*args, **kwargs):
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="Hello there"))]
+        )
+    monkeypatch.setattr(cog.hf_client, "chat_completion", fake_gen)
     msg = asyncio.run(cog._generate_message("Tester"))
     assert "Daily Hero role until midnight Pacific" in msg
 
@@ -33,9 +35,11 @@ def test_generate_message_success(cog, monkeypatch):
         "Greetings, Tester; your valiant efforts yesterday earned the Daily Hero honour, "
         "which persists until midnight, so cherish this well-deserved laurel in quiet, dignified triumph tonight."
     )
-    def fake_gen(prompt, **kwargs):
-        return sample
-    monkeypatch.setattr(cog.hf_client, "text_generation", fake_gen)
+    def fake_gen(*args, **kwargs):
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=sample))]
+        )
+    monkeypatch.setattr(cog.hf_client, "chat_completion", fake_gen)
     msg = asyncio.run(cog._generate_message("Tester"))
     assert msg == sample
 


### PR DESCRIPTION
## Summary
- swap Daily Hero DM generation to use Hugging Face chat completions API
- adjust tests for new chat completion call

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_6892d55e2484832b91a3670252c2169d