### PR TITLE
Improve Daily Hero DM generation

### DIFF
--- a/gentlebot/tasks/daily_hero_dm.py
+++ b/gentlebot/tasks/daily_hero_dm.py
@@ -85,8 +85,7 @@ class DailyHeroDMCog(commands.Cog):
         return FALLBACK_TEMPLATE.format(username=name, ordinal=ordinal)
 
     def _is_valid(self, text: str) -> bool:
-        words = text.split()
-        return "Daily Hero" in text and 25 <= len(words) <= 30
+        return "daily hero" in text.lower()
 
     async def _generate_message(self, display_name: str, wins: int) -> str:
         prompt = self._build_prompt(display_name, wins)

--- a/tests/test_daily_hero_dm.py
+++ b/tests/test_daily_hero_dm.py
@@ -40,6 +40,16 @@ def test_generate_message_success(cog, monkeypatch):
     assert msg == sample
 
 
+def test_generate_message_case_insens(cog, monkeypatch):
+    sample = (
+        "Salutations, Tester; your efforts in Gentlefolk yesterday earned you the daily hero title for the 5th time."
+    )
+
+    monkeypatch.setattr(router, "generate", lambda *a, **k: sample)
+    msg = asyncio.run(cog._generate_message("Tester", 5))
+    assert msg == sample
+
+
 def test_send_dm_logged(cog, monkeypatch, caplog):
     async def run_test():
         async def dummy_wait():


### PR DESCRIPTION
## Summary
- Drop word count check in Daily Hero DM validation so messages only require "daily hero" phrase
- Adjust regression test to verify case-insensitive handling without length limits

## Testing
- `python -m pytest -q`
- `python test_harness.py` *(fails: Client has not been properly initialised in RoleCog.badge_task)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb4982520832b90d005966d8041b3