### PR TITLE
Update Seahawks game threads with quarterly score updates

### DIFF
--- a/gentlebot/cogs/seahawks_thread_cog.py
+++ b/gentlebot/cogs/seahawks_thread_cog.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, time, timezone
-from typing import Any
+from typing import Any, Dict, List, Tuple
 
 import requests
 from dateutil import parser
@@ -26,10 +26,16 @@ class SeahawksThreadCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self.opened: set[str] = set()
+        # Track created threads and score update progress
+        self.threads: Dict[str, discord.Thread] = {}
+        self.opponents: Dict[str, str] = {}
+        self.quarters_sent: Dict[str, int] = {}
         self.game_task.start()
+        self.score_task.start()
 
     async def cog_unload(self) -> None:  # pragma: no cover - cleanup
         self.game_task.cancel()
+        self.score_task.cancel()
 
     # ---- external data helpers -------------------------------------------------
     def fetch_schedule(self) -> list[dict[str, Any]]:
@@ -119,6 +125,48 @@ class SeahawksThreadCog(commands.Cog):
             "opp_win": opp_win,
         }
 
+    def fetch_linescores(self, game_id: str) -> List[Tuple[int, int]]:
+        """Return per-quarter scoring tuples for Seahawks and opponent.
+
+        Filters out the trailing total row included in ESPN's data so
+        each tuple represents an actual period (quarter or overtime).
+        """
+        url = (
+            "https://site.api.espn.com/apis/site/v2/sports/football/nfl/summary?"
+            f"event={game_id}"
+        )
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        box = resp.json().get("boxscore", {})
+        teams = box.get("teams", [])
+        if len(teams) != 2:
+            return []
+        sea_team = next(
+            (t for t in teams if t.get("team", {}).get("abbreviation") == "SEA"),
+            None,
+        )
+        opp_team = next(
+            (t for t in teams if t.get("team", {}).get("abbreviation") != "SEA"),
+            None,
+        )
+        if not sea_team or not opp_team:
+            return []
+        sea_lines = [int(ls.get("value", 0)) for ls in sea_team.get("linescores", [])]
+        opp_lines = [int(ls.get("value", 0)) for ls in opp_team.get("linescores", [])]
+
+        def _strip_total(lines: List[int]) -> List[int]:
+            """Remove trailing total row if present."""
+            if len(lines) >= 2 and lines[-1] == sum(lines[:-1]):
+                return lines[:-1]
+            return lines
+
+        sea_lines = _strip_total(sea_lines)
+        opp_lines = _strip_total(opp_lines)
+        quarters: List[Tuple[int, int]] = []
+        for idx in range(min(len(sea_lines), len(opp_lines))):
+            quarters.append((sea_lines[idx], opp_lines[idx]))
+        return quarters
+
     # ---- helpers ----------------------------------------------------------------
     def _now(self) -> datetime:
         return datetime.now(timezone.utc)
@@ -168,12 +216,46 @@ class SeahawksThreadCog(commands.Cog):
             except Exception:  # pragma: no cover - network
                 log.exception("Failed to send message for %s", title)
             self.opened.add(g["id"])
+            self.threads[g["id"]] = thread
+            self.opponents[g["id"]] = g["opponent"]
+            self.quarters_sent[g["id"]] = 0
 
     # ---- background loop -------------------------------------------------------
     @tasks.loop(minutes=30)
     async def game_task(self) -> None:
         await self.bot.wait_until_ready()
         await self._open_threads()
+
+    async def _update_scores(self) -> None:
+        """Send quarter score updates to active game threads."""
+        for gid, thread in list(self.threads.items()):
+            try:
+                lines = self.fetch_linescores(gid)
+            except Exception:  # pragma: no cover - network
+                log.exception("Failed to fetch scores for %s", gid)
+                continue
+            posted = self.quarters_sent.get(gid, 0)
+            if len(lines) <= posted:
+                continue
+            sea_tot = opp_tot = 0
+            for qnum, (sea_q, opp_q) in enumerate(lines, start=1):
+                sea_tot += sea_q
+                opp_tot += opp_q
+                if qnum <= posted:
+                    continue
+                msg = (
+                    f"End of Q{qnum}: Seahawks {sea_tot} - {self.opponents.get(gid, 'Opponent')} {opp_tot}"
+                )
+                try:
+                    await thread.send(msg)
+                except Exception:  # pragma: no cover - network
+                    log.exception("Failed to send score update for %s Q%s", gid, qnum)
+            self.quarters_sent[gid] = len(lines)
+
+    @tasks.loop(minutes=5)
+    async def score_task(self) -> None:
+        await self.bot.wait_until_ready()
+        await self._update_scores()
 
 
 async def setup(bot: commands.Bot):

--- a/tests/test_seahawks_thread_cog.py
+++ b/tests/test_seahawks_thread_cog.py
@@ -104,6 +104,7 @@ def test_fetch_schedule_skips_bye_week(monkeypatch):
     bot = commands.Bot(command_prefix="!", intents=intents)
     monkeypatch.setattr(bot, "loop", SimpleNamespace(create_task=lambda c: None))
     monkeypatch.setattr(SeahawksThreadCog, "game_task", SimpleNamespace(start=lambda: None))
+    monkeypatch.setattr(SeahawksThreadCog, "score_task", SimpleNamespace(start=lambda: None))
     cog = SeahawksThreadCog(bot)
 
     games = cog.fetch_schedule()
