### PR TITLE
Log display names in presence updates

### DIFF
--- a/gentlebot/cogs/presence_archive_cog.py
+++ b/gentlebot/cogs/presence_archive_cog.py
@@ -43,7 +43,11 @@ class PresenceArchiveCog(commands.Cog):
         guild_id = getattr(after.guild, "id", None)
         if guild_id is None:
             return
-        log.info("Presence update for %s -> %s", after.id, after.raw_status)
+        log.info(
+            "Presence update for %s -> %s",
+            getattr(after, "display_name", after.id),
+            after.raw_status,
+        )
         activities = [getattr(a, "to_dict", lambda: {})() for a in after.activities]
         client_status = {
             k: v.value

--- a/tests/test_presence_archive_cog.py
+++ b/tests/test_presence_archive_cog.py
@@ -43,6 +43,7 @@ def test_presence_logged(monkeypatch, caplog):
         before = type("M", (), {
             "guild": guild,
             "id": 2,
+            "display_name": "TestUser",
             "activities": [],
             "raw_status": "offline",
             "desktop_status": discord.Status.offline,
@@ -52,6 +53,7 @@ def test_presence_logged(monkeypatch, caplog):
         after = type("M", (), {
             "guild": guild,
             "id": 2,
+            "display_name": "TestUser",
             "activities": [DummyActivity()],
             "raw_status": "online",
             "desktop_status": discord.Status.online,
@@ -60,7 +62,7 @@ def test_presence_logged(monkeypatch, caplog):
         })()
         with caplog.at_level(logging.INFO, logger="gentlebot.gentlebot.cogs.presence_archive_cog"):
             await cog.on_presence_update(before, after)
-        assert "Presence update for 2 -> online" in caplog.text
+        assert "Presence update for TestUser -> online" in caplog.text
         assert len(pool.executed) == 2
         insert_query, insert_args = pool.executed[0]
         assert "INSERT INTO discord.presence_update" in insert_query


### PR DESCRIPTION
## Summary
- log Discord presence updates using member display names
- adjust presence archive tests for display name logging

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68b233909410832bbfdeaa6ac77a2bdd