### PR TITLE
Add channel privacy metadata

### DIFF
--- a/db/versions/4b58c5e66f5d_add_channel_privacy_columns.py
+++ b/db/versions/4b58c5e66f5d_add_channel_privacy_columns.py
@@ -1,0 +1,48 @@
+"""add channel privacy columns
+
+Revision ID: 4b58c5e66f5d
+Revises: d24e408ee6dc
+Create Date: 2025-09-01 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '4b58c5e66f5d'
+down_revision: Union[str, None] = 'd24e408ee6dc'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    privacy = sa.Enum(
+        'public',
+        'guild_restricted',
+        'dm',
+        'group_dm',
+        'private_thread',
+        name='channelprivacykind',
+    )
+    privacy.create(op.get_bind(), checkfirst=True)
+    op.add_column(
+        'channel',
+        sa.Column('privacy_kind', privacy, server_default='public', nullable=False),
+        schema='discord',
+    )
+    op.add_column(
+        'channel',
+        sa.Column(
+            'is_private',
+            sa.Boolean,
+            sa.Computed("privacy_kind <> 'public'", persisted=True),
+            nullable=False,
+        ),
+        schema='discord',
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('channel', 'is_private', schema='discord')
+    op.drop_column('channel', 'privacy_kind', schema='discord')
+    sa.Enum(name='channelprivacykind').drop(op.get_bind(), checkfirst=True)


### PR DESCRIPTION
## Summary
- add privacy_kind enum and generated is_private flag to `discord.channel`
- derive channel privacy from Discord API data and store during upsert
- cover privacy helpers in tests

## Testing
- `python -m pytest -q`
- `python test_harness.py` *(fails: RuntimeError: Client has not been properly initialised ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b9001fa078832b98d7245e5efd08ac