### PR TITLE
Add daily haiku scheduler

### DIFF
--- a/gentlebot/cogs/daily_haiku_cog.py
+++ b/gentlebot/cogs/daily_haiku_cog.py
@@ -1,0 +1,11 @@
+"""Daily Haiku Cog.
+Posts a daily haiku summary in #lobby."""
+from __future__ import annotations
+
+from discord.ext import commands
+
+from ..tasks.daily_haiku import DailyHaikuCog as _DailyHaikuCog
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(_DailyHaikuCog(bot))

--- a/gentlebot/tasks/daily_haiku.py
+++ b/gentlebot/tasks/daily_haiku.py
@@ -1,0 +1,133 @@
+"""Scheduler that posts a daily haiku summarizing server chat."""
+from __future__ import annotations
+import logging
+import asyncio
+from datetime import datetime
+from datetime import timedelta
+
+import pytz
+import asyncpg
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+import discord
+from discord.ext import commands
+
+from .. import bot_config as cfg
+from ..util import build_db_url
+from ..llm.router import router, SafetyBlocked
+from ..infra.quotas import RateLimited
+
+log = logging.getLogger(f"gentlebot.{__name__}")
+
+LA = pytz.timezone("America/Los_Angeles")
+
+
+def build_prompt(day_str: str, corpus: str) -> dict:
+    system = (
+        "You are a concise poet. Write a single evocative haiku about the day’s Discord chat. "
+        "Strict 5-7-5 syllables. No names, no @mentions, no links, no brand names. "
+        "Use natural imagery; avoid slang and profanity."
+    )
+    user = (
+        f"DATE: {day_str}\n"
+        "TASK: Read the following conversation excerpts from today and produce ONE haiku.\n"
+        "REQUIREMENTS: 5-7-5 syllables, English, safe for work, no proper names.\n"
+        "OUTPUT: Only the haiku on three lines. No quotes, no preface.\n\n"
+        "CONVERSATION START\n"
+        f"{corpus}\n"
+        "CONVERSATION END"
+    )
+    return {"system": system, "user": user}
+
+
+class DailyHaikuCog(commands.Cog):
+    """Scheduler that posts a daily haiku summary in the lobby at 10pm Pacific."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self.scheduler: AsyncIOScheduler | None = None
+        self.pool: asyncpg.Pool | None = None
+
+    async def cog_load(self) -> None:
+        url = build_db_url()
+        if url:
+            url = url.replace("postgresql+asyncpg://", "postgresql://")
+
+            async def _init(conn: asyncpg.Connection) -> None:
+                await conn.execute("SET search_path=discord,public")
+
+            self.pool = await asyncpg.create_pool(url, init=_init)
+        self.scheduler = AsyncIOScheduler(timezone=LA)
+        trigger = CronTrigger(hour=22, minute=0, timezone=LA)
+        self.scheduler.add_job(self._post_haiku, trigger)
+        self.scheduler.start()
+        log.info("DailyHaiku scheduler started")
+
+    async def cog_unload(self) -> None:
+        if self.scheduler:
+            self.scheduler.shutdown(wait=False)
+            self.scheduler = None
+        if self.pool:
+            await self.pool.close()
+            self.pool = None
+
+    async def _fetch_corpus(self, start: datetime, end: datetime) -> str:
+        if not self.pool:
+            return ""
+        rows = await self.pool.fetch(
+            """
+            SELECT m.content
+            FROM discord.message m
+            JOIN discord.channel c ON m.channel_id = c.channel_id
+            LEFT JOIN discord."user" u ON m.author_id = u.user_id
+            WHERE m.guild_id = $1
+              AND m.created_at >= $2 AND m.created_at < $3
+              AND c.type = 0
+              AND (c.nsfw IS FALSE OR c.nsfw IS NULL)
+              AND (c.is_private IS FALSE OR c.is_private IS NULL)
+              AND (u.is_bot IS NOT TRUE)
+            """,
+            cfg.GUILD_ID,
+            start,
+            end,
+        )
+        return "\n".join(r["content"] or "" for r in rows if r["content"])
+
+    async def _post_haiku(self) -> None:
+        await self.bot.wait_until_ready()
+        now = datetime.now(tz=LA)
+        start = LA.localize(datetime(now.year, now.month, now.day))
+        corpus = await self._fetch_corpus(start, now)
+        if not corpus:
+            log.info("No messages available for haiku generation")
+            return
+        prompt = build_prompt(start.strftime("%Y-%m-%d"), corpus)
+        try:
+            text = await asyncio.to_thread(
+                router.generate,
+                "scheduled",
+                [
+                    {"role": "system", "content": prompt["system"]},
+                    {"role": "user", "content": prompt["user"]},
+                ],
+            )
+            text = text.strip()
+        except (RateLimited, SafetyBlocked) as e:
+            log.warning("scheduled haiku generation failed: %s", e)
+            return
+        except Exception:
+            log.exception("Haiku generation failed")
+            return
+        channel = self.bot.get_channel(cfg.LOBBY_CHANNEL_ID)
+        if not isinstance(channel, discord.TextChannel):
+            log.error("Lobby channel not found")
+            return
+        try:
+            await channel.send(text)
+        except discord.HTTPException:
+            log.warning("Failed to post haiku")
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(DailyHaikuCog(bot))

--- a/tests/test_daily_haiku.py
+++ b/tests/test_daily_haiku.py
@@ -1,0 +1,110 @@
+import asyncio
+import os
+import datetime as dt
+from types import SimpleNamespace
+
+import pytest
+import discord
+from discord.ext import commands
+from apscheduler.triggers.cron import CronTrigger
+
+from gentlebot import bot_config as cfg
+from gentlebot.tasks.daily_haiku import DailyHaikuCog, build_prompt
+from gentlebot.llm.router import router
+
+
+@pytest.fixture()
+def cog(monkeypatch):
+    os.environ.setdefault("GEMINI_API_KEY", "dummy")
+    bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+    return DailyHaikuCog(bot)
+
+
+def test_build_prompt():
+    prompt = build_prompt("2024-05-15", "hello\nworld")
+    assert "You are a concise poet" in prompt["system"]
+    assert "DATE: 2024-05-15" in prompt["user"]
+    assert "hello" in prompt["user"]
+
+
+def test_haiku_scheduled(cog, monkeypatch):
+    captured: dict[str, CronTrigger] = {}
+
+    class DummyScheduler:
+        def __init__(self, timezone):
+            self.timezone = timezone
+
+        def add_job(self, func, trigger):
+            captured["trigger"] = trigger
+
+        def start(self):
+            pass
+
+        def shutdown(self, wait=False):
+            pass
+
+    import gentlebot.tasks.daily_haiku as module
+
+    monkeypatch.setattr(module, "AsyncIOScheduler", DummyScheduler)
+
+    asyncio.run(cog.cog_load())
+
+    trigger = captured.get("trigger")
+    assert isinstance(trigger, CronTrigger)
+    assert "hour='22'" in str(trigger)
+    assert "minute='0'" in str(trigger)
+
+
+def test_post_haiku_posts_message(cog, monkeypatch):
+    async def run_test():
+        async def dummy_wait():
+            pass
+
+        monkeypatch.setattr(cog.bot, "wait_until_ready", dummy_wait)
+        monkeypatch.setattr(cfg, "GUILD_ID", 1, raising=False)
+        monkeypatch.setattr(cfg, "LOBBY_CHANNEL_ID", 2, raising=False)
+
+        captured_start: list[dt.datetime] = []
+
+        class DummyPool:
+            async def fetch(self, q, guild_id, start, end):
+                captured_start.append(start)
+                return [{"content": "one"}, {"content": "two"}]
+
+            async def close(self):
+                pass
+
+        cog.pool = DummyPool()
+
+        monkeypatch.setattr(
+            router,
+            "generate",
+            lambda route, msgs, temp=0.6, think_budget=0, json_mode=False: "line1\nline2\nline3",
+        )
+
+        sent: list[str] = []
+        import gentlebot.tasks.daily_haiku as module
+
+        class DummyDateTime(dt.datetime):
+            @classmethod
+            def now(cls, tz=None):
+                naive = dt.datetime(2024, 5, 15, 15, 30)
+                return tz.localize(naive) if tz else naive
+
+        monkeypatch.setattr(module, "datetime", DummyDateTime)
+
+        class DummyChannel(SimpleNamespace):
+            async def send(self, message):
+                sent.append(message)
+
+        monkeypatch.setattr(module.discord, "TextChannel", DummyChannel)
+        channel = DummyChannel()
+        monkeypatch.setattr(cog.bot, "get_channel", lambda cid: channel)
+
+        await cog._post_haiku()
+        assert sent == ["line1\nline2\nline3"]
+
+        expected = module.LA.localize(dt.datetime(2024, 5, 15))
+        assert captured_start == [expected]
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- schedule DailyHaikuCog to summarize each day's chat and post haiku to #lobby at 10 PM Pacific
- build haiku prompt from archived messages and call LLM on the `scheduled` route
- test prompt builder, scheduling, and posting behavior
- fix start-of-day calculation with proper pytz localization

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf3343ccd8832b96e69984534e6d71