### PR TITLE
Log friendly display names

### DIFF
--- a/gentlebot/backfill_archive.py
+++ b/gentlebot/backfill_archive.py
@@ -12,6 +12,7 @@ from discord.ext import commands
 
 from gentlebot import bot_config as cfg
 from gentlebot.cogs.message_archive_cog import MessageArchiveCog
+from gentlebot.util import chan_name
 
 log = logging.getLogger("gentlebot.backfill")
 
@@ -64,7 +65,9 @@ class BackfillBot(commands.Bot):
                 try:
                     self.counts["channel"] += await self.archive._upsert_channel(channel)
                 except Exception as exc:
-                    log.exception("Failed to record channel %s: %s", channel.name, exc)
+                    log.exception(
+                        "Failed to record channel %s: %s", chan_name(channel), exc
+                    )
                     continue
                 try:
                     async for msg in channel.history(limit=None, after=cutoff):
@@ -76,9 +79,17 @@ class BackfillBot(commands.Bot):
                         except Exception as msg_exc:
                             log.exception("Failed to record message %s: %s", msg.id, msg_exc)
                 except discord.Forbidden as exc:
-                    log.warning("History fetch failed for channel %s: %s", channel.name, exc)
+                      log.warning(
+                          "History fetch failed for channel %s: %s",
+                          chan_name(channel),
+                          exc,
+                      )
                 except Exception as exc:  # pragma: no cover - best effort logging
-                    log.exception("History fetch failed for channel %s: %s", channel.name, exc)
+                      log.exception(
+                          "History fetch failed for channel %s: %s",
+                          chan_name(channel),
+                          exc,
+                      )
 
 
 def parse_args() -> argparse.Namespace:

--- a/gentlebot/backfill_commands.py
+++ b/gentlebot/backfill_commands.py
@@ -12,7 +12,7 @@ import discord
 from discord.ext import commands
 
 from gentlebot import bot_config as cfg
-from gentlebot.util import build_db_url, rows_from_tag
+from gentlebot.util import build_db_url, rows_from_tag, chan_name
 
 log = logging.getLogger("gentlebot.backfill_commands")
 
@@ -86,9 +86,11 @@ class BackfillBot(commands.Bot):
                             )
                             self.inserted += rows_from_tag(result)
                 except discord.Forbidden:
-                    log.warning("History fetch forbidden for %s", channel)
+                    log.warning("History fetch forbidden for %s", chan_name(channel))
                 except Exception as exc:  # pragma: no cover - logging only
-                    log.exception("History fetch failed for %s: %s", channel, exc)
+                    log.exception(
+                        "History fetch failed for %s: %s", chan_name(channel), exc
+                    )
 
 
 def parse_args() -> argparse.Namespace:

--- a/gentlebot/cogs/gemini_cog.py
+++ b/gentlebot/cogs/gemini_cog.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 import discord
 from discord import app_commands
 from discord.ext import commands
-from ..util import chan_name
+from ..util import chan_name, user_name
 from ..llm.router import router, SafetyBlocked
 from ..infra.quotas import RateLimited
 
@@ -265,7 +265,7 @@ class GeminiCog(commands.Cog):
     @app_commands.command(name="ask", description="Ask Gentlebot a question.")
     async def ask(self, interaction: discord.Interaction, prompt: str):
         """Slash command to ask Gentlebot a question."""
-        log.info("/ask invoked by %s in %s", interaction.user.id, chan_name(interaction.channel))
+        log.info("/ask invoked by %s in %s", user_name(interaction.user), chan_name(interaction.channel))
         await interaction.response.defer()
         sanitized = self.sanitize_prompt(prompt)
         if not sanitized:

--- a/gentlebot/cogs/gentlebot_cog.py
+++ b/gentlebot/cogs/gentlebot_cog.py
@@ -11,7 +11,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-from ..util import chan_name
+from ..util import chan_name, user_name
 
 log = logging.getLogger(f"gentlebot.{__name__}")
 
@@ -30,7 +30,7 @@ class GentlebotCog(commands.Cog):
         """Echo the supplied text into the current channel."""
         log.info(
             "/gentlebot invoked by %s in %s: %s",
-            interaction.user.id,
+            user_name(interaction.user),
             chan_name(interaction.channel),
             say,
         )

