### PR TITLE
Fix Seahawks win probability parsing

### DIFF
--- a/gentlebot/cogs/seahawks_thread_cog.py
+++ b/gentlebot/cogs/seahawks_thread_cog.py
@@ -76,7 +76,12 @@ class SeahawksThreadCog(commands.Cog):
             ref = team.get("team", {}).get("$ref", "")
             team_id = ref.rstrip("/").split("/")[-1].split("?")[0]
             stats = {s.get("name"): s for s in team.get("statistics", [])}
-            win = stats.get("gameProjection", {}).get("value", 0.0) / 100
+            win_stat = (
+                stats.get("gameProjectionProbability")
+                or stats.get("teamOddsWinPercentage")
+                or stats.get("gameProjection")
+            )
+            win = win_stat.get("value", 0.0) / 100 if win_stat else 0.0
             return team_id, win
 
         home_id, home_win = _parse_team(data.get("homeTeam", {}))

--- a/tests/test_seahawks_thread_cog.py
+++ b/tests/test_seahawks_thread_cog.py
@@ -118,13 +118,19 @@ def test_fetch_projection(monkeypatch):
             "team": {
                 "$ref": "http://sports.core.api.espn.com/v2/sports/football/leagues/nfl/seasons/2024/teams/26?lang=en&region=us"
             },
-            "statistics": [{"name": "gameProjection", "value": 60.0}],
+            "statistics": [
+                {"name": "gameProjection", "value": 24.0},
+                {"name": "gameProjectionProbability", "value": 60.0},
+            ],
         },
         "awayTeam": {
             "team": {
                 "$ref": "http://sports.core.api.espn.com/v2/sports/football/leagues/nfl/seasons/2024/teams/10?lang=en&region=us"
             },
-            "statistics": [{"name": "gameProjection", "value": 40.0}],
+            "statistics": [
+                {"name": "gameProjection", "value": 16.0},
+                {"name": "teamOddsWinPercentage", "value": 40.0},
+            ],
         },
     }
 


### PR DESCRIPTION
## Summary
- use explicit win-probability stats from ESPN predictor instead of gameProjection points
- add test coverage for gameProjectionProbability and teamOddsWinPercentage

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4be4b0874832ba1f2dbc23983da4e