### PR TITLE
Replace HuggingFace references with Gemini

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Repository Guide
 
-Gentlebot is a modular Discord bot built with **discord.py** v2. Each feature lives in a separate _cog_ under the `cogs/` folder. The bot integrates with third‑party APIs such as Hugging Face and Yahoo Finance.
+Gentlebot is a modular Discord bot built with **discord.py** v2. Each feature lives in a separate _cog_ under the `cogs/` folder. The bot integrates with third‑party APIs such as Gemini and Yahoo Finance.
 
 ## Running the bot
 1. Create a virtual environment and install the libraries listed in the README.
@@ -15,7 +15,7 @@ Gentlebot is a modular Discord bot built with **discord.py** v2. Each feature li
 
 ## Interacting with APIs
  - API tokens and IDs are read from `.env` variables. Never commit actual tokens.
- - The Hugging Face cogs require `HF_API_TOKEN` and optionally `HF_API_TOKEN_ALT` for billing fallback; other cogs may use public APIs.
+ - The Gemini cogs require `GEMINI_API_KEY`; other cogs may use public APIs.
 
 ## Tests
 Before committing run the local checks below.  Install dependencies with

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Gentlebot
-Gentlebot is a modular Discord bot composed of several **cogs** that handle different features.  It uses `discord.py` v2 and integrates with third‑party APIs such as Hugging Face and Yahoo Finance.
+Gentlebot is a modular Discord bot composed of several **cogs** that handle different features.  It uses `discord.py` v2 and integrates with third‑party APIs such as Gemini and Yahoo Finance.
 
 ## Features
 - **SportsCog** – `/nextf1` and `/f1standings` plus `/bigdumper` for Mariners stats.
@@ -9,12 +9,12 @@ Gentlebot is a modular Discord bot composed of several **cogs** that handle diff
   Admins can still run `/refreshroles` to fetch 14 days of history and refresh
   roles manually. Ensure the bot's role is above these vanity roles and has the
   **Manage Roles** permission so it can assign and remove them.
-- **PromptCog** – Posts a daily prompt generated via the Hugging Face API at
+- **PromptCog** – Posts a daily prompt generated via the Gemini API at
   12:30 pm Pacific time by default. Categories rotate randomly among recent
   server discussion, general sports news, and engagement bait without
   repeating recent types. The rotation state persists in
   `prompt_state.json` so redeployments keep things fresh.
-- **HuggingFaceCog** – Adds AI conversation and emoji reactions using Hugging Face models.
+- **GeminiCog** – Adds AI conversation and emoji reactions using Gemini models.
 - **StatsCog** – `/engagement` now replies "Working on it..." and then gathers
   unlimited history in the background before posting the stats and optional
   activity chart.
@@ -29,7 +29,7 @@ gentlebot/cogs/               # feature cogs
   sports_cog.py     # F1 and baseball commands
   market_cog.py     # market commands and weekly game
   prompt_cog.py     # daily prompts
-  huggingface_cog.py # conversation + emoji reactions
+  gemini_cog.py    # conversation + emoji reactions
   stats_cog.py      # engagement statistics
 scripts/start.sh   # container entrypoint
 setup.sh           # install dependencies and create the venv
@@ -45,9 +45,7 @@ setup.sh           # install dependencies and create the venv
    DISCORD_GUILD_ID=<guild id>
     ALPHA_VANTAGE_KEY=<alpha vantage api key>
    MONEY_TALK_CHANNEL=<market channel id>
-   HF_API_TOKEN=<hugging face token>
-   # optional fallback if the primary token hits a billing error
-   HF_API_TOKEN_ALT=<secondary hugging face token>
+   GEMINI_API_KEY=<gemini api key>
    # optional Postgres credentials for logging
    PG_HOST=db
    PG_PORT=5432
@@ -143,9 +141,8 @@ roles at 08:30 PT.
 
 ## Notes
 - `BOT_ENV` controls whether `bot_config.py` loads **TEST** or **PROD** IDs.
- - The Hugging Face cogs require an API key in `HF_API_TOKEN` and optionally `HF_MODEL`.
-   You can provide a backup key in `HF_API_TOKEN_ALT` which will be used if the
-   primary token hits a billing error.
+ - Gemini features require a `GEMINI_API_KEY`. Optional overrides like `MODEL_GENERAL`
+   can customize which Gemini model is used.
  - Set `PG_DSN` (or PG_* creds) to enable writing bot logs to a Postgres database.
 
 ## Contributing

--- a/gentlebot/cogs/catchup_cog.py
+++ b/gentlebot/cogs/catchup_cog.py
@@ -139,7 +139,7 @@ class CatchupCog(commands.Cog):
         try:
             summary = await self._summarize(messages, style)
         except Exception as exc:
-            log.exception("HF summarization failed: %s", exc)
+            log.exception("Gemini summarization failed: %s", exc)
             summary = "⚠️ Unable to generate summary at this time."
         await interaction.response.send_message(summary[:1900], ephemeral=ephemeral)
 

