### PR TITLE
feat(image): friendly error messages

### DIFF
--- a/tests/test_image_cog.py
+++ b/tests/test_image_cog.py
@@ -1,6 +1,10 @@
 import asyncio
 import discord
 from discord.ext import commands
+from types import SimpleNamespace
+
+from gentlebot.cogs import image_cog
+from gentlebot.infra.quotas import RateLimited
 
 def test_image_cog_loads(monkeypatch):
     monkeypatch.setenv("GEMINI_API_KEY", "fake")
@@ -10,4 +14,84 @@ def test_image_cog_loads(monkeypatch):
         await bot.load_extension("gentlebot.cogs.image_cog")
         assert bot.get_cog("ImageCog") is not None
         await bot.close()
+    asyncio.run(run())
+
+
+class DummyResponse:
+    def __init__(self):
+        self.deferred = False
+
+    async def defer(self, *, thinking=True):
+        self.deferred = True
+
+
+class DummyFollowup:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, message=None, **_):
+        self.sent.append(message)
+
+
+class DummyInteraction:
+    def __init__(self):
+        self.response = DummyResponse()
+        self.followup = DummyFollowup()
+        self.user = SimpleNamespace(id=1)
+        self.channel = SimpleNamespace(id=1, name="chan")
+
+
+def test_image_error_uses_generate(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "fake")
+
+    async def run():
+        intents = discord.Intents.none()
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        await bot.load_extension("gentlebot.cogs.image_cog")
+        cog = bot.get_cog("ImageCog")
+
+        interaction = DummyInteraction()
+
+        def fake_generate_image(prompt):
+            raise Exception("boom")
+
+        def fake_generate(*args, **kwargs):
+            return "friendly"
+
+        monkeypatch.setattr(image_cog.router, "generate_image", fake_generate_image)
+        monkeypatch.setattr(image_cog.router, "generate", fake_generate)
+
+        await image_cog.ImageCog.image.callback(cog, interaction, prompt="hi")
+        assert interaction.followup.sent == ["friendly"]
+        await bot.close()
+
+    asyncio.run(run())
+
+
+def test_image_error_fallback(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "fake")
+
+    async def run():
+        intents = discord.Intents.none()
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        await bot.load_extension("gentlebot.cogs.image_cog")
+        cog = bot.get_cog("ImageCog")
+
+        interaction = DummyInteraction()
+
+        def raise_rate_limited(prompt):
+            raise RateLimited()
+
+        def fail_generate(*args, **kwargs):
+            raise RateLimited()
+
+        monkeypatch.setattr(image_cog.router, "generate_image", raise_rate_limited)
+        monkeypatch.setattr(image_cog.router, "generate", fail_generate)
+
+        await image_cog.ImageCog.image.callback(cog, interaction, prompt="hi")
+        assert interaction.followup.sent == [
+            "Unfortunately I've exceeded quota and am being told to wait. Try again in a bit."
+        ]
+        await bot.close()
+
     asyncio.run(run())


### PR DESCRIPTION
## Summary
- craft friendly error messages via `generate_content` when `/image` fails
- fall back to a generic quota warning on generation failures
- add tests for friendly error and fallback behaviour

## Testing
- `pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2417824cc832b8155089ba0357189