### PR TITLE
feat: send vibe check in embed

### DIFF
--- a/gentlebot/cogs/vibecheck_cog.py
+++ b/gentlebot/cogs/vibecheck_cog.py
@@ -391,10 +391,10 @@ class VibeCheckCog(commands.Cog):
         overall = int(clamp(overall, 0, 100))
 
         # assemble output -----------------------------------------------------
+        title = f"Vibe Check ({now.strftime('%b %-d')})"
         lines: list[str] = []
-        lines.append(f"**Vibe Check** ({now.strftime('%b %-d')})")
         lines.append(
-            f" **Gentlefolk** (Last 7 days) ▷ **{overall}/100** Overall Score"
+            f"**Gentlefolk** (Last 7 days) ▷ **{overall}/100** Overall Score"
         )
         lines.append(
             f"*Activity Level*: {bar}  (↑ {delta_pct*100:.0f}% vs prior)"
@@ -431,7 +431,8 @@ class VibeCheckCog(commands.Cog):
         tips = await self._friendship_tips(cur_msgs, prior_msgs)
         lines.extend(f"- {t}" for t in tips)
 
-        await interaction.followup.send("\n".join(lines), ephemeral=True)
+        embed = discord.Embed(title=title, description="\n".join(lines))
+        await interaction.followup.send(embed=embed, ephemeral=True)
 
     # ------------------------------------------------------------------
     async def _derive_topics(

--- a/tests/test_vibecheck.py
+++ b/tests/test_vibecheck.py
@@ -127,7 +127,7 @@ def test_vibecheck_defers(monkeypatch):
         def __init__(self):
             self.sent = None
 
-        async def send(self, content, **kwargs):
+        async def send(self, content=None, **kwargs):
             self.sent = (content, kwargs)
 
     interaction = SimpleNamespace(
@@ -146,7 +146,9 @@ def test_vibecheck_defers(monkeypatch):
     assert interaction.response.deferred is True
     assert interaction.followup.sent is not None
     assert interaction.followup.sent[1].get("ephemeral") is True
-    output = interaction.followup.sent[0]
+    embed = interaction.followup.sent[1]["embed"]
+    assert embed.title.startswith("Vibe Check")
+    output = embed.description
     assert "- tip" in output.splitlines()
 
 
@@ -199,7 +201,7 @@ def test_third_place_includes_hero_counts(monkeypatch):
         def __init__(self):
             self.sent = None
 
-        async def send(self, content, **kwargs):
+        async def send(self, content=None, **kwargs):
             self.sent = (content, kwargs)
 
     # Setup guild with top poster roles
@@ -239,7 +241,7 @@ def test_third_place_includes_hero_counts(monkeypatch):
 
     asyncio.run(run())
 
-    output = interaction.followup.sent[0]
+    output = interaction.followup.sent[1]["embed"].description
     lines = output.splitlines()
     first = next(l for l in lines if l.startswith("🥇"))
     second = next(l for l in lines if l.startswith("🥈"))
@@ -315,7 +317,7 @@ def test_vibecheck_uses_top_poster_roles(monkeypatch):
         def __init__(self):
             self.sent = None
 
-        async def send(self, content, **kwargs):
+        async def send(self, content=None, **kwargs):
             self.sent = (content, kwargs)
 
     interaction = SimpleNamespace(
@@ -332,7 +334,7 @@ def test_vibecheck_uses_top_poster_roles(monkeypatch):
 
     asyncio.run(run())
 
-    lines = interaction.followup.sent[0].splitlines()
+    lines = interaction.followup.sent[1]["embed"].description.splitlines()
     assert not any(l.startswith("🥇") for l in lines)
     second = next(l for l in lines if l.startswith("🥈"))
     third = next(l for l in lines if l.startswith("🥉"))
@@ -402,7 +404,7 @@ def test_vibecheck_omits_private_channels(monkeypatch):
         def __init__(self):
             self.sent = None
 
-        async def send(self, content, **kwargs):
+        async def send(self, content=None, **kwargs):
             self.sent = (content, kwargs)
 
     interaction = SimpleNamespace(
@@ -418,7 +420,7 @@ def test_vibecheck_omits_private_channels(monkeypatch):
 
     asyncio.run(run())
 
-    output = interaction.followup.sent[0]
+    output = interaction.followup.sent[1]["embed"].description
     assert "#secret" not in output
     assert "#public" in output
 
@@ -479,7 +481,7 @@ def test_gather_messages_filters_private_channels(monkeypatch):
         def __init__(self):
             self.sent = None
 
-        async def send(self, content, **kwargs):
+        async def send(self, content=None, **kwargs):
             self.sent = (content, kwargs)
 
     interaction = SimpleNamespace(
@@ -495,7 +497,7 @@ def test_gather_messages_filters_private_channels(monkeypatch):
 
     asyncio.run(run())
 
-    output = interaction.followup.sent[0]
+    output = interaction.followup.sent[1]["embed"].description
     assert "#secret" not in output
     assert "#public" in output
 


### PR DESCRIPTION
## Summary
- return /vibecheck results in a Discord embed with dated title
- adjust tests for embed-based responses

## Testing
- `pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68b915bfcb90832b9590add439777e71