### PR TITLE
Run backfills sequentially to respect identify limits

### DIFF
--- a/gentlebot/__main__.py
+++ b/gentlebot/__main__.py
@@ -79,14 +79,16 @@ async def on_ready() -> None:
             backfill_roles,
         )
 
-        _backfill_tasks.extend(
-            [
-                asyncio.create_task(backfill_commands.run_backfill(days)),
-                asyncio.create_task(backfill_archive.run_backfill(days)),
-                asyncio.create_task(backfill_reactions.run_backfill(days)),
-                asyncio.create_task(backfill_roles.run_backfill()),
-            ]
-        )
+        async def _run_backfills() -> None:
+            await backfill_commands.run_backfill(days)
+            await asyncio.sleep(5)
+            await backfill_archive.run_backfill(days)
+            await asyncio.sleep(5)
+            await backfill_reactions.run_backfill(days)
+            await asyncio.sleep(5)
+            await backfill_roles.run_backfill()
+
+        _backfill_tasks.append(asyncio.create_task(_run_backfills()))
 
 @bot.event
 async def on_error(event: str, *args, **kwargs) -> None:


### PR DESCRIPTION
## Summary
- Stagger backfill logins to avoid Discord identify throttling

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68b13a34b20c832ba3abac12b8efb43e