### PR TITLE
Increase MLB Stats API timeout for Big Dumper updates

### DIFF
--- a/gentlebot/cogs/bigdumper_watcher_cog.py
+++ b/gentlebot/cogs/bigdumper_watcher_cog.py
@@ -10,7 +10,7 @@ from requests.adapters import HTTPAdapter, Retry
 import discord
 from discord.ext import commands, tasks
 
-from .sports_cog import PLAYER_ID
+from .sports_cog import PLAYER_ID, STATS_TIMEOUT
 from .sports_cog import SportsCog
 from .. import bot_config as cfg
 
@@ -49,7 +49,7 @@ class BigDumperWatcherCog(commands.Cog):
         year = datetime.now().year
         url = f"https://statsapi.mlb.com/api/v1/people/{PLAYER_ID}/stats"
         params = {"stats": "season", "group": "hitting", "season": year}
-        resp = self.session.get(url, params=params, timeout=10)
+        resp = self.session.get(url, params=params, timeout=STATS_TIMEOUT)
         resp.raise_for_status()
         data = resp.json()
         return int(data["stats"][0]["splits"][0]["stat"].get("homeRuns", 0))

--- a/tests/test_stats_timeout.py
+++ b/tests/test_stats_timeout.py
@@ -1,0 +1,44 @@
+import types
+
+import pytest
+from gentlebot.cogs.bigdumper_watcher_cog import BigDumperWatcherCog
+from gentlebot.cogs.sports_cog import SportsCog, STATS_TIMEOUT
+
+
+class DummyResp:
+    def __init__(self, data=None):
+        self._data = data or {"stats": [{"splits": [{"stat": {"homeRuns": 7}}]}]}
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._data
+
+
+def test_fetch_hr_uses_timeout(monkeypatch):
+    cog = BigDumperWatcherCog(bot=None)
+    called = {}
+
+    def fake_get(url, params=None, timeout=None):
+        called['timeout'] = timeout
+        return DummyResp()
+
+    monkeypatch.setattr(cog.session, 'get', fake_get)
+    hr = cog._fetch_hr()
+    assert hr == 7
+    assert called['timeout'] == STATS_TIMEOUT
+
+
+def test_fetch_season_stats_uses_timeout(monkeypatch):
+    cog = SportsCog(bot=None)
+    called = {}
+
+    def fake_get(url, params=None, timeout=None):
+        called['timeout'] = timeout
+        return DummyResp()
+
+    monkeypatch.setattr(cog.session, 'get', fake_get)
+    stats = cog.fetch_season_stats()
+    assert called['timeout'] == STATS_TIMEOUT
+    assert stats.get('homeRuns') == 7


### PR DESCRIPTION
## Summary
- add shared `STATS_TIMEOUT` for MLB Stats API requests
- retry and apply timeout in SportsCog and BigDumperWatcherCog
- test that MLB stats calls honor new timeout constant

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb72a54840832b974deedad3aecd3d