### PR TITLE
Exclude private channels from vibecheck overview

### DIFF
--- a/gentlebot/cogs/vibecheck_cog.py
+++ b/gentlebot/cogs/vibecheck_cog.py
@@ -270,8 +270,19 @@ class VibeCheckCog(commands.Cog):
             channel_msgs[m.channel_id].append(m)
         channel_counts = {cid: len(lst) for cid, lst in channel_msgs.items()}
         channel_names = {m.channel_id: m.channel_name for m in cur_msgs}
+
+        # Only consider channels visible to @everyone
+        public_channels: list[tuple[int, int]] = []
+        for cid, count in channel_counts.items():
+            channel = self.bot.get_channel(cid)
+            if channel is None or channel.guild is None:
+                continue
+            perms = channel.permissions_for(channel.guild.default_role)
+            if getattr(perms, "read_messages", False):
+                public_channels.append((cid, count))
+
         top_channels = sorted(
-            channel_counts.items(), key=lambda kv: kv[1], reverse=True
+            public_channels, key=lambda kv: kv[1], reverse=True
         )[:3]
 
         # media mix -----------------------------------------------------------

--- a/tests/test_vibecheck.py
+++ b/tests/test_vibecheck.py
@@ -243,6 +243,74 @@ def test_third_place_includes_hero_counts(monkeypatch):
     assert "Daily Hero" in third_line
 
 
+def test_vibecheck_omits_private_channels(monkeypatch):
+    bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+    cog = VibeCheckCog(bot)
+    cog.pool = object()
+    now = datetime.now(timezone.utc)
+    msgs = [
+        ArchivedMessage(1, "public", 1, "u1", "m", now, False, 0),
+        ArchivedMessage(2, "secret", 2, "u2", "m", now, False, 0),
+    ]
+
+    async def fake_gather(start, end):
+        return msgs
+
+    async def fake_tips(cur, prior):
+        return []
+
+    monkeypatch.setattr(cog, "_gather_messages", fake_gather)
+    monkeypatch.setattr(cog, "_friendship_tips", fake_tips)
+    monkeypatch.setattr(cog, "_derive_topics", lambda m: ("t1", "t2"))
+
+    class DummyGuild:
+        def __init__(self):
+            self.default_role = object()
+
+    class DummyChannel:
+        def __init__(self, visible: bool):
+            self.visible = visible
+            self.guild = DummyGuild()
+
+        def permissions_for(self, role):
+            if role is self.guild.default_role:
+                return SimpleNamespace(read_messages=self.visible)
+            return SimpleNamespace(read_messages=False)
+
+    def fake_get_channel(cid):
+        return DummyChannel(visible=(cid == 1))
+
+    monkeypatch.setattr(bot, "get_channel", fake_get_channel)
+
+    class DummyResponse:
+        async def defer(self, **kwargs):
+            pass
+
+    class DummyFollowup:
+        def __init__(self):
+            self.sent = None
+
+        async def send(self, content, **kwargs):
+            self.sent = (content, kwargs)
+
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(display_name="u", id=1),
+        channel=SimpleNamespace(name="c"),
+        response=DummyResponse(),
+        followup=DummyFollowup(),
+    )
+
+    async def run():
+        await VibeCheckCog.vibecheck.callback(cog, interaction)
+        await bot.close()
+
+    asyncio.run(run())
+
+    output = interaction.followup.sent[0]
+    assert "#secret" not in output
+    assert "#public" in output
+
+
 def test_gather_messages_uses_reaction_action():
     bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
     cog = VibeCheckCog(bot)


### PR DESCRIPTION
## Summary
- filter `/vibecheck` channel hotness to only include channels visible to everyone
- add regression test ensuring private channels are omitted

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68b84c6466a8832b9c56139048098c89