### PR TITLE
Update Seahawks game threads with quarterly score updates

### DIFF
--- a/gentlebot/cogs/seahawks_thread_cog.py
+++ b/gentlebot/cogs/seahawks_thread_cog.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, time, timezone
-from typing import Any
+from typing import Any, Dict, List, Tuple
 
 import requests
 from dateutil import parser
@@ -26,10 +26,16 @@ class SeahawksThreadCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self.opened: set[str] = set()
+        # Track created threads and score update progress
+        self.threads: Dict[str, discord.Thread] = {}
+        self.opponents: Dict[str, str] = {}
+        self.quarters_sent: Dict[str, int] = {}
         self.game_task.start()
+        self.score_task.start()
 
     async def cog_unload(self) -> None:  # pragma: no cover - cleanup
         self.game_task.cancel()
+        self.score_task.cancel()
 
     # ---- external data helpers -------------------------------------------------
     def fetch_schedule(self) -> list[dict[str, Any]]:
@@ -119,6 +125,35 @@ class SeahawksThreadCog(commands.Cog):
             "opp_win": opp_win,
         }
 
+    def fetch_linescores(self, game_id: str) -> List[Tuple[int, int]]:
+        """Return per-quarter scoring tuples for Seahawks and opponent."""
+        url = (
+            "https://site.api.espn.com/apis/site/v2/sports/football/nfl/summary?"
+            f"event={game_id}"
+        )
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        box = resp.json().get("boxscore", {})
+        teams = box.get("teams", [])
+        if len(teams) != 2:
+            return []
+        sea_team = next(
+            (t for t in teams if t.get("team", {}).get("abbreviation") == "SEA"),
+            None,
+        )
+        opp_team = next(
+            (t for t in teams if t.get("team", {}).get("abbreviation") != "SEA"),
+            None,
+        )
+        if not sea_team or not opp_team:
+            return []
+        sea_lines = [int(ls.get("value", 0)) for ls in sea_team.get("linescores", [])]
+        opp_lines = [int(ls.get("value", 0)) for ls in opp_team.get("linescores", [])]
+        quarters: List[Tuple[int, int]] = []
+        for idx in range(min(len(sea_lines), len(opp_lines))):
+            quarters.append((sea_lines[idx], opp_lines[idx]))
+        return quarters
+
     # ---- helpers ----------------------------------------------------------------
     def _now(self) -> datetime:
         return datetime.now(timezone.utc)
@@ -168,12 +203,46 @@ class SeahawksThreadCog(commands.Cog):
             except Exception:  # pragma: no cover - network
                 log.exception("Failed to send message for %s", title)
             self.opened.add(g["id"])
+            self.threads[g["id"]] = thread
+            self.opponents[g["id"]] = g["opponent"]
+            self.quarters_sent[g["id"]] = 0
 
     # ---- background loop -------------------------------------------------------
     @tasks.loop(minutes=30)
     async def game_task(self) -> None:
         await self.bot.wait_until_ready()
         await self._open_threads()
+
+    async def _update_scores(self) -> None:
+        """Send quarter score updates to active game threads."""
+        for gid, thread in list(self.threads.items()):
+            try:
+                lines = self.fetch_linescores(gid)
+            except Exception:  # pragma: no cover - network
+                log.exception("Failed to fetch scores for %s", gid)
+                continue
+            posted = self.quarters_sent.get(gid, 0)
+            if len(lines) <= posted:
+                continue
+            sea_tot = opp_tot = 0
+            for qnum, (sea_q, opp_q) in enumerate(lines, start=1):
+                sea_tot += sea_q
+                opp_tot += opp_q
+                if qnum <= posted:
+                    continue
+                msg = (
+                    f"End of Q{qnum}: Seahawks {sea_tot} - {self.opponents.get(gid, 'Opponent')} {opp_tot}"
+                )
+                try:
+                    await thread.send(msg)
+                except Exception:  # pragma: no cover - network
+                    log.exception("Failed to send score update for %s Q%s", gid, qnum)
+            self.quarters_sent[gid] = len(lines)
+
+    @tasks.loop(minutes=5)
+    async def score_task(self) -> None:
+        await self.bot.wait_until_ready()
+        await self._update_scores()
 
 
 async def setup(bot: commands.Bot):

