### PR TITLE
Improve Gemini image parsing

### DIFF
--- a/tests/test_router_image.py
+++ b/tests/test_router_image.py
@@ -1,0 +1,34 @@
+from types import SimpleNamespace
+
+from gentlebot.llm.router import LLMRouter
+
+
+def test_generate_image_returns_final_image(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "fake")
+    router = LLMRouter()
+
+    class DummyQuota:
+        def check(self, *a, **k):
+            return None
+
+    router.quota = DummyQuota()
+
+    def fake_generate_image(model: str, prompt: str):
+        return SimpleNamespace(
+            candidates=[
+                SimpleNamespace(
+                    content=SimpleNamespace(
+                        parts=[
+                            SimpleNamespace(text="notice"),
+                            SimpleNamespace(inline_data=SimpleNamespace(data=b"img1")),
+                            SimpleNamespace(text="ignored"),
+                            SimpleNamespace(inline_data=SimpleNamespace(data=b"img2")),
+                        ]
+                    )
+                )
+            ]
+        )
+
+    router.client.generate_image = fake_generate_image
+    data = router.generate_image("test")
+    assert data == b"img2"


### PR DESCRIPTION
## Summary
- parse Gemini image responses for last inline data part
- add test ensuring only final image is returned

## Testing
- `pytest -q`
- `python test_harness.py` *(fails: RuntimeError: Client has not been properly initialised. Please use the login method or asynchronous context manager before calling this method)*

------
https://chatgpt.com/codex/tasks/task_e_68b2394e01f8832b907fc5acd1650f0e