### PR TITLE
Warn when GEMINI_API_KEY is missing

### DIFF
--- a/gentlebot/llm/router.py
+++ b/gentlebot/llm/router.py
@@ -24,7 +24,9 @@ class SafetyBlocked(Exception):
 
 class LLMRouter:
     def __init__(self) -> None:
-        api_key = os.getenv("GEMINI_API_KEY", "test")
+        api_key = os.getenv("GEMINI_API_KEY")
+        if api_key is None:
+            log.debug("GEMINI_API_KEY environment variable not set")
         self.client = GeminiClient(api_key)
         self.models = {
             "general": os.getenv("MODEL_GENERAL", "gemini-2.5-flash"),


### PR DESCRIPTION
## Summary
- warn if GEMINI_API_KEY env var is missing and log key length when provided
- add debug logging in Gemini LLM client for failed API calls

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_68b2311dcf9c832b97510b95376f7d1b