--- a/gentlebot/cogs/gemini_cog.py
+++ b/gentlebot/cogs/gemini_cog.py
@@ -1,4 +1,4 @@
-"""HuggingFace-powered conversational responses and emoji reactions."""
+"""Gemini-powered conversational responses and emoji reactions."""
 
 import re
 import time
@@ -19,7 +19,7 @@ from ..infra.quotas import RateLimited
 log = logging.getLogger(f"gentlebot.{__name__}")
 
 
-class HuggingFaceCog(commands.Cog):
+class GeminiCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
 
@@ -129,8 +129,9 @@ class HuggingFaceCog(commands.Cog):
 
     async def choose_emoji_llm(self, message_content: str, available_emojis: list[str]) -> str | None:
         """
-        Ask the HF model to select an emoji from the provided available_emojis list that humorously reacts to the message_content.
-        Returns the selected emoji string from available_emojis, or None on failure.
+        Ask the Gemini model to select an emoji from the provided available_emojis list
+        that humorously reacts to the message_content. Returns the selected emoji string
+        from available_emojis, or None on failure.
         """
         emoji_list_str = ", ".join(available_emojis)
         prompt = (
@@ -145,7 +146,7 @@ class HuggingFaceCog(commands.Cog):
                     return emoji
             return None
         except Exception as e:
-            log.exception("HF emoji selection failed: %s", e)
+            log.exception("Gemini emoji selection failed: %s", e)
             return None
 
     @commands.Cog.listener()
@@ -283,4 +284,4 @@ class HuggingFaceCog(commands.Cog):
                 await interaction.followup.send(chunk)
 
 async def setup(bot: commands.Bot):
-    await bot.add_cog(HuggingFaceCog(bot))
+    await bot.add_cog(GeminiCog(bot))

--- a/gentlebot/cogs/prompt_cog.py
+++ b/gentlebot/cogs/prompt_cog.py
@@ -201,7 +201,7 @@ class PromptCog(commands.Cog):
         self.pool = None
 
     async def fetch_prompt(self) -> str:
-        """Generate a new prompt via HF inference, including history."""
+        """Generate a new prompt via Gemini inference, including history."""
         category = random.choice(PROMPT_CATEGORIES)
         self.last_category = category
         messages = [

--- a/gentlebot/tasks/daily_hero_dm.py
+++ b/gentlebot/tasks/daily_hero_dm.py
@@ -108,7 +108,7 @@ class DailyHeroDMCog(commands.Cog):
             return self._fallback(display_name, wins)
 
         if not self._is_valid(text):
-            log.debug("Invalid HF message '%s'; using fallback", text)
+            log.debug("Invalid Gemini message '%s'; using fallback", text)
             return self._fallback(display_name, wins)
         return text
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ beautifulsoup4
 yfinance
 matplotlib
 pandas
-huggingface-hub
 watchfiles
 watchdog
 APScheduler==3.10.4

--- a/test_harness.py
+++ b/test_harness.py
@@ -5,7 +5,7 @@ import os
 import discord
 
 os.environ.setdefault("env", "TEST")
-os.environ.setdefault("HF_API_TOKEN", "dummy")
+os.environ.setdefault("GEMINI_API_KEY", "dummy")
 os.environ.setdefault("DISCORD_TOKEN", "dummy")
 os.environ.setdefault("PG_DSN", "")
 os.environ.pop("PG_USER", None)

--- a/tests/test_gemini_cog.py
+++ b/tests/test_gemini_cog.py
@@ -5,8 +5,8 @@ from unittest.mock import AsyncMock, MagicMock
 import discord
 from discord.ext import commands
 
-import gentlebot.cogs.huggingface_cog as hf_cog
-from gentlebot.cogs.huggingface_cog import HuggingFaceCog
+import gentlebot.cogs.gemini_cog as gemini_cog
+from gentlebot.cogs.gemini_cog import GeminiCog
 
 
 @asynccontextmanager
@@ -18,7 +18,7 @@ def test_on_message_logs_failure_no_reply(monkeypatch):
     monkeypatch.setenv("GEMINI_API_KEY", "fake")
     intents = discord.Intents.none()
     bot = commands.Bot(command_prefix="!", intents=intents)
-    cog = HuggingFaceCog(bot)
+    cog = GeminiCog(bot)
     cog.mention_strs = ["<@123>"]
 
     message = MagicMock(spec=discord.Message)
@@ -33,7 +33,7 @@ def test_on_message_logs_failure_no_reply(monkeypatch):
     message.channel.typing.return_value = dummy_typing()
     message.reply = AsyncMock()
 
-    monkeypatch.setattr(hf_cog.random, "random", lambda: 1)
+    monkeypatch.setattr(gemini_cog.random, "random", lambda: 1)
 
     async def raise_error(*args, **kwargs):
         raise RuntimeError("boom")


### PR DESCRIPTION
## Summary
- rename HuggingFaceCog to GeminiCog and update related tests
- document Gemini usage and GEMINI_API_KEY setup
- drop huggingface-hub dependency and update Gemini references across cogs

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2328bc070832bb9e54a12766a35ee