### PR TITLE
Add server name and win count to Daily Hero DM

### DIFF
--- a/gentlebot/tasks/daily_hero_dm.py
+++ b/gentlebot/tasks/daily_hero_dm.py
@@ -3,6 +3,7 @@ import os
 import logging
 
 import pytz
+import asyncpg
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 
@@ -11,6 +12,7 @@ from discord.ext import commands
 from huggingface_hub import InferenceClient
 
 from .. import bot_config as cfg
+from ..util import build_db_url
 
 log = logging.getLogger(f"gentlebot.{__name__}")
 
@@ -20,8 +22,9 @@ PROMPT_TEMPLATE = (
     "You are Gentlebot, a refined British butler announcing Discord honours.\n\n"
     "Compose a single-sentence direct message to {display_name} that:\n"
     "• greets the user (Good day / Greetings / Salutations / Well met)  \n"
-    "• states they earned the “Daily Hero” role for yesterday’s contributions  \n"
+    "• states they earned the “Daily Hero” role in Gentlefolk for yesterday’s contributions  \n"
     "• notes the role expires at midnight  \n"
+    "• mentions this is their {ordinal} time receiving it  \n"
     "• contains no requests, tasks, or calls-to-action  \n"
     "• uses formal British-but-warm diction  \n"
     "• 25-30 words total\n"
@@ -29,12 +32,12 @@ PROMPT_TEMPLATE = (
 )
 
 FALLBACK_TEMPLATE = (
-    "Good day, {username}. Your sterling contributions yesterday have earned you the Daily Hero role until midnight Pacific. Bask accordingly. — Gentlebot 🤖"
+    "Good day, {username}. Your sterling contributions yesterday in Gentlefolk have earned you the Daily Hero role until midnight Pacific for the {ordinal} time. Bask accordingly. — Gentlebot 🤖"
 )
 
 
 class DailyHeroDMCog(commands.Cog):
-    """Scheduler that DMs yesterday's Daily Hero at 9am Pacific, 30 minutes after the role rotates."""
+    """Scheduler that DMs yesterday's Daily Hero at 9am Pacific, noting server name and win count."""
 
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
@@ -44,8 +47,17 @@ class DailyHeroDMCog(commands.Cog):
         self.model_id = os.getenv("HF_MODEL", "meta-llama/Meta-Llama-3-8B-Instruct")
         self.hf_client = InferenceClient(api_key=token, provider="together")
         self.scheduler: AsyncIOScheduler | None = None
+        self.pool: asyncpg.Pool | None = None
 
     async def cog_load(self) -> None:
+        url = build_db_url()
+        if url:
+            url = url.replace("postgresql+asyncpg://", "postgresql://")
+
+            async def _init(conn: asyncpg.Connection) -> None:
+                await conn.execute("SET search_path=discord,public")
+
+            self.pool = await asyncpg.create_pool(url, init=_init)
         self.scheduler = AsyncIOScheduler(timezone=LA)
         trigger = CronTrigger(hour=9, minute=0, timezone=LA)
         self.scheduler.add_job(self._send_dm, trigger)
@@ -56,19 +68,32 @@ class DailyHeroDMCog(commands.Cog):
         if self.scheduler:
             self.scheduler.shutdown(wait=False)
             self.scheduler = None
+        if self.pool:
+            await self.pool.close()
+            self.pool = None
 
-    def _build_prompt(self, display_name: str) -> str:
-        return PROMPT_TEMPLATE.format(display_name=display_name)
+    def _ordinal(self, n: int) -> str:
+        suffix = "th"
+        if 10 <= n % 100 <= 20:
+            suffix = "th"
+        else:
+            suffix = {1: "st", 2: "nd", 3: "rd"}.get(n % 10, "th")
+        return f"{n}{suffix}"
 
-    def _fallback(self, name: str) -> str:
-        return FALLBACK_TEMPLATE.format(username=name)
+    def _build_prompt(self, display_name: str, wins: int) -> str:
+        ordinal = self._ordinal(wins)
+        return PROMPT_TEMPLATE.format(display_name=display_name, ordinal=ordinal)
+
+    def _fallback(self, name: str, wins: int) -> str:
+        ordinal = self._ordinal(wins)
+        return FALLBACK_TEMPLATE.format(username=name, ordinal=ordinal)
 
     def _is_valid(self, text: str) -> bool:
         words = text.split()
         return "Daily Hero" in text and 25 <= len(words) <= 30
 
-    async def _generate_message(self, display_name: str) -> str:
-        prompt = self._build_prompt(display_name)
+    async def _generate_message(self, display_name: str, wins: int) -> str:
+        prompt = self._build_prompt(display_name, wins)
         try:
             completion = self.hf_client.chat.completions.create(
                 model=self.model_id,
@@ -80,12 +105,22 @@ class DailyHeroDMCog(commands.Cog):
             text = getattr(completion.choices[0].message, "content", "").strip().replace("\n", " ")
         except Exception as e:
             log.exception("HF generation failed: %s", e)
-            return self._fallback(display_name)
+            return self._fallback(display_name, wins)
 
         if not self._is_valid(text):
             log.debug("Invalid HF message '%s'; using fallback", text)
-            return self._fallback(display_name)
+            return self._fallback(display_name, wins)
         return text
+
+    async def _win_count(self, role_id: int, user_id: int) -> int:
+        if not self.pool:
+            return 0
+        row = await self.pool.fetchrow(
+            "SELECT COUNT(*) AS c FROM discord.role_event WHERE role_id=$1 AND user_id=$2 AND action=1",
+            role_id,
+            user_id,
+        )
+        return int(row["c"]) if row else 0
 
     async def _send_dm(self) -> None:
         await self.bot.wait_until_ready()
@@ -98,7 +133,8 @@ class DailyHeroDMCog(commands.Cog):
             log.error("Daily Hero role not found")
             return
         for member in list(role.members):
-            message = await self._generate_message(member.display_name)
+            wins = await self._win_count(role.id, member.id) or 1
+            message = await self._generate_message(member.display_name, wins)
             try:
                 await member.send(message)
                 log.info(


### PR DESCRIPTION
## Summary
- Personalize Daily Hero congratulation DM with server name and ordinal win count
- Track Daily Hero win totals via database query
- Expand tests for Daily Hero messaging and scheduling

## Testing
- `pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68937e0bb1c4832b9c2e611dc09ba1c5