### PR TITLE
Wrap /image prompt caption in spoiler tags

### DIFF
--- a/gentlebot/cogs/image_cog.py
+++ b/gentlebot/cogs/image_cog.py
@@ -69,9 +69,10 @@ class ImageCog(commands.Cog):
             return
         if data:
             file = discord.File(io.BytesIO(data), filename="gemini.png")
-            message = f"> {prompt}"
-            if len(message) > 1900:
-                message = message[:1897] + "..."
+            safe_prompt = prompt
+            if len(prompt) > 1894:
+                safe_prompt = prompt[:1891] + "..."
+            message = f"> ||{safe_prompt}||"
             await interaction.followup.send(message, file=file)
         else:
             await interaction.followup.send("Image generation didn't work.")

--- a/tests/test_image_cog.py
+++ b/tests/test_image_cog.py
@@ -115,7 +115,7 @@ def test_image_includes_prompt(monkeypatch):
 
         await image_cog.ImageCog.image.callback(cog, interaction, prompt="hi")
         content, kwargs = interaction.followup.sent[0]
-        assert content == "> hi"
+        assert content == "> ||hi||"
         assert isinstance(kwargs["file"], discord.File)
         await bot.close()
 


### PR DESCRIPTION
## Summary
- Hide /image prompt captions by surrounding them with spoiler tags
- Adjust /image tests for spoiler caption

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_68be5d2b1014832bb4250fe3beeb1a94