--- a/gentlebot/cogs/market_cog.py
+++ b/gentlebot/cogs/market_cog.py
@@ -30,7 +30,7 @@ from zoneinfo import ZoneInfo
 import discord
 from discord import app_commands
 from discord.ext import commands, tasks
-from ..util import chan_name
+from ..util import chan_name, user_name
 import matplotlib
 matplotlib.use("Agg")  # headless
 import matplotlib.pyplot as plt
@@ -134,7 +134,7 @@ class MarketCog(commands.Cog):
     @app_commands.describe(symbol="Ticker symbol", period="Time period")
     @app_commands.choices(period=[app_commands.Choice(name=n, value=v) for n,v in period_choices])
     async def stock(self, itx: discord.Interaction, symbol: str, period: app_commands.Choice[str]):
-        log.info("/stock invoked by %s in %s", itx.user.id, chan_name(itx.channel))
+        log.info("/stock invoked by %s in %s", user_name(itx.user), chan_name(itx.channel))
         await itx.response.defer(thinking=True)
         symbol = symbol.upper()
         tk = yf.Ticker(symbol)
@@ -172,7 +172,7 @@ class MarketCog(commands.Cog):
     @app_commands.command(name="earnings", description="Next earnings date for a ticker")
     @app_commands.describe(symbol="Ticker symbol")
     async def earnings(self, itx: discord.Interaction, symbol: str):
-        log.info("/earnings invoked by %s in %s", itx.user.id, chan_name(itx.channel))
+        log.info("/earnings invoked by %s in %s", user_name(itx.user), chan_name(itx.channel))
         await itx.response.defer(thinking=True)
         tk = yf.Ticker(symbol.upper())
         try:
@@ -392,7 +392,7 @@ class MarketCog(commands.Cog):
     @app_commands.command(name="marketmood", description="US market sentiment snapshot")
     @app_commands.describe(ephemeral="Only you can see the response")
     async def marketmood(self, itx: discord.Interaction, ephemeral: Optional[bool] = False):
-        log.info("/marketmood invoked by %s in %s", itx.user.id, chan_name(itx.channel))
+        log.info("/marketmood invoked by %s in %s", user_name(itx.user), chan_name(itx.channel))
         await itx.response.defer(thinking=True, ephemeral=ephemeral)
         data = await self._gather_data()
         ts = data["timestamp"].astimezone(PT_TZ).strftime("%b %d, %-I:%M %p PT")
@@ -426,7 +426,7 @@ class MarketCog(commands.Cog):
     @app_commands.command(name="marketbet", description="Place a weekly bull/bear bet or set reminder")
     @app_commands.describe(direction="bullish or bearish", reminder="Enable DM reminder on Monday")
     async def marketbet(self, itx: discord.Interaction, direction: Optional[Literal["bullish", "bearish"]] = None, reminder: Optional[bool] = None):
-        log.info("/marketbet invoked by %s in %s", itx.user.id, chan_name(itx.channel))
+        log.info("/marketbet invoked by %s in %s", user_name(itx.user), chan_name(itx.channel))
         await itx.response.defer(thinking=True, ephemeral=True)
         now = datetime.now(NY_TZ)
         week_start = _week_start(now)

--- a/gentlebot/cogs/prompt_cog.py
+++ b/gentlebot/cogs/prompt_cog.py
@@ -23,7 +23,7 @@ from datetime import datetime, timedelta
 from collections import deque
 import discord
 from discord.ext import commands
-from ..util import chan_name
+from ..util import chan_name, user_name
 from ..db import get_pool
 from .. import bot_config as cfg
 from ..llm.router import router, SafetyBlocked
@@ -425,7 +425,7 @@ class PromptCog(commands.Cog):
 
     @commands.command(name='skip_prompt')
     async def skip_prompt(self, ctx: commands.Context):
-        log.info("skip_prompt invoked by %s in %s", ctx.author.id, chan_name(ctx.channel))
+        log.info("skip_prompt invoked by %s in %s", user_name(ctx.author), chan_name(ctx.channel))
         prompt = await self.fetch_prompt()
         await ctx.send(f"{prompt}")
 

