### PR TITLE
Include hero counts for third top poster and refine vibe topics

### DIFF
--- a/tests/test_vibecheck.py
+++ b/tests/test_vibecheck.py
@@ -1,7 +1,7 @@
 import asyncio
 import pytest
 import discord
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from types import SimpleNamespace
 from discord.ext import commands
 
@@ -78,6 +78,50 @@ def test_derive_topics_handles_none_content():
     assert topics == ["hello world", "..."]
 
 
+def test_derive_topics_filters_names_and_diff():
+    bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+    cog = VibeCheckCog(bot)
+    now = datetime.now(timezone.utc)
+    msgs = [
+        ArchivedMessage(
+            channel_id=1,
+            channel_name="c",
+            author_id=1,
+            author_name="Alice",
+            content="Alice loves pizza and pasta",
+            created_at=now,
+            has_image=False,
+            reactions=0,
+        ),
+        ArchivedMessage(
+            channel_id=1,
+            channel_name="c",
+            author_id=2,
+            author_name="Bob",
+            content="Bob loves pizza and chess",
+            created_at=now,
+            has_image=False,
+            reactions=0,
+        ),
+        ArchivedMessage(
+            channel_id=1,
+            channel_name="c",
+            author_id=3,
+            author_name="Eve",
+            content="dogs chase cats daily",
+            created_at=now,
+            has_image=False,
+            reactions=0,
+        ),
+    ]
+    topics = cog._derive_topics(msgs)
+    asyncio.run(bot.close())
+    assert all(
+        name not in t.lower() for name in ["alice", "bob"] for t in topics
+    )
+    assert set(topics[0].split()).isdisjoint(set(topics[1].split()))
+
+
 def test_vibecheck_defers(monkeypatch):
     bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
     cog = VibeCheckCog(bot)
@@ -124,6 +168,79 @@ def test_vibecheck_defers(monkeypatch):
     assert interaction.response.deferred is True
     assert interaction.followup.sent is not None
     assert interaction.followup.sent[1].get("ephemeral") is True
+
+
+def test_third_place_includes_hero_counts(monkeypatch):
+    bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+    cog = VibeCheckCog(bot)
+    cog.pool = object()
+
+    now = datetime.now(timezone.utc)
+    msgs = []
+    day1 = now - timedelta(days=1)
+    for _ in range(5):
+        msgs.append(
+            ArchivedMessage(1, "c", 1, "u1", "m", day1, False, 0)
+        )
+    msgs.append(ArchivedMessage(1, "c", 2, "u2", "m", day1, False, 0))
+    msgs.append(ArchivedMessage(1, "c", 3, "u3", "m", day1, False, 0))
+
+    day2 = now - timedelta(days=2)
+    for _ in range(4):
+        msgs.append(
+            ArchivedMessage(1, "c", 2, "u2", "m", day2, False, 0)
+        )
+    msgs.append(ArchivedMessage(1, "c", 1, "u1", "m", day2, False, 0))
+    msgs.append(ArchivedMessage(1, "c", 3, "u3", "m", day2, False, 0))
+
+    day3 = now - timedelta(days=3)
+    for _ in range(3):
+        msgs.append(
+            ArchivedMessage(1, "c", 3, "u3", "m", day3, False, 0)
+        )
+    msgs.append(ArchivedMessage(1, "c", 1, "u1", "m", day3, False, 0))
+    msgs.append(ArchivedMessage(1, "c", 2, "u2", "m", day3, False, 0))
+
+    async def fake_gather(start, end):
+        return msgs
+
+    async def fake_tips(cur, prior):
+        return []
+
+    monkeypatch.setattr(cog, "_gather_messages", fake_gather)
+    monkeypatch.setattr(cog, "_friendship_tips", fake_tips)
+    monkeypatch.setattr(cog, "_derive_topics", lambda msgs: ("t1", "t2"))
+
+    class DummyResponse:
+        def __init__(self):
+            self.deferred = False
+
+        async def defer(self, **kwargs):
+            self.deferred = True
+
+    class DummyFollowup:
+        def __init__(self):
+            self.sent = None
+
+        async def send(self, content, **kwargs):
+            self.sent = (content, kwargs)
+
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(display_name="u", id=1),
+        channel=SimpleNamespace(name="c"),
+        response=DummyResponse(),
+        followup=DummyFollowup(),
+    )
+
+    async def run():
+        await VibeCheckCog.vibecheck.callback(cog, interaction)
+        await bot.close()
+
+    asyncio.run(run())
+
+    output = interaction.followup.sent[0]
+    third_line = next(l for l in output.splitlines() if l.startswith("🥉"))
+    assert "Daily Hero" in third_line
 
 
 def test_gather_messages_uses_reaction_action():


### PR DESCRIPTION
## Summary
- Always show daily hero counts for all top posters in `/vibecheck`
- Filter author display names and ensure distinct phrases when deriving channel topics
- Add tests for topic derivation and third-place hero count reporting

## Testing
- `pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7d56f7454832bb9542eedfdbe26f9