### PR TITLE
Ensure F1 and Seahawks threads are public

### DIFF
--- a/gentlebot/cogs/f1_thread_cog.py
+++ b/gentlebot/cogs/f1_thread_cog.py
@@ -214,7 +214,11 @@ class F1ThreadCog(commands.Cog):
         for row in sessions:
             title = self._make_title(row)
             try:
-                thread = await channel.create_thread(name=title, auto_archive_duration=1440)
+                thread = await channel.create_thread(
+                    name=title,
+                    auto_archive_duration=1440,
+                    type=discord.ChannelType.public_thread,
+                )
             except Exception:
                 log.exception("Failed to create thread %s", title)
                 continue

--- a/gentlebot/cogs/seahawks_thread_cog.py
+++ b/gentlebot/cogs/seahawks_thread_cog.py
@@ -111,7 +111,11 @@ class SeahawksThreadCog(commands.Cog):
                 continue
             title = self._thread_title(g["short"], start_pst)
             try:
-                thread = await channel.create_thread(name=title, auto_archive_duration=1440)
+                thread = await channel.create_thread(
+                    name=title,
+                    auto_archive_duration=1440,
+                    type=discord.ChannelType.public_thread,
+                )
             except Exception:  # pragma: no cover - network
                 log.exception("Failed to create thread %s", title)
                 continue

--- a/tests/test_f1_thread_cog.py
+++ b/tests/test_f1_thread_cog.py
@@ -36,10 +36,12 @@ def test_open_threads(monkeypatch):
         monkeypatch.setattr(cog, "_due_sessions", fake_due_sessions)
 
         created = []
+        thread_types = []
 
-        async def fake_create_thread(name, auto_archive_duration=None):
+        async def fake_create_thread(name, auto_archive_duration=None, type=None):
             t = DummyThread(id=123, name=name, deleted=False, sent=[])
             created.append(name)
+            thread_types.append(type)
             return t
 
         class DummyChannel(SimpleNamespace):
@@ -63,6 +65,7 @@ def test_open_threads(monkeypatch):
         flag = iso_to_flag("HU")
         expected_title = f"{flag} 2025 Hungarian GP | Qualifying — Sat 07:00 PDT"
         assert created == [expected_title]
+        assert thread_types == [discord.ChannelType.public_thread]
         assert marked == [(1, 123)]
         assert sent[0].startswith(f"**{flag} 2025 Hungarian GP – Qualifying**")
 

--- a/tests/test_seahawks_thread_cog.py
+++ b/tests/test_seahawks_thread_cog.py
@@ -23,10 +23,12 @@ def test_opens_thread_with_projection(monkeypatch):
         monkeypatch.setattr(cog, "fetch_projection", lambda gid: projection)
 
         created = []
+        thread_types = []
         sent = []
 
-        async def fake_create_thread(name, auto_archive_duration=None):
+        async def fake_create_thread(name, auto_archive_duration=None, type=None):
             created.append(name)
+            thread_types.append(type)
             return SimpleNamespace(send=lambda msg: sent.append(msg))
 
         channel = SimpleNamespace(create_thread=fake_create_thread)
@@ -39,6 +41,7 @@ def test_opens_thread_with_projection(monkeypatch):
 
         await cog._open_threads()
         assert created == ["🏈 LAR @ SEA (1/1, 5:30pm PST)"]
+        assert thread_types == [discord.ChannelType.public_thread]
         assert "Projected score: Seahawks 24 - Rams 21" in sent[0]
         assert "Win odds: Seahawks 55.0%, Rams 45.0%" in sent[0]
 


### PR DESCRIPTION
## Summary
- create F1 session threads as public threads
- ensure Seahawks game threads are public and tested

## Testing
- `python -m pytest -q` *(fails: tests/test_prompt_cog.py::test_engagement_bait_category_and_fallback, tests/test_prompt_cog.py::test_sports_news_category_and_fallback)*
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4b97bc824832b95515aead4494d2f