--- a/gentlebot/cogs/sports_cog.py
+++ b/gentlebot/cogs/sports_cog.py
@@ -22,7 +22,7 @@ import asyncio
 import discord
 from discord import app_commands
 from discord.ext import commands
-from ..util import chan_name
+from ..util import chan_name, user_name
 import requests
 from dateutil import parser
 import pytz
@@ -315,7 +315,7 @@ class SportsCog(commands.Cog):
     # --- Cal Raleigh command -------------------------------------------------
     @app_commands.command(name="bigdumper", description="Cal Raleigh stats and latest homer")
     async def bigdumper(self, interaction: discord.Interaction):
-        log.info("/bigdumper invoked by %s in %s", interaction.user.id, chan_name(interaction.channel))
+        log.info("/bigdumper invoked by %s in %s", user_name(interaction.user), chan_name(interaction.channel))
         await interaction.response.defer(thinking=True)
         embed = await self.build_bigdumper_embed()
         if embed is None:
@@ -326,7 +326,7 @@ class SportsCog(commands.Cog):
     @app_commands.command(name="nextf1", description="Show the next F1 race weekend preview with track map")
     async def nextf1(self, interaction: discord.Interaction):
         """Show embed for next race weekend."""
-        log.info("/nextf1 invoked by %s in %s", interaction.user.id, chan_name(interaction.channel))
+        log.info("/nextf1 invoked by %s in %s", user_name(interaction.user), chan_name(interaction.channel))
         await interaction.response.defer(thinking=True)
         now = datetime.now(timezone.utc)
         sessions = self.fetch_f1_schedule()
@@ -342,7 +342,7 @@ class SportsCog(commands.Cog):
 
     @app_commands.command(name="f1standings", description="Show current F1 driver & constructor standings")
     async def f1standings(self, interaction: discord.Interaction):
-        log.info("/f1standings invoked by %s in %s", interaction.user.id, chan_name(interaction.channel))
+        log.info("/f1standings invoked by %s in %s", user_name(interaction.user), chan_name(interaction.channel))
         await interaction.response.defer(thinking=True)
         drivers, constructors = self.fetch_f1_standings()
         if not drivers and not constructors:

--- a/gentlebot/cogs/stats_cog.py
+++ b/gentlebot/cogs/stats_cog.py
@@ -17,7 +17,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from .. import bot_config as cfg
-from ..util import chan_name
+from ..util import chan_name, user_name
 
 # Use a hierarchical logger so messages propagate to the main gentlebot logger
 log = logging.getLogger(f"gentlebot.{__name__}")
@@ -413,7 +413,7 @@ class StatsCog(commands.Cog):
     ):
         log.info(
             "/engagement invoked by %s in %s",
-            interaction.user.id,
+            user_name(interaction.user),
             chan_name(interaction.channel),
         )
         await interaction.response.send_message("Working on it...")

--- a/gentlebot/cogs/techmeme_cog.py
+++ b/gentlebot/cogs/techmeme_cog.py
@@ -15,7 +15,7 @@ from discord.ext import commands
 import feedparser
 from bs4 import BeautifulSoup
 
-from ..util import chan_name
+from ..util import chan_name, user_name
 
 # Use a hierarchical logger so messages propagate to the main gentlebot logger
 log = logging.getLogger(f"gentlebot.{__name__}")
@@ -32,7 +32,7 @@ class TechmemeCog(commands.Cog):
     @app_commands.command(name="techmeme", description="Show the latest Techmeme headlines")
     @app_commands.describe(ephemeral="Whether the response should be ephemeral")
     async def techmeme(self, interaction: discord.Interaction, ephemeral: bool = False):
-        log.info("/techmeme invoked by %s in %s", interaction.user.id, chan_name(interaction.channel))
+        log.info("/techmeme invoked by %s in %s", user_name(interaction.user), chan_name(interaction.channel))
         await interaction.response.defer(thinking=True, ephemeral=ephemeral)
         try:
             feed = await asyncio.to_thread(feedparser.parse, TECHMEME_RSS)

