### PR TITLE
Fix prompt query to use discord schema

### DIFF
--- a/gentlebot/cogs/prompt_cog.py
+++ b/gentlebot/cogs/prompt_cog.py
@@ -158,8 +158,8 @@ def _strip_outer_quotes(text: str) -> str:
 # Prompt categories
 PROMPT_CATEGORIES = [
     "Recent Server Discussion",
-    # "Engagement Bait",
-    # "Sports News",
+    "Engagement Bait",
+    "Sports News",
 ]
 
 SPORTS_NEWS_PATHS = [
@@ -296,9 +296,9 @@ class PromptCog(commands.Cog):
         rows = await self.pool.fetch(
             """
             SELECT m.content
-            FROM message m
-            JOIN "user" u ON u.user_id = m.author_id
-            JOIN channel c ON c.channel_id = m.channel_id
+            FROM discord.message m
+            JOIN discord."user" u ON u.user_id = m.author_id
+            JOIN discord.channel c ON c.channel_id = m.channel_id
             WHERE u.is_bot = FALSE
               AND c.type = 0
               AND m.created_at >= now() - interval '72 hours'

--- a/tests/test_prompt_cog.py
+++ b/tests/test_prompt_cog.py
@@ -126,6 +126,30 @@ def test_on_message_uses_schema():
     asyncio.run(run())
 
 
+def test_recent_server_topic_uses_schema(monkeypatch):
+    async def run():
+        cog = prompt_cog.PromptCog(bot=types.SimpleNamespace())
+
+        captured = {}
+
+        class DummyPool:
+            async def fetch(self, query, *args):
+                captured['query'] = query
+                return [{"content": "hi"}]
+
+        cog.pool = DummyPool()
+        monkeypatch.setattr(prompt_cog.router, "generate", lambda *a, **k: "topic")
+
+        topic = await cog._recent_server_topic()
+
+        assert 'FROM discord.message' in captured['query']
+        assert 'JOIN discord."user"' in captured['query']
+        assert 'JOIN discord.channel' in captured['query']
+        assert topic == 'topic'
+
+    asyncio.run(run())
+
+
 def test_duplicate_prompt_updates_message_count():
     async def run():
         bot = types.SimpleNamespace()


### PR DESCRIPTION
## Summary
- ensure daily prompt query references `discord` schema to avoid missing table errors
- re-enable engagement bait and sports news categories
- test that recent server topic query uses fully qualified table names

## Testing
- `python -m pytest -q`
- `python test_harness.py` *(fails: Client has not been properly initialised)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b945abe0832b9fabfdbd29a07bd7