### PR TITLE
feat: preserve user mentions in LLM prompts

### DIFF
--- a/gentlebot/cogs/gemini_cog.py
+++ b/gentlebot/cogs/gemini_cog.py
@@ -73,8 +73,14 @@ class GeminiCog(commands.Cog):
             log.warning("GeminiCog disabled archive due to missing database URL")
 
     def strip_mentions(self, raw: str) -> str:
-        """Remove user and role mentions and collapse blank lines."""
-        text = self.MENTION_CLEANUP.sub("", raw)
+        """Replace user mentions with names, drop role mentions, collapse blanks."""
+
+        def repl(match: re.Match) -> str:
+            uid = int(match.group(1))
+            user = self.bot.get_user(uid)
+            return f"@{user_name(user) if user else uid}"
+
+        text = self.MENTION_CLEANUP.sub(repl, raw)
         text = self.DISALLOWED_PATTERN.sub("", text)
         text = re.sub(r"\n{3,}", "\n\n", text)
         return text.strip()

--- a/tests/test_gemini_cog.py
+++ b/tests/test_gemini_cog.py
@@ -135,6 +135,17 @@ def test_choose_emoji_llm_custom_and_standard(monkeypatch):
     assert result == "🔥"
 
 
+def test_sanitize_prompt_replaces_user_mentions(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "fake")
+    intents = discord.Intents.none()
+    bot = commands.Bot(command_prefix="!", intents=intents)
+    cog = GeminiCog(bot)
+    user = MagicMock()
+    user.display_name = "Spencer"
+    monkeypatch.setattr(bot, "get_user", lambda uid: user if uid == 1 else None)
+    assert cog.sanitize_prompt("<@1> hello") == "@Spencer hello"
+
+
 def test_on_message_includes_archive_context(monkeypatch):
     monkeypatch.setenv("GEMINI_API_KEY", "fake")
     intents = discord.Intents.none()


### PR DESCRIPTION
## Summary
- preserve user mentions by replacing them with display names before sending to the LLM
- add coverage for mention replacement behavior

## Testing
- `pytest -q`
- `python test_harness.py`

------
https://chatgpt.com/codex/tasks/task_e_68c4be14d0bc832b939ba28c5f927894