### PR TITLE
Allow Gemini ambient reactions to use custom and standard emojis

### DIFF
--- a/tests/test_gemini_cog.py
+++ b/tests/test_gemini_cog.py
@@ -112,3 +112,24 @@ def test_call_llm_logs_output_not_input(monkeypatch, caplog):
 
     assert "secret input" not in caplog.text
     assert "logged output" in caplog.text
+
+
+def test_choose_emoji_llm_custom_and_standard(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "fake")
+    intents = discord.Intents.none()
+    bot = commands.Bot(command_prefix="!", intents=intents)
+    cog = GeminiCog(bot)
+
+    async def fake_custom(_cid: int, _prompt: str) -> str:
+        return "<:party:123>"
+
+    cog.call_llm = fake_custom
+    result = asyncio.run(cog.choose_emoji_llm("hello", ["<:party:123>"]))
+    assert result == "<:party:123>"
+
+    async def fake_standard(_cid: int, _prompt: str) -> str:
+        return "🔥"
+
+    cog.call_llm = fake_standard
+    result = asyncio.run(cog.choose_emoji_llm("hello", []))
+    assert result == "🔥"


### PR DESCRIPTION
## Summary
- let Gemini choose standard or guild custom emojis for ambient reactions
- fallback to defaults if model fails and test both custom and standard responses

## Testing
- `python -m pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_68be5cee60a8832bbe6917a9e9b4d2f4