### PR TITLE
feat: add ambient image generation reaction

### DIFF
--- a/gentlebot/cogs/ambient_image_cog.py
+++ b/gentlebot/cogs/ambient_image_cog.py
@@ -1,0 +1,89 @@
+"""Ambient image generation reactions."""
+from __future__ import annotations
+
+import io
+import asyncio
+import random
+import logging
+
+import discord
+from discord.ext import commands
+
+from ..llm.router import router, SafetyBlocked
+from ..infra.quotas import RateLimited
+
+log = logging.getLogger(f"gentlebot.{__name__}")
+
+
+class AmbientImageCog(commands.Cog):
+    """Occasionally generate playful images inspired by channel chatter."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self.trigger_chance = 0.005  # 0.5%
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message) -> None:
+        if message.author.bot:
+            return
+        if getattr(message.flags, "ephemeral", False):
+            return
+        if random.random() >= self.trigger_chance:
+            return
+
+        texts: list[str] = []
+        async for m in message.channel.history(limit=20):
+            if m.author.bot:
+                continue
+            texts.append(m.content.strip())
+        texts.reverse()
+        context = "\n".join(t for t in texts if t)
+        if not context:
+            return
+
+        messages = [
+            {
+                "role": "user",
+                "content": (
+                    "Craft a short imaginative prompt for an artistic image "
+                    "based on this conversation:\n"
+                    f"{context}"
+                ),
+            }
+        ]
+        try:
+            prompt = await asyncio.to_thread(router.generate, "general", messages)
+        except RateLimited:
+            log.info("Prompt generation rate limited")
+            return
+        except SafetyBlocked:
+            log.info("Prompt generation blocked by safety policies")
+            return
+        except Exception:
+            log.exception("Prompt generation failed")
+            return
+
+        if not prompt.strip():
+            return
+        try:
+            data = await asyncio.to_thread(router.generate_image, prompt)
+        except RateLimited:
+            log.info("Image generation rate limited")
+            return
+        except SafetyBlocked:
+            log.info("Image generation blocked by safety policies")
+            return
+        except Exception:
+            log.exception("Ambient image generation failed")
+            return
+        if not data:
+            return
+        file = discord.File(io.BytesIO(data), filename="ambient.png")
+        try:
+            await message.channel.send(file=file)
+        except Exception:
+            log.exception("Failed to send ambient image")
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(AmbientImageCog(bot))

--- a/tests/test_ambient_image_cog.py
+++ b/tests/test_ambient_image_cog.py
@@ -1,0 +1,68 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+from discord.ext import commands
+
+from gentlebot.cogs import ambient_image_cog
+
+
+def test_ambient_image_cog_loads(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "fake")
+
+    async def run():
+        intents = discord.Intents.none()
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        await bot.load_extension("gentlebot.cogs.ambient_image_cog")
+        assert bot.get_cog("AmbientImageCog") is not None
+        await bot.close()
+
+    asyncio.run(run())
+
+
+def test_ambient_image_cog_triggers(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "fake")
+
+    intents = discord.Intents.none()
+    bot = commands.Bot(command_prefix="!", intents=intents)
+    cog = ambient_image_cog.AmbientImageCog(bot)
+
+    message = MagicMock(spec=discord.Message)
+    message.author.bot = False
+    message.flags = MagicMock(ephemeral=False)
+    message.channel = MagicMock()
+    message.channel.send = AsyncMock()
+
+    history_messages = []
+    for i in range(20):
+        m = MagicMock(spec=discord.Message)
+        m.author.bot = False
+        m.content = f"msg{i}"
+        history_messages.append(m)
+
+    async def fake_history(limit):
+        for m in history_messages:
+            yield m
+
+    message.channel.history.side_effect = fake_history
+
+    monkeypatch.setattr(ambient_image_cog.random, "random", lambda: 0)
+
+    captured = {}
+
+    def fake_generate(route, messages, *args, **kwargs):
+        captured["messages"] = messages
+        return "final prompt"
+
+    def fake_generate_image(prompt: str):
+        captured["prompt"] = prompt
+        return b"img"
+
+    monkeypatch.setattr(ambient_image_cog.router, "generate", fake_generate)
+    monkeypatch.setattr(ambient_image_cog.router, "generate_image", fake_generate_image)
+
+    asyncio.run(cog.on_message(message))
+
+    assert "msg0" in captured["messages"][0]["content"]
+    assert captured["prompt"] == "final prompt"
+    message.channel.send.assert_called_once()


### PR DESCRIPTION
## Summary
- generate playful ambient images from recent channel chatter using LLM-crafted prompts at a 0.5% trigger rate
- test ambient image cog load and prompt-based trigger behavior

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68be6138ae38832b834e87d8feef0819