### PR TITLE
feat: add sports news prompt category

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Gentlebot is a modular Discord bot composed of several **cogs** that handle diff
   roles manually. Ensure the bot's role is above these vanity roles and has the
   **Manage Roles** permission so it can assign and remove them.
 - **PromptCog** – Posts a daily prompt generated via the Hugging Face API at
-  12:30 pm Pacific time by default. Categories rotate randomly without
-  repeating recent types, and the rotation state persists in
+  12:30 pm Pacific time by default. Categories rotate randomly among recent
+  server discussion, general sports news, and engagement bait without
+  repeating recent types. The rotation state persists in
   `prompt_state.json` so redeployments keep things fresh.
 - **HuggingFaceCog** – Adds AI conversation and emoji reactions using Hugging Face models.
 - **StatsCog** – `/engagement` now replies "Working on it..." and then gathers

--- a/tests/test_prompt_cog.py
+++ b/tests/test_prompt_cog.py
@@ -22,6 +22,30 @@ def test_engagement_bait_category_and_fallback(monkeypatch):
     assert cog.last_category == "Engagement Bait"
 
 
+def test_sports_news_category_and_fallback(monkeypatch):
+    assert "Sports News" in prompt_cog.PROMPT_CATEGORIES
+
+    monkeypatch.setenv("HF_API_TOKEN", "")
+    monkeypatch.setattr(prompt_cog, "FALLBACK_PROMPTS", ["Goal or no goal?"])
+
+    async def fake_topic(self):
+        return "Team X wins"
+
+    monkeypatch.setattr(prompt_cog.PromptCog, "_sports_news_topic", fake_topic)
+
+    def fake_choice(seq):
+        if seq == prompt_cog.PROMPT_CATEGORIES:
+            return "Sports News"
+        return seq[0]
+
+    monkeypatch.setattr(prompt_cog.random, "choice", fake_choice)
+
+    cog = prompt_cog.PromptCog(bot=types.SimpleNamespace())
+    prompt = asyncio.run(cog.fetch_prompt())
+    assert prompt == "Goal or no goal?"
+    assert cog.last_category == "Sports News"
+
+
 def test_current_event_category_removed():
     assert "Current event" not in prompt_cog.PROMPT_CATEGORIES
 


### PR DESCRIPTION
## Summary
- add "Sports News" to daily prompt categories
- fetch sports headlines from ESPN to seed prompts
- document new category and test fallback logic

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_689faa5958c4832bb45aed5b8291c25e