--- a/gentlebot/cogs/test_logging_cog.py
+++ b/gentlebot/cogs/test_logging_cog.py
@@ -3,7 +3,7 @@ import logging
 
 import discord
 from discord.ext import commands
-from ..util import chan_name
+from ..util import chan_name, user_name
 
 # Use the same logger as main.py so handlers are attached
 log = logging.getLogger("gentlebot")
@@ -25,20 +25,30 @@ class TestLoggingCog(commands.Cog):
         if interaction.type is discord.InteractionType.application_command:
             data = interaction.data or {}
             name = data.get("name")
-            log.info("[TEST] Slash command /%s by %s in %s", name, interaction.user.id, chan_name(interaction.channel))
+            log.info(
+                "[TEST] Slash command /%s by %s in %s",
+                name,
+                user_name(interaction.user),
+                chan_name(interaction.channel),
+            )
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
         if message.author.bot:
             return
-        log.info("[TEST] Message from %s in %s: %s", message.author.id, chan_name(message.channel), message.content.replace('\n', ' '))
+        log.info(
+            "[TEST] Message from %s in %s: %s",
+            user_name(message.author),
+            chan_name(message.channel),
+            message.content.replace("\n", " "),
+        )
 
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
         log.info(
             "[TEST] Reaction %s added by %s to %s in %s",
             str(payload.emoji),
-            payload.user_id,
+            user_name(self.bot.get_user(payload.user_id) or payload.user_id),
             payload.message_id,
             chan_name(self.bot.get_channel(payload.channel_id)),
         )

--- a/gentlebot/cogs/version_cog.py
+++ b/gentlebot/cogs/version_cog.py
@@ -12,7 +12,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from ..version import VERSION
-from ..util import chan_name
+from ..util import chan_name, user_name
 
 # Use a hierarchical logger so messages propagate to the main gentlebot logger
 log = logging.getLogger(f"gentlebot.{__name__}")
@@ -27,7 +27,11 @@ class VersionCog(commands.Cog):
     @app_commands.command(name="version", description="Show the current bot version")
     async def version(self, interaction: discord.Interaction):
         """Reply with the Git commit hash of the running bot."""
-        log.info("/version invoked by %s in %s", interaction.user.id, chan_name(interaction.channel))
+        log.info(
+            "/version invoked by %s in %s",
+            user_name(interaction.user),
+            chan_name(interaction.channel),
+        )
         await interaction.response.send_message(
             f"Gentlebot version: {VERSION}", ephemeral=True
         )

--- a/gentlebot/cogs/vibecheck_cog.py
+++ b/gentlebot/cogs/vibecheck_cog.py
@@ -16,7 +16,7 @@ from datetime import datetime, timedelta, timezone
 import discord
 from discord import app_commands
 from discord.ext import commands
-from ..util import chan_name
+from ..util import chan_name, user_name
 from .. import bot_config as cfg
 from ..llm.router import router, SafetyBlocked
 from ..infra.quotas import RateLimited
@@ -169,7 +169,11 @@ class VibeCheckCog(commands.Cog):
     @app_commands.command(name="vibecheck", description="Check the server vibe")
     async def vibecheck(self, interaction: discord.Interaction):
         """Return a quick read on how things feel in the server."""
-        log.info("/vibecheck invoked by %s in %s", interaction.user.id, chan_name(interaction.channel))
+        log.info(
+            "/vibecheck invoked by %s in %s",
+            user_name(interaction.user),
+            chan_name(interaction.channel),
+        )
         now = time.time()
         if self._cache and now - self._cache[0] < 60:
             await interaction.response.send_message(embed=self._cache[1])

--- a/gentlebot/tasks/daily_digest.py
+++ b/gentlebot/tasks/daily_digest.py
@@ -12,7 +12,7 @@ import discord
 from discord.ext import commands
 
 from .. import bot_config as cfg
-from ..util import build_db_url, ReactionAction
+from ..util import build_db_url, ReactionAction, user_name
 
 log = logging.getLogger(f"gentlebot.{__name__}")
 
@@ -220,14 +220,22 @@ class DailyDigestCog(commands.Cog):
         top_msgs = await self._top_posters(14)
         top_reacts = await self._reaction_magnets(14)
         hero_candidates = await self._yesterday_top_poster()