@@ -159,6 +160,7 @@ def test_fetch_projection(monkeypatch):
     bot = commands.Bot(command_prefix="!", intents=intents)
     monkeypatch.setattr(bot, "loop", SimpleNamespace(create_task=lambda c: None))
     monkeypatch.setattr(SeahawksThreadCog, "game_task", SimpleNamespace(start=lambda: None))
+    monkeypatch.setattr(SeahawksThreadCog, "score_task", SimpleNamespace(start=lambda: None))
     cog = SeahawksThreadCog(bot)
 
     proj = cog.fetch_projection("gid")
@@ -168,3 +170,137 @@ def test_fetch_projection(monkeypatch):
         "sea_win": 0.6,
         "opp_win": 0.4,
     }
+
+
+def test_quarter_score_updates(monkeypatch):
+    async def run_test():
+        intents = discord.Intents.none()
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        monkeypatch.setattr(bot, "loop", SimpleNamespace(create_task=lambda c: None))
+        cog = SeahawksThreadCog(bot)
+        monkeypatch.setattr(cog, "game_task", SimpleNamespace(start=lambda: None))
+        monkeypatch.setattr(cog, "score_task", SimpleNamespace(start=lambda: None))
+
+        start = PST.localize(datetime(2024, 1, 1, 17, 30)).astimezone(timezone.utc)
+        schedule = [{"id": "g1", "opponent": "Rams", "short": "LAR @ SEA", "start": start}]
+        monkeypatch.setattr(cog, "fetch_schedule", lambda: schedule)
+        monkeypatch.setattr(cog, "fetch_projection", lambda gid: {"sea_score": 0, "opp_score": 0, "sea_win": 0.5, "opp_win": 0.5})
+
+        sent: list[str] = []
+
+        async def fake_create_thread(name, auto_archive_duration=None, type=None):
+            async def _send(msg):
+                sent.append(msg)
+            return SimpleNamespace(send=_send)
+
+        channel = SimpleNamespace(create_thread=fake_create_thread)
+        monkeypatch.setattr(bot, "get_channel", lambda cid: channel)
+        monkeypatch.setattr(discord, "TextChannel", SimpleNamespace)
+
+        now = PST.localize(datetime(2024, 1, 1, 9, 5)).astimezone(timezone.utc)
+        monkeypatch.setattr(cog, "_now", lambda: now)
+
+        await cog._open_threads()
+        sent.clear()
+
+        responses = [
+            {
+                "boxscore": {
+                    "teams": [
+                        {
+                            "team": {"abbreviation": "SEA"},
+                            "linescores": [
+                                {"period": "1", "value": 7},
+                                {"period": "T", "value": 7},
+                            ],
+                        },
+                        {
+                            "team": {"abbreviation": "LAR"},
+                            "linescores": [
+                                {"period": "1", "value": 3},
+                                {"period": "T", "value": 3},
+                            ],
+                        },
+                    ]
+                }
+            },
+            {
+                "boxscore": {
+                    "teams": [
+                        {
+                            "team": {"abbreviation": "SEA"},
+                            "linescores": [
+                                {"period": "1", "value": 7},
+                                {"period": "2", "value": 0},
+                                {"period": "T", "value": 7},
+                            ],
+                        },
+                        {
+                            "team": {"abbreviation": "LAR"},
+                            "linescores": [
+                                {"period": "1", "value": 3},
+                                {"period": "2", "value": 10},
+                                {"period": "T", "value": 13},
+                            ],
+                        },
+                    ]
+                }
+            },
+            {
+                "boxscore": {
+                    "teams": [
+                        {
+                            "team": {"abbreviation": "SEA"},
+                            "linescores": [
+                                {"period": "1", "value": 7},
+                                {"period": "2", "value": 0},
+                                {"period": "3", "value": 7},
+                                {"period": "4", "value": 3},
+                                {"period": "T", "value": 17},
+                            ],
+                        },
+                        {
+                            "team": {"abbreviation": "LAR"},
+                            "linescores": [
+                                {"period": "1", "value": 3},
+                                {"period": "2", "value": 10},
+                                {"period": "3", "value": 0},
+                                {"period": "4", "value": 7},
+                                {"period": "T", "value": 20},
+                            ],
+                        },
+                    ]
+                }
+            },
+        ]
+
+        def fake_get(url, timeout=10):
+            data = responses.pop(0) if responses else responses[-1]
+            class FakeResp:
+                def json(self):
+                    return data
+
+                def raise_for_status(self):
+                    pass
+
+            return FakeResp()
+
+        monkeypatch.setattr(
+            "gentlebot.cogs.seahawks_thread_cog.requests.get", fake_get
+        )
+
+        await cog._update_scores()
+        assert sent[-1] == "End of Q1: Seahawks 7 - Rams 3"
+
+        await cog._update_scores()
+        assert sent[-1] == "End of Q2: Seahawks 7 - Rams 13"
+
+        await cog._update_scores()
+        assert sent[-1] == "End of Q4: Seahawks 17 - Rams 20"
+        assert len(sent) == 4
+        assert not any("Q5" in m for m in sent)
+
+        await cog._update_scores()
+        assert len(sent) == 4
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- Post end-of-quarter score updates in Seahawks game day threads
- Filter ESPN linescores to discard total rows and keep running tallies accurate
- Test final-score handling to ensure only four quarter messages are posted

## Testing
- `python -m pytest -q`
- `python test_harness.py` *(fails: Client has not been properly initialised)*

------
https://chatgpt.com/codex/tasks/task_e_68c71597ce9c832b8b65f6a9e43ed9c5