--- a/tests/test_seahawks_thread_cog.py
+++ b/tests/test_seahawks_thread_cog.py
@@ -104,6 +104,7 @@ def test_fetch_schedule_skips_bye_week(monkeypatch):
     bot = commands.Bot(command_prefix="!", intents=intents)
     monkeypatch.setattr(bot, "loop", SimpleNamespace(create_task=lambda c: None))
     monkeypatch.setattr(SeahawksThreadCog, "game_task", SimpleNamespace(start=lambda: None))
+    monkeypatch.setattr(SeahawksThreadCog, "score_task", SimpleNamespace(start=lambda: None))
     cog = SeahawksThreadCog(bot)
 
     games = cog.fetch_schedule()
@@ -159,6 +160,7 @@ def test_fetch_projection(monkeypatch):
     bot = commands.Bot(command_prefix="!", intents=intents)
     monkeypatch.setattr(bot, "loop", SimpleNamespace(create_task=lambda c: None))
     monkeypatch.setattr(SeahawksThreadCog, "game_task", SimpleNamespace(start=lambda: None))
+    monkeypatch.setattr(SeahawksThreadCog, "score_task", SimpleNamespace(start=lambda: None))
     cog = SeahawksThreadCog(bot)
 
     proj = cog.fetch_projection("gid")
@@ -168,3 +170,42 @@ def test_fetch_projection(monkeypatch):
         "sea_win": 0.6,
         "opp_win": 0.4,
     }
+
+
+def test_quarter_score_updates(monkeypatch):
+    async def run_test():
+        intents = discord.Intents.none()
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        monkeypatch.setattr(bot, "loop", SimpleNamespace(create_task=lambda c: None))
+        cog = SeahawksThreadCog(bot)
+        monkeypatch.setattr(cog, "game_task", SimpleNamespace(start=lambda: None))
+        monkeypatch.setattr(cog, "score_task", SimpleNamespace(start=lambda: None))
+
+        start = PST.localize(datetime(2024, 1, 1, 17, 30)).astimezone(timezone.utc)
+        schedule = [{"id": "g1", "opponent": "Rams", "short": "LAR @ SEA", "start": start}]
+        monkeypatch.setattr(cog, "fetch_schedule", lambda: schedule)
+        monkeypatch.setattr(cog, "fetch_projection", lambda gid: {"sea_score": 0, "opp_score": 0, "sea_win": 0.5, "opp_win": 0.5})
+
+        sent: list[str] = []
+
+        async def fake_create_thread(name, auto_archive_duration=None, type=None):
+            return SimpleNamespace(send=lambda msg: sent.append(msg))
+
+        channel = SimpleNamespace(create_thread=fake_create_thread)
+        monkeypatch.setattr(bot, "get_channel", lambda cid: channel)
+        monkeypatch.setattr(discord, "TextChannel", SimpleNamespace)
+
+        now = PST.localize(datetime(2024, 1, 1, 9, 5)).astimezone(timezone.utc)
+        monkeypatch.setattr(cog, "_now", lambda: now)
+
+        await cog._open_threads()
+
+        monkeypatch.setattr(cog, "fetch_linescores", lambda gid: [(7, 3)])
+        await cog._update_scores()
+        assert sent[-1] == "End of Q1: Seahawks 7 - Rams 3"
+
+        monkeypatch.setattr(cog, "fetch_linescores", lambda gid: [(7, 3), (0, 10)])
+        await cog._update_scores()
+        assert sent[-1] == "End of Q2: Seahawks 7 - Rams 13"
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- Post end-of-quarter score updates in Seahawks game day threads
- Track game threads and fetch per-quarter scoring from ESPN
- Test quarterly updates and adjust existing Seahawks tests

## Testing
- `python -m pytest -q`
- `python test_harness.py` *(fails: Client has not been properly initialised)*


------
https://chatgpt.com/codex/tasks/task_e_68c71597ce9c832b8b65f6a9e43ed9c5