### PR TITLE
Avoid repeating current event topics

### DIFF
--- a/db/versions/4e8c76419777_add_topic_column_to_daily_prompt.py
+++ b/db/versions/4e8c76419777_add_topic_column_to_daily_prompt.py
@@ -1,0 +1,19 @@
+"""add topic column to daily_prompt"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '4e8c76419777'
+down_revision: Union[str, None] = '13a7e7c7add3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+def upgrade() -> None:
+    op.add_column(
+        'daily_prompt',
+        sa.Column('topic', sa.Text, nullable=True),
+        schema='discord',
+    )
+
+def downgrade() -> None:
+    op.drop_column('daily_prompt', 'topic', schema='discord')


### PR DESCRIPTION
## Summary
- prevent repeating current event topics by checking recent topic history
- store news topic alongside prompts in the database
- test prompt generator skips recently used news topics

## Testing
- `python -m pytest -q`
- `python test_harness.py` *(fails: Client has not been properly initialised)*

------
https://chatgpt.com/codex/tasks/task_e_689c173561f4832ba24989a649415268