### PR TITLE
Scope Gemini quotas and quiet scheduled errors

### DIFF
--- a/gentlebot/cogs/image.py
+++ b/gentlebot/cogs/image.py
@@ -1,0 +1,49 @@
+"""Image generation commands."""
+from __future__ import annotations
+
+import io
+import asyncio
+import logging
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from ..llm.router import router, SafetyBlocked
+from ..infra.quotas import RateLimited
+
+log = logging.getLogger(f"gentlebot.{__name__}")
+
+
+class ImageCog(commands.Cog):
+    """Expose an /image command using Gemini."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @app_commands.command(name="image", description="Generate an image with Gemini")
+    async def image(self, interaction: discord.Interaction, prompt: str) -> None:
+        await interaction.response.defer(thinking=True)
+        try:
+            data = await asyncio.to_thread(router.generate_image, prompt)
+        except RateLimited:
+            await interaction.followup.send(
+                "Let me get back to you on this... I'm a bit busy right now.")
+            return
+        except SafetyBlocked:
+            await interaction.followup.send(
+                "Your inquiry is being blocked by my policy commitments.")
+            return
+        except Exception:
+            log.exception("Image generation failed")
+            await interaction.followup.send("Something's wrong... I need a mechanic.")
+            return
+        if data:
+            file = discord.File(io.BytesIO(data), filename="gemini.png")
+            await interaction.followup.send(file=file)
+        else:
+            await interaction.followup.send("Image generation didn't work.")
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(ImageCog(bot))

--- a/gentlebot/infra/quotas.py
+++ b/gentlebot/infra/quotas.py
@@ -1,0 +1,74 @@
+"""Simple in-process quota guards."""
+from __future__ import annotations
+
+import time
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from typing import Dict
+
+
+class RateLimited(Exception):
+    """Raised when a quota is exceeded."""
+
+
+def _now() -> float:
+    return time.time()
+
+
+@dataclass
+class Limit:
+    rpm: int | None = None
+    tpm: int | None = None
+    rpd: int | None = None
+
+
+class QuotaGuard:
+    def __init__(self, limits: Dict[str, Limit]):
+        self.limits = limits
+        self.req_hist: Dict[str, deque[float]] = defaultdict(deque)
+        self.tok_hist: Dict[str, deque[tuple[float, int]]] = defaultdict(deque)
+        self.daily: Dict[str, tuple[float, int]] = defaultdict(lambda: (_now(), 0))
+
+    def check(self, route: str, tokens: int) -> float:
+        """Check quotas for *route*. Return temperature delta."""
+        now = _now()
+        limit = self.limits.get(route)
+        if not limit:
+            return 0.0
+
+        # RPM
+        if limit.rpm is not None:
+            hist = self.req_hist[route]
+            while hist and hist[0] <= now - 60:
+                hist.popleft()
+            if len(hist) >= limit.rpm:
+                raise RateLimited
+            hist.append(now)
+            if len(hist) >= 0.9 * limit.rpm:
+                return -0.2
+
+        # TPM
+        if limit.tpm is not None:
+            thist = self.tok_hist[route]
+            while thist and thist[0][0] <= now - 60:
+                thist.popleft()
+            used = sum(t for _, t in thist)
+            if used + tokens > limit.tpm:
+                raise RateLimited
+            thist.append((now, tokens))
+            if used + tokens >= 0.9 * limit.tpm:
+                return -0.2
+
+        # RPD
+        if limit.rpd is not None:
+            day_start, count = self.daily[route]
+            if now - day_start >= 86400:
+                day_start, count = now, 0
+            if count + 1 > limit.rpd:
+                raise RateLimited
+            count += 1
+            self.daily[route] = (day_start, count)
+            if count >= 0.9 * limit.rpd:
+                return -0.2
+
+        return 0.0

--- a/gentlebot/infra/retries.py
+++ b/gentlebot/infra/retries.py
@@ -1,0 +1,28 @@
+"""Simple exponential backoff helper."""
+from __future__ import annotations
+
+import random
+import time
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
+
+
+def call_with_backoff(
+    fn: Callable[[], T],
+    retries: int = 3,
+    base: float = 0.5,
+    max_delay: float = 8.0,
+) -> T:
+    """Call *fn* with exponential backoff on transient HTTP errors."""
+    for attempt in range(retries + 1):
+        try:
+            return fn()
+        except Exception as exc:  # pragma: no cover - network
+            status = getattr(getattr(exc, "response", None), "status_code", None)
+            if status not in {408, 409, 429} and not (status and 500 <= status < 600):
+                raise
+            delay = min(max_delay, base * (2 ** attempt))
+            delay += random.uniform(0, 0.1)
+            time.sleep(delay)
+    return fn()

--- a/gentlebot/llm/providers/gemini.py
+++ b/gentlebot/llm/providers/gemini.py
@@ -1,0 +1,78 @@
+import logging
+from typing import List, Dict, Any
+from types import SimpleNamespace
+
+try:
+    from google import genai  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    class _DummyClient:
+        def __init__(self, *a, **k):
+            pass
+
+        class models:
+            @staticmethod
+            def generate_content(*a, **k):
+                raise RuntimeError("google-genai library not installed")
+
+    class _DummyTypes:
+        class GenerateContentConfig:
+            def __init__(self, *a, **k):
+                pass
+
+        class ThinkingConfig:
+            def __init__(self, *a, **k):
+                pass
+
+        class Part:
+            @staticmethod
+            def from_bytes(data: bytes, mime_type: str):
+                return data
+
+    genai = SimpleNamespace(Client=_DummyClient, types=_DummyTypes)  # type: ignore
+
+log = logging.getLogger(f"gentlebot.{__name__}")
+
+
+ROLE_MAP = {"user": "user", "assistant": "model", "system": "system"}
+
+
+class GeminiClient:
+    """Wrapper around the google-genai client."""
+
+    def __init__(self, api_key: str) -> None:
+        self.client = genai.Client(api_key=api_key)
+
+    def _convert_messages(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        parts = []
+        for m in messages:
+            role = ROLE_MAP.get(m.get("role", "user"), "user")
+            parts.append({"role": role, "parts": [m.get("content", "")]})
+        return parts
+
+    def generate(
+        self,
+        model: str,
+        messages: List[Dict[str, Any]],
+        temperature: float = 0.6,
+        json_mode: bool = False,
+        thinking_budget: int = 0,
+    ) -> Any:
+        config = genai.types.GenerateContentConfig(temperature=temperature)
+        if json_mode:
+            config.response_mime_type = "application/json"
+        if thinking_budget:
+            config.thinking = genai.types.ThinkingConfig(budget_tokens=thinking_budget)
+        content = self._convert_messages(messages)
+        response = self.client.models.generate_content(
+            model=model,
+            contents=content,
+            config=config,
+        )
+        return response
+
+    def generate_image(self, model: str, prompt: str, *images: bytes) -> Any:
+        parts = [prompt]
+        for img in images:
+            parts.append(genai.types.Part.from_bytes(img, mime_type="image/png"))
+        response = self.client.models.generate_content(model=model, contents=parts)
+        return response

--- a/gentlebot/llm/router.py
+++ b/gentlebot/llm/router.py
@@ -1,0 +1,152 @@
+"""LLM routing and observability."""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import List, Dict, Any
+
+from .providers.gemini import GeminiClient
+from ..infra.retries import call_with_backoff
+from ..infra.quotas import QuotaGuard, Limit, RateLimited
+
+log = logging.getLogger(f"gentlebot.{__name__}")
+
+
+class SafetyBlocked(Exception):
+    """Raised when content is blocked for safety."""
+
+
+class LLMRouter:
+    def __init__(self) -> None:
+        api_key = os.getenv("GEMINI_API_KEY", "test")
+        self.client = GeminiClient(api_key)
+        self.models = {
+            "general": os.getenv("MODEL_GENERAL", "gemini-2.5-flash"),
+            "scheduled": os.getenv("MODEL_SCHEDULED", "gemini-2.5-pro"),
+            "image": os.getenv("MODEL_IMAGE", "gemini-2.5-flash-image-preview"),
+        }
+        def _limit(route: str, default: Limit) -> Limit:
+            prefix = f"GEMINI_{route.upper()}_"
+            rpm = os.getenv(f"{prefix}RPM")
+            tpm = os.getenv(f"{prefix}TPM")
+            rpd = os.getenv(f"{prefix}RPD")
+            return Limit(
+                rpm=int(rpm) if rpm is not None else default.rpm,
+                tpm=int(tpm) if tpm is not None else default.tpm,
+                rpd=int(rpd) if rpd is not None else default.rpd,
+            )
+
+        self.quota = QuotaGuard(
+            {
+                "general": _limit("general", Limit(rpm=15, tpm=1_000_000, rpd=1_500)),
+                "scheduled": _limit("scheduled", Limit(rpm=2, tpm=1_000_000, rpd=1_500)),
+                "image": _limit("image", Limit(rpm=15, tpm=1_000_000, rpd=1_500)),
+            }
+        )
+
+    def _tokens_estimate(self, messages: List[Dict[str, Any]]) -> int:
+        return sum(len(m.get("content", "").split()) for m in messages)
+
+    def generate(
+        self,
+        route: str,
+        messages: List[Dict[str, Any]],
+        temperature: float = 0.6,
+        think_budget: int = 0,
+        json_mode: bool = False,
+    ) -> str:
+        model = self.models.get(route)
+        if not model:
+            raise ValueError(f"unknown route {route}")
+        tokens_in = self._tokens_estimate(messages)
+        temp_delta = self.quota.check(route, tokens_in)
+        temp = max(0.0, temperature + temp_delta)
+        start = time.time()
+
+        def _call():
+            return self.client.generate(
+                model=model,
+                messages=messages,
+                temperature=temp,
+                json_mode=json_mode,
+                thinking_budget=think_budget,
+            )
+
+        try:
+            resp = call_with_backoff(_call)
+        except RateLimited:
+            log.info(
+                "route=%s model=%s tokens_in=%s status=rate_limited", route, model, tokens_in
+            )
+            raise
+        except Exception as exc:
+            log.exception(
+                "route=%s model=%s tokens_in=%s status=error", route, model, tokens_in
+            )
+            raise
+
+        tokens_out = getattr(getattr(resp, "usage_metadata", None), "candidates_token_count", 0)
+        text = getattr(resp, "text", "")
+        status = "ok"
+        block_reason = None
+        if not text:
+            status = "blocked"
+            block_reason = getattr(resp, "prompt_feedback", None)
+            raise SafetyBlocked
+
+        total_ms = (time.time() - start) * 1000
+        log.info(
+            "route=%s model=%s tokens_in=%s tokens_out=%s ttfb_ms=0 total_ms=%s status=%s block_reason=%s",
+            route,
+            model,
+            tokens_in,
+            tokens_out,
+            int(total_ms),
+            status,
+            block_reason,
+        )
+        return text
+
+    def generate_image(self, prompt: str) -> bytes | None:
+        model = self.models.get("image")
+        if not model:
+            raise ValueError("image model not configured")
+        tokens_in = len(prompt.split())
+        self.quota.check("image", tokens_in)
+        start = time.time()
+
+        def _call():
+            return self.client.generate_image(model=model, prompt=prompt)
+
+        try:
+            resp = call_with_backoff(_call)
+        except RateLimited:
+            log.info("route=image model=%s tokens_in=%s status=rate_limited", model, tokens_in)
+            raise
+        except Exception:
+            log.exception(
+                "route=image model=%s tokens_in=%s status=error", model, tokens_in
+            )
+            raise
+
+        data = None
+        try:
+            data = resp.candidates[0].content.parts[0].inline_data.data  # type: ignore
+        except Exception:
+            data = None
+        total_ms = (time.time() - start) * 1000
+        log.info(
+            "route=image model=%s tokens_in=%s tokens_out=0 ttfb_ms=0 total_ms=%s status=%s block_reason=%s",
+            model,
+            tokens_in,
+            int(total_ms),
+            "ok" if data else "error",
+            None,
+        )
+        if data:
+            return data
+        return None
+
+
+router = LLMRouter()

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ huggingface-hub
 watchfiles
 watchdog
 APScheduler==3.10.4
+google-genai

--- a/tests/test_catchup_cog.py
+++ b/tests/test_catchup_cog.py
@@ -24,7 +24,7 @@ class DummyPool:
 
 def test_catchup_command_registration(monkeypatch):
     async def run():
-        monkeypatch.setenv("HF_API_TOKEN", "test")
+        monkeypatch.setenv("GEMINI_API_KEY", "test")
         intents = discord.Intents.none()
         bot = commands.Bot(command_prefix="!", intents=intents)
         cog = CatchupCog(bot)
@@ -47,7 +47,7 @@ def test_catchup_command_registration(monkeypatch):
 
 def test_collect_messages_uses_archive(monkeypatch):
     async def run():
-        monkeypatch.setenv("HF_API_TOKEN", "x")
+        monkeypatch.setenv("GEMINI_API_KEY", "x")
         bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
         cog = CatchupCog(bot)
         await bot.add_cog(cog)

--- a/tests/test_huggingface_cog.py
+++ b/tests/test_huggingface_cog.py
@@ -15,7 +15,7 @@ async def dummy_typing():
 
 
 def test_on_message_logs_failure_no_reply(monkeypatch):
-    monkeypatch.setenv("HF_API_TOKEN", "fake")
+    monkeypatch.setenv("GEMINI_API_KEY", "fake")
     intents = discord.Intents.none()
     bot = commands.Bot(command_prefix="!", intents=intents)
     cog = HuggingFaceCog(bot)
@@ -38,7 +38,7 @@ def test_on_message_logs_failure_no_reply(monkeypatch):
     async def raise_error(*args, **kwargs):
         raise RuntimeError("boom")
 
-    cog.call_hf = raise_error
+    cog.call_llm = raise_error
 
     asyncio.run(cog.on_message(message))
 

--- a/tests/test_prompt_cog.py
+++ b/tests/test_prompt_cog.py
@@ -6,8 +6,9 @@ from gentlebot.cogs import prompt_cog
 def test_engagement_bait_category_and_fallback(monkeypatch):
     assert "Engagement Bait" in prompt_cog.PROMPT_CATEGORIES
 
-    monkeypatch.setenv("HF_API_TOKEN", "")
+    monkeypatch.setenv("GEMINI_API_KEY", "test")
     monkeypatch.setattr(prompt_cog, "FALLBACK_PROMPTS", ["React with an emoji!"])
+    monkeypatch.setattr(prompt_cog.router, "generate", lambda *a, **k: (_ for _ in ()).throw(Exception("boom")))
 
     def fake_choice(seq):
         if seq == prompt_cog.PROMPT_CATEGORIES:
@@ -25,8 +26,9 @@ def test_engagement_bait_category_and_fallback(monkeypatch):
 def test_sports_news_category_and_fallback(monkeypatch):
     assert "Sports News" in prompt_cog.PROMPT_CATEGORIES
 
-    monkeypatch.setenv("HF_API_TOKEN", "")
+    monkeypatch.setenv("GEMINI_API_KEY", "test")
     monkeypatch.setattr(prompt_cog, "FALLBACK_PROMPTS", ["Goal or no goal?"])
+    monkeypatch.setattr(prompt_cog.router, "generate", lambda *a, **k: (_ for _ in ()).throw(Exception("boom")))
 
     async def fake_topic(self):
         return "Team X wins"
@@ -177,23 +179,8 @@ def test_duplicate_prompt_updates_message_count():
 
 
 def test_fetch_prompt_strips_outer_quotes(monkeypatch):
-    monkeypatch.setenv("HF_API_TOKEN", "token")
-
-    class DummyInferenceClient:
-        def __init__(self, provider, api_key):
-            self.chat = types.SimpleNamespace(
-                completions=types.SimpleNamespace(create=None)
-            )
-
-    async def fake_to_thread(func, *args, **kwargs):
-        msg = types.SimpleNamespace(content='"Quoted prompt"')
-        completion = types.SimpleNamespace(
-            choices=[types.SimpleNamespace(message=msg)]
-        )
-        return completion
-
-    monkeypatch.setattr(prompt_cog, "InferenceClient", DummyInferenceClient)
-    monkeypatch.setattr(prompt_cog.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setenv("GEMINI_API_KEY", "token")
+    monkeypatch.setattr(prompt_cog.router, "generate", lambda *a, **k: '"Quoted prompt"')
     monkeypatch.setattr(prompt_cog.random, "choice", lambda seq: seq[0])
 
     cog = prompt_cog.PromptCog(bot=types.SimpleNamespace())


### PR DESCRIPTION
## Summary
- tie QuotaGuard limits to each Gemini model with environment overrides
- swallow errors for scheduled prompts and hero DMs, logging instead of replying
- stub google-genai import so tests run without the dependency

## Testing
- `pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68b120b8d634832b80df43909a05249d