### PR TITLE
Fix daily prompt scheduler resilience

### DIFF
--- a/tests/test_prompt_schedule.py
+++ b/tests/test_prompt_schedule.py
@@ -1,4 +1,6 @@
 from datetime import datetime, timedelta
+import asyncio
+import types
 from gentlebot.cogs import prompt_cog
 
 
@@ -18,3 +20,40 @@ def test_next_run_time_after_schedule():
     assert next_run.date() == now.date() + timedelta(days=1)
     assert next_run.hour == prompt_cog.SCHEDULE_HOUR
     assert next_run.minute == prompt_cog.SCHEDULE_MINUTE
+
+
+def test_scheduler_restarts_when_done(monkeypatch):
+    """Scheduler should restart if previous task finished or crashed."""
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    async def dummy_wait():
+        pass
+
+    bot = types.SimpleNamespace(
+        loop=loop,
+        wait_until_ready=dummy_wait,
+        is_closed=lambda: False,
+    )
+    cog = prompt_cog.PromptCog(bot)
+
+    async def fake_scheduler(self):
+        return
+
+    monkeypatch.setattr(prompt_cog.PromptCog, "_scheduler", fake_scheduler)
+
+    async def run():
+        await cog.on_ready()
+        first = cog._scheduler_task
+        assert first is not None
+        await asyncio.sleep(0)
+        assert first.done()
+        await cog.on_ready()
+        second = cog._scheduler_task
+        assert second is not first
+
+    try:
+        loop.run_until_complete(run())
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()


### PR DESCRIPTION
## Summary
- ensure daily prompt scheduler task restarts if it stops
- handle prompt send errors so scheduler continues
- add regression test for scheduler restart

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdaaeda004832b85d82b8362b2ed56