### PR TITLE
Fix daily prompt channel lookup

### DIFF
--- a/gentlebot/cogs/prompt_cog.py
+++ b/gentlebot/cogs/prompt_cog.py
@@ -360,9 +360,12 @@ class PromptCog(commands.Cog):
             log.error("DAILY_PING_CHANNEL not set in config.")
             return
         channel = self.bot.get_channel(channel_id)
-        if not channel:
-            log.error("Unable to find channel with ID %s", channel_id)
-            return
+        if channel is None:
+            try:
+                channel = await self.bot.fetch_channel(channel_id)
+            except Exception as exc:
+                log.error("Unable to find channel with ID %s: %s", channel_id, exc)
+                return
         prompt = await self.fetch_prompt()
         category = self.last_category
         try:


### PR DESCRIPTION
## Summary
- ensure daily ping uses `fetch_channel` when not in cache
- add regression test for channel fetching

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb7274aac8832b977fc51f18849ede