### PR TITLE
feat: schedule weekly vibe check

### DIFF
--- a/gentlebot/cogs/vibecheck_weekly_cog.py
+++ b/gentlebot/cogs/vibecheck_weekly_cog.py
@@ -1,0 +1,11 @@
+"""Cog wrapper to schedule weekly vibe checks."""
+from __future__ import annotations
+
+from discord.ext import commands
+
+from ..tasks.vibecheck_weekly import WeeklyVibeCheckCog as _WeeklyVibeCheckCog
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(_WeeklyVibeCheckCog(bot))
+

--- a/gentlebot/tasks/vibecheck_weekly.py
+++ b/gentlebot/tasks/vibecheck_weekly.py
@@ -1,0 +1,63 @@
+"""Weekly VibeCheck scheduler.
+
+Posts the `/vibecheck` report in #lobby every Monday at 9am Pacific."""
+from __future__ import annotations
+
+import logging
+
+import pytz
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+import discord
+from discord.ext import commands
+
+from .. import bot_config as cfg
+from ..cogs.vibecheck_cog import VibeCheckCog
+
+log = logging.getLogger(f"gentlebot.{__name__}")
+
+LA = pytz.timezone("America/Los_Angeles")
+
+
+class WeeklyVibeCheckCog(commands.Cog):
+    """Scheduler that posts a weekly vibe check in the lobby."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self.scheduler: AsyncIOScheduler | None = None
+
+    async def cog_load(self) -> None:
+        self.scheduler = AsyncIOScheduler(timezone=LA)
+        trigger = CronTrigger(day_of_week="mon", hour=9, minute=0, timezone=LA)
+        self.scheduler.add_job(self._run_vibecheck, trigger)
+        self.scheduler.start()
+        log.info("Weekly VibeCheck scheduler started")
+
+    async def cog_unload(self) -> None:
+        if self.scheduler:
+            self.scheduler.shutdown(wait=False)
+            self.scheduler = None
+
+    async def _run_vibecheck(self) -> None:
+        await self.bot.wait_until_ready()
+        channel = self.bot.get_channel(cfg.LOBBY_CHANNEL_ID)
+        if not isinstance(channel, discord.TextChannel):
+            log.error("Lobby channel not found")
+            return
+        cog = self.bot.get_cog("VibeCheckCog")
+        if not isinstance(cog, VibeCheckCog):
+            log.error("VibeCheckCog not loaded")
+            return
+        embed = await cog.build_embed(
+            self.bot.get_guild(cfg.GUILD_ID), llm_route="scheduled"
+        )
+        if not embed:
+            log.error("Vibe report unavailable")
+            return
+        await channel.send(embed=embed)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(WeeklyVibeCheckCog(bot))
+

--- a/tests/test_vibecheck.py
+++ b/tests/test_vibecheck.py
@@ -101,7 +101,7 @@ def test_vibecheck_defers(monkeypatch):
     async def fake_gather(start, end):
         return []
 
-    async def fake_tips(cur, prior):
+    async def fake_tips(cur, prior, route="general"):
         return ["tip"]
 
     async def fake_public_ids():
@@ -169,13 +169,13 @@ def test_third_place_includes_hero_counts(monkeypatch):
     async def fake_gather(start, end):
         return msgs
 
-    async def fake_tips(cur, prior):
+    async def fake_tips(cur, prior, route="general"):
         return []
 
     monkeypatch.setattr(cog, "_gather_messages", fake_gather)
     monkeypatch.setattr(cog, "_friendship_tips", fake_tips)
 
-    async def fake_topics(msgs):
+    async def fake_topics(msgs, route="general"):
         return ("t1", "t2")
 
     monkeypatch.setattr(cog, "_derive_topics", fake_topics)
@@ -268,10 +268,10 @@ def test_vibecheck_uses_top_poster_roles(monkeypatch):
     async def fake_gather(start, end):
         return msgs
 
-    async def fake_tips(cur, prior):
+    async def fake_tips(cur, prior, route="general"):
         return []
 
-    async def fake_topics(msgs):
+    async def fake_topics(msgs, route="general"):
         return ("t1", "t2")
 
     async def fake_public_ids():
@@ -356,7 +356,7 @@ def test_vibecheck_omits_private_channels(monkeypatch):
     async def fake_gather(start, end):
         return msgs
 
-    async def fake_tips(cur, prior):
+    async def fake_tips(cur, prior, route="general"):
         return []
 
     async def fake_public_ids():
@@ -365,7 +365,7 @@ def test_vibecheck_omits_private_channels(monkeypatch):
     monkeypatch.setattr(cog, "_gather_messages", fake_gather)
     monkeypatch.setattr(cog, "_friendship_tips", fake_tips)
 
-    async def fake_topics(msgs):
+    async def fake_topics(msgs, route="general"):
         return ("t1", "t2")
 
     monkeypatch.setattr(cog, "_derive_topics", fake_topics)
@@ -438,13 +438,13 @@ def test_gather_messages_filters_private_channels(monkeypatch):
     async def fake_gather(start, end):
         return msgs
 
-    async def fake_tips(cur, prior):
+    async def fake_tips(cur, prior, route="general"):
         return []
 
     monkeypatch.setattr(cog, "_gather_messages", fake_gather)
     monkeypatch.setattr(cog, "_friendship_tips", fake_tips)
 
-    async def fake_topics(m):
+    async def fake_topics(m, route="general"):
         return ("t1", "t2")
 
     monkeypatch.setattr(cog, "_derive_topics", fake_topics)


### PR DESCRIPTION
## Summary
- refactor vibe check generation into reusable `build_embed`
- post weekly vibe check in #lobby every Monday 9am Pacific
- run scheduled vibe check with the pro LLM model

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68b91c282a18832bb7c2121c2541d664