### PR TITLE
Add Gentlebot persona system instruction for Gemini API

### DIFF
--- a/gentlebot/llm/providers/gemini.py
+++ b/gentlebot/llm/providers/gemini.py
@@ -33,8 +33,8 @@ except Exception:  # pragma: no cover - optional dependency
 log = logging.getLogger(f"gentlebot.{__name__}")
 
 
-# Gemini only accepts "user" or "model" roles; "system" prompts are coerced to
-# a "user" role because google-genai v1.32.0 lacks a dedicated parameter.
+# Gemini accepts only ``user`` or ``model`` roles; map assistant messages to
+# ``model`` and treat all others as ``user``.
 ROLE_MAP = {"user": "user", "assistant": "model"}
 
 
@@ -86,8 +86,11 @@ class GeminiClient:
         temperature: float = 0.6,
         json_mode: bool = False,
         thinking_budget: int = 0,
+        system_instruction: str | None = None,
     ) -> Any:
-        config = genai.types.GenerateContentConfig(temperature=temperature)
+        config = genai.types.GenerateContentConfig(
+            temperature=temperature, system_instruction=system_instruction
+        )
         if json_mode:
             config.response_mime_type = "application/json"
         if thinking_budget:

--- a/gentlebot/llm/router.py
+++ b/gentlebot/llm/router.py
@@ -78,8 +78,13 @@ class LLMRouter:
             }
         )
 
-    def _tokens_estimate(self, messages: List[Dict[str, Any]]) -> int:
-        return sum(len(m.get("content", "").split()) for m in messages)
+    def _tokens_estimate(
+        self, messages: List[Dict[str, Any]], system_instruction: str | None = None
+    ) -> int:
+        count = sum(len(m.get("content", "").split()) for m in messages)
+        if system_instruction:
+            count += len(system_instruction.split())
+        return count
 
     def generate(
         self,
@@ -92,7 +97,7 @@ class LLMRouter:
         model = self.models.get(route)
         if not model:
             raise ValueError(f"unknown route {route}")
-        tokens_in = self._tokens_estimate(messages)
+        tokens_in = self._tokens_estimate(messages, SYSTEM_INSTRUCTION)
         temp_delta = self.quota.check(route, tokens_in)
         temp = max(0.0, temperature + temp_delta)
         start = time.time()

--- a/gentlebot/llm/router.py
+++ b/gentlebot/llm/router.py
@@ -18,6 +18,32 @@ log = logging.getLogger(f"gentlebot.{__name__}")
 load_dotenv()
 
 
+SYSTEM_INSTRUCTION = (
+    "You are Gentlebot, a Discord copilot/robot for the Gentlefolk community.\n\n"
+    "Personality and voice:\n"
+    "- Calm, concise, factual. Default to 2-5 sentences.\n"
+    "- Lead with the answer. No filler, no exclamation points.\n"
+    "- Friendly but dry. One light touch of humor only if it increases clarity.\n"
+    "- Never role-play a human. State uncertainty plainly: \"Unknown\" or \"I don't have evidence for that.\"\n\n"
+    "Interaction rules:\n"
+    "- If the request is clear, act. If information is missing, do not ask questions; give 2-3 viable next steps the user can choose.\n"
+    "- Prefer synthesis over summary. When useful, return a one-screen TL;DR, then details.\n"
+    "- For how-to requests: output numbered steps first, then notes.\n"
+    "- For code: give minimal, runnable examples with language-tagged fences; add comments sparingly.\n"
+    "- Avoid flooding: keep under ~1200 characters per message when possible. Offer \"Send full version?\" if longer.\n"
+    "- Discord etiquette: never use @everyone/@here; only @mention the requester.\n\n"
+    "Truth and sources:\n"
+    "- Do not guess or invent. If a claim isn't solid, mark it as speculative or decline.\n"
+    "- When using external facts, provide links or clear citations.\n"
+    "- Red-team your own outputs for safety, legality, and privacy. Refuse unsafe or disallowed content.\n\n"
+    "Style constraints:\n"
+    "- No emojis unless asked. No markdown tables unless asked. Bullets or numbers for structure.\n"
+    "- No moralizing or personal opinions. Present trade-offs and probabilities where relevant.\n\n"
+    "Tools:\n"
+    "- No access to tools in this environment."
+)
+
+
 class SafetyBlocked(Exception):
     """Raised when content is blocked for safety."""
 
@@ -78,6 +104,7 @@ class LLMRouter:
                 temperature=temp,
                 json_mode=json_mode,
                 thinking_budget=think_budget,
+                system_instruction=SYSTEM_INSTRUCTION,
             )
 
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ pandas
 watchfiles
 watchdog
 APScheduler==3.10.4
-google-genai
+google-genai>=1.32.0

--- a/tests/test_llm_system_instruction.py
+++ b/tests/test_llm_system_instruction.py
@@ -1,0 +1,30 @@
+"""Ensure LLMRouter sends the Gentlebot persona as system instruction."""
+from types import SimpleNamespace
+
+import gentlebot.llm.router as llm_router
+
+
+def test_router_includes_system_instruction(monkeypatch):
+    captured: dict[str, str | None] = {}
+
+    def fake_generate(
+        self,
+        model: str,
+        messages,
+        temperature: float = 0.6,
+        json_mode: bool = False,
+        thinking_budget: int = 0,
+        system_instruction: str | None = None,
+    ):
+        captured["system_instruction"] = system_instruction
+        return SimpleNamespace(text="ok", usage_metadata=SimpleNamespace(candidates_token_count=0))
+
+    monkeypatch.setattr(llm_router.GeminiClient, "generate", fake_generate)
+
+    router = llm_router.LLMRouter()
+    router.generate("general", [{"content": "hi"}])
+
+    assert captured["system_instruction"].startswith(
+        "You are Gentlebot, a Discord copilot/robot for the Gentlefolk community."
+    )
+


### PR DESCRIPTION
## Summary
- send Gentlebot's personality rules as a system instruction on every Gemini request
- plumb system instruction support through Gemini client and require recent google-genai
- add test covering system instruction forwarding

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68b23d44c850832b9273c66e7098955c