### PR TITLE
Serialize role tags before database insert

### DIFF
--- a/gentlebot/backfill_roles.py
+++ b/gentlebot/backfill_roles.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 
 import asyncpg
@@ -60,6 +61,7 @@ class BackfillBot(commands.Bot):
                     if role.tags is not None
                     else None
                 )
+                tag_json = json.dumps(tag_dict) if tag_dict is not None else None
                 inserted = await self.pool.fetchval(
                     """
                     INSERT INTO discord.role (
@@ -88,7 +90,7 @@ class BackfillBot(commands.Bot):
                     getattr(role.icon, "key", None) if role.icon else None,
                     role.unicode_emoji,
                     role.flags.value,
-                    tag_dict,
+                    tag_json,
                 )
                 self.counts["role"] += int(bool(inserted))
             for member in guild.members:

--- a/tests/test_backfill_roles.py
+++ b/tests/test_backfill_roles.py
@@ -1,0 +1,66 @@
+import asyncio
+import discord
+
+from gentlebot.backfill_roles import BackfillBot
+
+
+class DummyPool:
+    def __init__(self):
+        self.fetchval_calls = []
+        self.execute_calls = []
+
+    async def fetchval(self, query, *args):
+        self.fetchval_calls.append((query, args))
+        return 1
+
+    async def execute(self, query, *args):
+        self.execute_calls.append((query, args))
+        return "INSERT 0 1"
+
+    async def close(self):
+        pass
+
+
+def test_tags_serialized():
+    async def run_test():
+        bot = BackfillBot()
+        bot.pool = DummyPool()
+        bot._connection.user = type("U", (), {"id": 1, "name": "u"})()
+
+        class Tags:
+            __slots__ = ("bot_id",)
+
+            def __init__(self):
+                self.bot_id = 4
+
+        role = type(
+            "R",
+            (),
+            {
+                "id": 5,
+                "guild": None,
+                "name": "r",
+                "color": discord.Colour.default(),
+                "tags": Tags(),
+                "permissions": discord.Permissions.none(),
+                "hoist": False,
+                "mentionable": False,
+                "managed": False,
+                "icon": None,
+                "unicode_emoji": None,
+                "flags": discord.RoleFlags(),
+                "position": 0,
+            },
+        )()
+        guild = type("G", (), {"id": 1, "roles": [role], "members": [],})()
+        role.guild = guild
+        member = type("M", (), {"id": 10, "roles": [role]})()
+        guild.members.append(member)
+        bot._connection._guilds = {guild.id: guild}
+
+        await bot.on_ready()
+        assert bot.pool.fetchval_calls
+        query, args = bot.pool.fetchval_calls[0]
+        assert isinstance(args[-1], str)
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- ensure `backfill_roles` serializes Discord role tags to JSON strings before inserting into Postgres
- add regression test verifying tag serialization during backfill

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc9c643ce0832bb965de42c065adf9