### PR TITLE
feat: quote prompt with image

### DIFF
--- a/gentlebot/cogs/image_cog.py
+++ b/gentlebot/cogs/image_cog.py
@@ -69,7 +69,10 @@ class ImageCog(commands.Cog):
             return
         if data:
             file = discord.File(io.BytesIO(data), filename="gemini.png")
-            await interaction.followup.send(file=file)
+            message = f"> {prompt}"
+            if len(message) > 1900:
+                message = message[:1897] + "..."
+            await interaction.followup.send(message, file=file)
         else:
             await interaction.followup.send("Image generation didn't work.")
 


### PR DESCRIPTION
## Summary
- Quote the original prompt when sending generated images via `/image`
- Extend image cog tests to cover quoting and capture follow-up content and files

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68be562c509c832bba977489df04bc4e