-        log.debug("Hero candidates: %s", hero_candidates)
+        log.debug(
+            "Hero candidates: %s",
+            [user_name(guild.get_member(uid) or uid) for uid, _ in hero_candidates],
+        )
         hero: int | None = None
         for uid, _ in hero_candidates:
             last = await self._last_hero_time(uid)
-            log.debug("Evaluating candidate %s with last hero time %s", uid, last)
+            name = user_name(guild.get_member(uid) or uid)
+            log.debug(
+                "Evaluating candidate %s with last hero time %s",
+                name,
+                last,
+            )
             if not last or last <= datetime.now(tz=LA) - timedelta(hours=72):
                 hero = uid
-                log.debug("Selected Daily Hero: %s", uid)
+                log.debug("Selected Daily Hero: %s", name)
                 break
         if hero is None:
             log.debug("No eligible Daily Hero found")

--- a/gentlebot/util.py
+++ b/gentlebot/util.py
@@ -10,6 +10,7 @@ class ReactionAction(IntEnum):
     MESSAGE_REACTION_ADD = 0
     MESSAGE_REACTION_REMOVE = 1
 
+
 def build_db_url() -> str | None:
     """Return a Postgres DSN built from env vars."""
     url = os.getenv("PG_DSN") or os.getenv("DATABASE_URL")
@@ -22,15 +23,45 @@ def build_db_url() -> str | None:
         return f"postgresql+asyncpg://{user}:{pwd}@db:5432/{db}"
     return None
 
+
+def user_name(user: discord.abc.Snowflake | int | None) -> str:
+    """Return a user's display name or fallback to their ID."""
+    if user is None:
+        return "unknown"
+    if isinstance(user, int):
+        return str(user)
+    name = getattr(user, "display_name", None) or getattr(user, "name", None)
+    if name:
+        return name
+    uid = getattr(user, "id", None)
+    return str(uid) if uid is not None else "unknown"
+
+
 def chan_name(channel: discord.abc.Connectable | None) -> str:
     """Return a readable channel name or fallback to ID."""
     if channel is None:
         return "unknown"
     name = getattr(channel, "name", None)
     if name:
-        return name
+        return f"#{name}"
+    recipient = getattr(channel, "recipient", None)
+    if recipient:
+        return f"DM with {user_name(recipient)}"
     channel_id = getattr(channel, "id", None)
     return str(channel_id) if channel_id is not None else "unknown"
+
+
+def guild_name(guild: discord.abc.Snowflake | int | None) -> str:
+    """Return a guild's name or fallback to ID."""
+    if guild is None:
+        return "unknown"
+    if isinstance(guild, int):
+        return str(guild)
+    name = getattr(guild, "name", None)
+    if name:
+        return name
+    gid = getattr(guild, "id", None)
+    return str(gid) if gid is not None else "unknown"
 
 
 def int_env(var: str, default: int = 0) -> int:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,8 @@
 import pytest
 
-from gentlebot.util import rows_from_tag
+from types import SimpleNamespace
+
+from gentlebot.util import chan_name, guild_name, rows_from_tag, user_name
 
 @pytest.mark.parametrize("tag,expected", [
     ("INSERT 0 1", 1),
@@ -10,3 +12,18 @@ from gentlebot.util import rows_from_tag
 ])
 def test_rows_from_tag(tag, expected):
     assert rows_from_tag(tag) == expected
+
+
+def test_user_name_display_preferred():
+    obj = SimpleNamespace(display_name="Tester", id=42)
+    assert user_name(obj) == "Tester"
+
+
+def test_chan_name_prefixes_hash():
+    chan = SimpleNamespace(name="general")
+    assert chan_name(chan) == "#general"
+
+
+def test_guild_name_from_name():
+    guild = SimpleNamespace(name="Gentlefolk")
+    assert guild_name(guild) == "Gentlefolk"


### PR DESCRIPTION
## Summary
- Log user, channel, and guild display names instead of raw IDs
- Add helpers for user, channel, and guild name lookup
- Cover new helpers with unit tests

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68b23b9f8484832b8481ad3316c818e4