### PR TITLE
Load .env before creating Gemini client

### DIFF
--- a/gentlebot/llm/router.py
+++ b/gentlebot/llm/router.py
@@ -9,8 +9,13 @@ from typing import List, Dict, Any
 from .providers.gemini import GeminiClient
 from ..infra.retries import call_with_backoff
 from ..infra.quotas import QuotaGuard, Limit, RateLimited
+from dotenv import load_dotenv
 
 log = logging.getLogger(f"gentlebot.{__name__}")
+
+# Ensure environment variables from a local .env are loaded so the Gemini
+# API key is available even when this module is imported before bot_config.
+load_dotenv()
 
 
 class SafetyBlocked(Exception):


### PR DESCRIPTION
## Summary
- Ensure `.env` variables are loaded in `LLMRouter` so the Gemini client receives a valid `GEMINI_API_KEY`

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_68b1cf020dd4832b82f6a3849f5c5484