### PR TITLE
Handle Gemini system role and mute missing command errors

### DIFF
--- a/gentlebot/__main__.py
+++ b/gentlebot/__main__.py
@@ -7,6 +7,7 @@ from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
 
 import discord
+from discord import app_commands
 from discord.ext import commands
 
 from . import bot_config as cfg
@@ -30,6 +31,17 @@ console_handler.setLevel(logging.INFO)
 root_logger = logging.getLogger()
 root_logger.setLevel(level)
 root_logger.addHandler(console_handler)
+
+# Suppress noisy CommandNotFound errors from the app command tree
+class _IgnoreMissingCommand(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        exc = record.exc_info[1] if record.exc_info else None
+        return not isinstance(exc, app_commands.CommandNotFound)
+
+
+logging.getLogger("discord.app_commands.tree").addFilter(
+    _IgnoreMissingCommand()
+)
 
 logger.info(
     "Starting GentleBot in %s environment with level %s",


### PR DESCRIPTION
## Summary
- stop discord command tree from logging noisy CommandNotFound errors
- map system prompts to Gemini's `system_instruction` and use valid `user`/`model` roles

## Testing
- `python -m pytest -q`
- `python test_harness.py` *(fails: Client has not been properly initialised ... but cogs still loaded)*

------
https://chatgpt.com/codex/tasks/task_e_68b233431180832b9e9af1de56772575