### PR TITLE
Use free-tier Gemini image model

### DIFF
--- a/gentlebot/llm/router.py
+++ b/gentlebot/llm/router.py
@@ -57,7 +57,7 @@ class LLMRouter:
         self.models = {
             "general": os.getenv("MODEL_GENERAL", "gemini-2.5-flash"),
             "scheduled": os.getenv("MODEL_SCHEDULED", "gemini-2.5-pro"),
-            "image": os.getenv("MODEL_IMAGE", "gemini-2.5-flash-image-preview"),
+            "image": os.getenv("MODEL_IMAGE", "gemini-2.0-flash-preview-image"),
         }
         def _limit(route: str, default: Limit) -> Limit:
             prefix = f"GEMINI_{route.upper()}_"
@@ -74,7 +74,7 @@ class LLMRouter:
             {
                 "general": _limit("general", Limit(rpm=15, tpm=1_000_000, rpd=1_500)),
                 "scheduled": _limit("scheduled", Limit(rpm=2, tpm=1_000_000, rpd=1_500)),
-                "image": _limit("image", Limit(rpm=15, tpm=1_000_000, rpd=1_500)),
+                "image": _limit("image", Limit(rpm=10, tpm=1_000_000, rpd=1_500)),
             }
         )
 

--- a/tests/test_router_defaults.py
+++ b/tests/test_router_defaults.py
@@ -1,0 +1,11 @@
+from gentlebot.llm.router import LLMRouter
+
+
+def test_image_route_defaults_to_free_model(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "fake")
+    monkeypatch.delenv("MODEL_IMAGE", raising=False)
+    monkeypatch.delenv("GEMINI_IMAGE_RPM", raising=False)
+    router = LLMRouter()
+    assert router.models["image"] == "gemini-2.0-flash-preview-image"
+    assert router.quota.limits["image"].rpm == 10
+


### PR DESCRIPTION
## Summary
- default image route now uses free Gemini 2.0 Flash Preview Image model
- adjust image route quota to 10 RPM
- add test for image route defaults

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4b8b25198832ba9f91f3dba2d79ae