### PR TITLE
Retry command sync on failure

### DIFF
--- a/gentlebot/__main__.py
+++ b/gentlebot/__main__.py
@@ -64,9 +64,9 @@ async def on_ready() -> None:
         try:
             cmds = await bot.tree.sync()
             logger.info("Synced %d commands.", len(cmds))
+            _synced = True
         except Exception as e:
             logger.exception("Failed to sync commands: %s", e)
-        _synced = True
 
 @bot.event
 async def on_error(event: str, *args, **kwargs) -> None:


### PR DESCRIPTION
## Summary
- Only mark slash command sync complete after a successful `bot.tree.sync`

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68b132b44efc832b9d7a3bd527abc9d1