### PR TITLE
Fix vibecheck reactions query

### DIFF
--- a/gentlebot/cogs/vibecheck_cog.py
+++ b/gentlebot/cogs/vibecheck_cog.py
@@ -102,9 +102,13 @@ class VibeCheckCog(commands.Cog):
                          AND (a.content_type ILIKE 'image/%' OR a.url ~ '\\.(?:png|jpe?g|gif)$')
                    ) AS has_image,
                    COALESCE(
-                       (SELECT COUNT(*) FILTER (WHERE action = 0) - COUNT(*) FILTER (WHERE action = 1)
-                        FROM discord.reaction_event r
-                        WHERE r.message_id = m.message_id),
+                       (
+                           SELECT
+                               COUNT(*) FILTER (WHERE reaction_action = 'MESSAGE_REACTION_ADD')
+                               - COUNT(*) FILTER (WHERE reaction_action = 'MESSAGE_REACTION_REMOVE')
+                           FROM discord.reaction_event r
+                           WHERE r.message_id = m.message_id
+                       ),
                        0
                    ) AS reactions
             FROM discord.message m


### PR DESCRIPTION
## Summary
- fix `/vibecheck` reaction tally to use `reaction_action` enum
- add regression test for `reaction_action` usage in `_gather_messages`

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7bee77e9c832b9f1f704fcf3a1819