### PR TITLE
Add ESPN Big Dumper tracker with compact output

### DIFF
--- a/gentlebot/big_dumper_espn.py
+++ b/gentlebot/big_dumper_espn.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+"""Fetch Big Dumper data from ESPN's public APIs."""
+
+import re
+from datetime import datetime
+from typing import Any
+
+import aiohttp
+from dateutil import tz
+
+# Seattle team/athlete constants
+SEA_TEAM_ABBR = "SEA"
+SEA_TEAM_NAME = "Mariners"
+SEA_TEAM_SLUG = "sea"
+RALEIGH_ID = 41459
+
+UTC = tz.gettz("UTC")
+
+
+class ESPN:
+    """Thin async wrapper around the unofficial ESPN MLB endpoints."""
+
+    BASE_COMMON = "https://site.api.espn.com/apis/common/v3/sports/baseball/mlb"
+    BASE_V2 = "https://site.api.espn.com/apis/v2/sports/baseball/mlb"
+
+    def __init__(self, session: aiohttp.ClientSession) -> None:
+        self.sess = session
+
+    async def get(self, url: str, **params: Any) -> Any:
+        async with self.sess.get(url, params=params, timeout=20) as r:
+            r.raise_for_status()
+            return await r.json()
+
+    async def athlete(self, athlete_id: int) -> Any:
+        return await self.get(f"{self.BASE_COMMON}/athletes/{athlete_id}")
+
+    async def athlete_splits(self, athlete_id: int, season: int) -> Any:
+        return await self.get(f"{self.BASE_COMMON}/athletes/{athlete_id}/splits", season=season)
+
+    async def athlete_gamelog(self, athlete_id: int, season: int) -> Any:
+        return await self.get(f"{self.BASE_COMMON}/athletes/{athlete_id}/gamelog", season=season)
+
+    async def team_with_schedule(self, team_slug: str) -> Any:
+        return await self.get(f"{self.BASE_V2}/teams/{team_slug}", enable="schedule")
+
+    async def standings(self, season: int) -> Any:
+        return await self.get(f"{self.BASE_V2}/standings", season=season)
+
+    async def playbyplay(self, event_id: str) -> Any:
+        return await self.get(f"{self.BASE_V2}/playbyplay", event=event_id)
+
+    async def summary(self, event_id: str) -> Any:
+        return await self.get(f"{self.BASE_V2}/summary", event=event_id)
+
+
+def _find_stat(stats_obj: dict | None, key_names: list[str]) -> str | None:
+    if not stats_obj:
+        return None
+    try:
+        for split in stats_obj.get("splits", []):
+            for cat in split.get("categories", []):
+                for st in cat.get("stats", []):
+                    name = (st.get("name") or st.get("displayName") or "").lower()
+                    if any(k.lower() == name for k in key_names):
+                        return st.get("value") or st.get("displayValue")
+    except Exception:
+        pass
+    return None
+
+
+def _fmt_pct(val: str | None) -> str | None:
+    if not val:
+        return None
+    try:
+        v = float(val)
+        return f"{v:.3f}".lstrip("0")
+    except Exception:
+        return val
+
+
+def _parse_split_line(split_group: dict, label: str) -> dict:
+    for grp in split_group.get("splits", []):
+        if str(grp.get("displayName", "")).lower().startswith(label.lower()):
+            cats: dict[str, str] = {}
+            for cat in grp.get("categories", []):
+                for st in cat.get("stats", []):
+                    cats[st.get("name", "")] = st.get("value") or st.get("displayValue")
+            avg = _fmt_pct(cats.get("avg") or cats.get("battingAverage"))
+            obp = _fmt_pct(cats.get("obp") or cats.get("onBasePct"))
+            slg = _fmt_pct(cats.get("slg") or cats.get("sluggingPct"))
+            hr = cats.get("homeRuns") or cats.get("HR")
+            return {"slash": f"{avg}/{obp}/{slg}" if all([avg, obp, slg]) else None, "hr": hr}
+    return {"slash": None, "hr": None}
+
+
+def _feet_ev_from_text(text: str) -> tuple[str | None, str | None]:
+    if not text:
+        return None, None
+    ft = re.search(r"(\d{3,4})\s?ft", text)
+    ev = re.search(r"(\d{2,3}\.\d)\s?mph", text)
+    return (ft.group(1) if ft else None, ev.group(1) if ev else None)
+
+
+def _local_day(dt_iso: str, tz_name: str = "America/Los_Angeles") -> str:
+    try:
+        from_zone = tz.gettz("UTC")
+        to_zone = tz.gettz(tz_name)
+        dt = datetime.fromisoformat(dt_iso.replace("Z", "+00:00")).astimezone(to_zone)
+        return dt.strftime("%b %d")
+    except Exception:
+        return dt_iso[:10]
+
+
+async def gather_big_dumper_data(athlete_id: int = RALEIGH_ID, season: int | None = None) -> dict:
+    season = season or datetime.now(tz=UTC).year
+    async with aiohttp.ClientSession(headers={"User-Agent": "gentlebot/1.0"}) as s:
+        api = ESPN(s)
+        athlete_json = await api.athlete(athlete_id)
+        stats = athlete_json.get("statistics") or {}
+        hr = _find_stat(stats, ["homeRuns", "HR"])
+        rbi = _find_stat(stats, ["runsBattedIn", "RBI"])
+        ops = _fmt_pct(_find_stat(stats, ["ops"]))
+        slg = _fmt_pct(_find_stat(stats, ["sluggingPct", "SLG"]))
+        avg = _fmt_pct(_find_stat(stats, ["battingAverage", "AVG"]))
+
+        splits = await api.athlete_splits(athlete_id, season)
+        l7 = _parse_split_line(splits, "last 7")
+        l15 = _parse_split_line(splits, "last 15")
+        post = _parse_split_line(splits, "post all-star") or _parse_split_line(splits, "since all-star")
+
+        gamelog = await api.athlete_gamelog(athlete_id, season)
+        games = gamelog.get("events") or gamelog.get("items") or []
+        normalized = []
+        for g in games:
+            event_id = str(g.get("id") or g.get("eventId") or g.get("event", {}).get("id", ""))
+            abbr_opp = (
+                g.get("opponent", {}).get("abbreviation")
+                or g.get("opponent", {}).get("shortDisplayName", "")
+            )
+            homeAway = g.get("homeAway") or (g.get("isHome") and "home" or "away")
+            stats_map: dict[str, Any] = {}
+            for st in g.get("stats") or []:
+                stats_map[st.get("name") or st.get("displayName")] = st.get("value") or st.get("displayValue")
+            normalized.append(
+                {
+                    "eventId": event_id,
+                    "date": g.get("date") or g.get("startDate") or "",
+                    "opponent": abbr_opp,
+                    "homeAway": homeAway,
+                    "HR": int(str(stats_map.get("homeRuns") or stats_map.get("HR") or 0) or 0),
+                }
+            )
+        team_games_played = len([g for g in normalized if g.get("date")])
+        hr_int = int(hr or 0)
+        pace = round((hr_int / max(team_games_played, 1)) * 162)
+
+        latest_hr_events = [
+            g
+            for g in sorted(normalized, key=lambda x: x["date"], reverse=True)
+            if g.get("HR", 0) > 0
+        ][:3]
+        last_hr_detail: dict[str, Any] | None = None
+        last3_lines: list[tuple[str, str]] = []
+        for idx, g in enumerate(latest_hr_events):
+            pbp = await api.playbyplay(g["eventId"]) if g["eventId"] else {}
+            play_hit = None
+            for drive in pbp.get("drives", []) + pbp.get("items", []):
+                plays = drive.get("plays", []) if "plays" in drive else [drive]
+                for pl in plays:
+                    t = (pl.get("type", {}) or {}).get("text", "").lower()
+                    inv = pl.get("athletesInvolved") or []
+                    if "home run" in t or "homered" in (pl.get("text", "").lower()):
+                        if any(str(a.get("id")) == str(athlete_id) for a in inv):
+                            play_hit = pl
+                            break
+                if play_hit:
+                    break
+            if play_hit:
+                text = play_hit.get("text") or play_hit.get("headline") or ""
+                ft, ev = _feet_ev_from_text(text)
+                media = play_hit.get("media") or {}
+                video_url = None
+                if isinstance(media, dict):
+                    for l in media.get("links", []):
+                        if l.get("href"):
+                            video_url = l["href"]
+                            break
+                if not video_url:
+                    video_url = f"https://www.espn.com/mlb/playbyplay/_/gameId/{g['eventId']}"
+                if idx == 0:
+                    last_hr_detail = {
+                        "num": hr,
+                        "date": _local_day(g["date"]),
+                        "opp": g["opponent"],
+                        "ft": ft,
+                        "ev": ev,
+                        "url": video_url,
+                    }
+                line = f"#{int(hr_int - (idx))}  {g['date'][:10]}  {'@' if g['homeAway']=='away' else 'vs'}{g['opponent']}"
+                if ft or ev:
+                    line += f"  {ft + ' ft' if ft else ''}{'  ' if ft and ev else ''}{ev + ' EV' if ev else ''}"
+                line += "  Video"
+                last3_lines.append((line, video_url))
+            else:
+                line = f"#{int(hr_int - (idx))}  {g['date'][:10]}  {'@' if g['homeAway']=='away' else 'vs'}{g['opponent']}"
+                last3_lines.append((line, f"https://www.espn.com/mlb/game/_/gameId/{g['eventId']}"))
+
+        std = await api.standings(season)
+        al_west = None
+        def iter_teams(node):
+            for ch in node.get("children", []):
+                yield ch
+                yield from iter_teams(ch)
+        for g in iter_teams(std):
+            if g.get("name", "").lower() in ("al west", "american league west", "west"):
+                if any("American League" in (p.get("name", "")) for p in g.get("parents", [])) or "al" in (
+                    g.get("abbreviation", "").lower()
+                ):
+                    al_west = g
+        if not al_west:
+            candidates = [
+                g
+                for g in iter_teams(std)
+                if g.get("standings", {}).get("entries")
+                and len(g["standings"]["entries"]) == 5
+                and "west" in g.get("name", "").lower()
+            ]
+            al_west = candidates[0] if candidates else None
+
+        rank = gb = streak = last10 = "—"
+        record_overall = division_leader = "—"
+        if al_west:
+            entries = al_west["standings"]["entries"]
+            norm = []
+            for e in entries:
+                t = e.get("team", {})
+                recs = {i.get("type"): i for i in e.get("records", [])}
+                overall = recs.get("overall") or recs.get("total")
+                gb_val = recs.get("division").get("gamesBehind") if recs.get("division") else None
+                streak_val = (
+                    next((i.get("summary") for i in e.get("streaks", []) if i.get("type") == "current"), None)
+                    or overall.get("streak")
+                )
+                last10_val = next(
+                    (i.get("summary") for i in e.get("records", []) if i.get("name", "").lower() == "last 10"),
+                    None,
+                )
+                if not last10_val:
+                    last10_val = next(
+                        (i.get("summary") for i in e.get("stats", []) if i.get("name", "").lower() == "last10"),
+                        None,
+                    )
+                norm.append(
+                    {
+                        "abbr": t.get("abbreviation"),
+                        "name": t.get("displayName"),
+                        "rank": e.get("rank"),
+                        "overall": overall.get("summary") if overall else "",
+                        "gb": str(gb_val) if gb_val is not None else "—",
+                        "streak": streak_val or "—",
+                        "last10": last10_val or "—",
+                    }
+                )
+            leader = norm[0]["abbr"] if norm else "—"
+            for row in norm:
+                if row["abbr"] == SEA_TEAM_ABBR:
+                    rank, gb, streak, last10 = row["rank"], row["gb"], row["streak"], row["last10"]
+                    record_overall = row["overall"]
+                    division_leader = leader
+
+        data = {
+            "season_strip": {
+                "HR": hr,
+                "RBI": rbi,
+                "OPS": ops,
+                "SLG": slg,
+                "AVG": avg,
+            },
+            "recent": {"l7": l7, "l15": l15, "post": post},
+            "pace": pace,
+            "latest_hr": last_hr_detail,
+            "last3_hrs": last3_lines,
+            "standings": {
+                "rank": rank,
+                "gb": gb,
+                "streak": streak,
+                "last10": last10,
+                "overall": record_overall,
+                "leader": division_leader,
+            },
+        }
+        return data
+
+
+def build_compact_message(d: dict) -> str:
+    s = d["season_strip"]
+    st = d["standings"]
+    l7 = d["recent"]["l7"]["slash"]
+    l7_hr = d["recent"]["l7"]["hr"]
+    line: list[str] = []
+    line.append(f"Big Dumper Tracker — {datetime.now().strftime('%b %d')}")
+    strip = f"Season   HR {s['HR']} • RBI {s['RBI']} • OPS {s['OPS']}"
+    line.append(strip)
+    if l7:
+        recent = f"Recent   L7: {l7} ({l7_hr or 0} HR) • Streak: {st['streak']}"
+        line.append(recent)
+    line.append(f"Pace     {d['pace']} HR over 162")
+    if d["latest_hr"]:
+        L = d["latest_hr"]
+        meta = " • ".join(
+            x
+            for x in [
+                f"{L['date']}",
+                f"@{L['opp']}",
+                f"{L['ft']} ft" if L['ft'] else None,
+                f"{L['ev']} EV" if L['ev'] else None,
+            ]
+            if x
+        )
+        line.append(f"Latest   #{L['num']} — {meta} — Video: {L['url']}")
+    line.append(
+        f"AL West  {st['rank']} • {st['gb']} GB of {st['leader']} • L10: {st['last10']}"
+    )
+    return "```\n" + "\n".join(line) + "\n```"
+
+
+def build_rich_embed_payload(d: dict) -> dict:
+    s, st = d["season_strip"], d["standings"]
+    desc = (
+        f"HR **{s['HR']}** • RBI **{s['RBI']}** • OPS **{s['OPS']}** • SLG {s['SLG']} • AVG {s['AVG']}"
+    )
+    l7 = d["recent"]["l7"]["slash"]
+    l7hr = d["recent"]["l7"]["hr"]
+    l15 = d["recent"]["l15"]["slash"]
+    l15hr = d["recent"]["l15"]["hr"]
+    post = d["recent"]["post"]["slash"]
+    posthr = d["recent"]["post"]["hr"]
+    form_lines = []
+    if l7:
+        form_lines.append(f"**L7**  {l7} ({l7hr or 0} HR)")
+    if l15:
+        form_lines.append(f"**L15** {l15} ({l15hr or 0} HR)")
+    if post:
+        form_lines.append(f"**Post** {post} (since ASG)")
+    form_val = "\n".join(form_lines) if form_lines else "—"
+    if d["last3_hrs"]:
+        last3 = "\n".join([f"{t}  [Video]({u})" for (t, u) in d["last3_hrs"]])
+    else:
+        last3 = "—"
+    fields = [
+        {"name": "Form", "value": form_val, "inline": True},
+        {"name": "Last 3 HRs", "value": last3, "inline": True},
+        {
+            "name": "AL West",
+            "value": f"{st['rank']} • {st['gb']} GB of {st['leader']} • L10: {st['last10']}",
+            "inline": False,
+        },
+        {"name": "Pace", "value": f"{d['pace']} HR over 162", "inline": True},
+    ]
+    payload = {
+        "title": f"Big Dumper — Season Snapshot ({datetime.now().strftime('%b %d')})",
+        "description": desc,
+        "fields": fields,
+        "thumbnail": {"url": "https://a.espncdn.com/i/teamlogos/mlb/500/sea.png"},
+        "color": 10181046,
+    }
+    return payload
+
+
+async def demo(style: str = "compact") -> Any:
+    data = await gather_big_dumper_data(RALEIGH_ID)
+    if style == "compact":
+        return build_compact_message(data)
+    return build_rich_embed_payload(data)

--- a/gentlebot/cogs/bigdumper_watcher_cog.py
+++ b/gentlebot/cogs/bigdumper_watcher_cog.py
@@ -5,8 +5,7 @@ import asyncio
 import logging
 from datetime import datetime
 
-import requests
-from requests.adapters import HTTPAdapter, Retry
+import aiohttp
 import discord
 from discord.ext import commands, tasks
 
@@ -22,44 +21,44 @@ class BigDumperWatcherCog(commands.Cog):
 
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
-        self.session = requests.Session()
-        retries = Retry(
-            total=3,
-            backoff_factor=1,
-            status_forcelist=[500, 502, 503, 504],
-            allowed_methods=["GET"],
-        )
-        adapter = HTTPAdapter(max_retries=retries)
-        self.session.mount("https://", adapter)
-        self.session.mount("http://", adapter)
+        timeout = aiohttp.ClientTimeout(total=STATS_TIMEOUT)
+        self.session = aiohttp.ClientSession(timeout=timeout)
         self.last_hr = 0
 
     async def cog_load(self) -> None:
         try:
-            self.last_hr = await asyncio.to_thread(self._fetch_hr)
+            self.last_hr = await self._fetch_hr()
         except Exception as exc:  # pragma: no cover - network
             log.warning("Failed to fetch initial HR count: %s", exc)
         self.check_task.start()
 
-    async def cog_unload(self) -> None:
+    def cog_unload(self) -> None:
         self.check_task.cancel()
-        self.session.close()
+        if not self.session.closed:
+            asyncio.create_task(self.session.close())
 
-    def _fetch_hr(self) -> int:
+    async def _fetch_hr(self) -> int:
         year = datetime.now().year
         url = f"https://statsapi.mlb.com/api/v1/people/{PLAYER_ID}/stats"
         params = {"stats": "season", "group": "hitting", "season": year}
-        resp = self.session.get(url, params=params, timeout=STATS_TIMEOUT)
-        resp.raise_for_status()
-        data = resp.json()
-        return int(data["stats"][0]["splits"][0]["stat"].get("homeRuns", 0))
+        for attempt in range(3):
+            try:
+                async with self.session.get(url, params=params) as resp:
+                    resp.raise_for_status()
+                    data = await resp.json()
+                    return int(data["stats"][0]["splits"][0]["stat"].get("homeRuns", 0))
+            except aiohttp.ClientError as exc:
+                if attempt == 2:
+                    raise exc
+                await asyncio.sleep(1)
+        return 0
 
     @tasks.loop(minutes=10)
     async def check_task(self) -> None:
         await self.bot.wait_until_ready()
         try:
-            hr = await asyncio.to_thread(self._fetch_hr)
-        except requests.RequestException as exc:  # pragma: no cover - network
+            hr = await self._fetch_hr()
+        except aiohttp.ClientError as exc:  # pragma: no cover - network
             log.warning("Failed to fetch HR count: %s", exc)
             return
         except Exception as exc:  # pragma: no cover - network

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aiohttp
 discord.py>=2.3
 requests
 feedparser

--- a/tests/test_sports_bigdumper.py
+++ b/tests/test_sports_bigdumper.py
@@ -1,0 +1,90 @@
+import asyncio
+from types import SimpleNamespace
+
+import discord
+from discord.ext import commands
+from discord import app_commands
+
+from gentlebot.cogs import sports_cog
+from gentlebot import big_dumper_espn
+
+
+sample_data = {
+    "season_strip": {"HR": "10", "RBI": "30", "OPS": ".800", "SLG": ".500", "AVG": ".250"},
+    "recent": {
+        "l7": {"slash": "0.200/0.300/0.400", "hr": "1"},
+        "l15": {"slash": "0.250/0.320/0.450", "hr": "2"},
+        "post": {"slash": "0.260/0.350/0.500", "hr": "5"},
+    },
+    "pace": 30,
+    "latest_hr": {"num": "10", "date": "Jun 10", "opp": "LAA", "ft": "420", "ev": "110", "url": "http://video"},
+    "last3_hrs": [("line1", "url1"), ("line2", "url2")],
+    "standings": {"rank": "1", "gb": "0", "streak": "W3", "last10": "7-3", "overall": "40-30", "leader": "SEA"},
+}
+
+
+class DummyResponse:
+    def __init__(self):
+        self.deferred = False
+
+    async def defer(self, *, thinking=True):
+        self.deferred = True
+
+
+class DummyFollowup:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, content=None, **kwargs):
+        self.sent.append((content, kwargs))
+
+
+class DummyInteraction:
+    def __init__(self):
+        self.response = DummyResponse()
+        self.followup = DummyFollowup()
+        self.user = SimpleNamespace(id=1)
+        self.channel = SimpleNamespace(id=1, name="chan")
+
+
+def test_bigdumper_compact(monkeypatch):
+    async def fake_gather(*args, **kwargs):
+        return sample_data
+
+    monkeypatch.setattr(big_dumper_espn, "gather_big_dumper_data", fake_gather)
+
+    async def inner():
+        intents = discord.Intents.none()
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        await bot.load_extension("gentlebot.cogs.sports_cog")
+        cog = bot.get_cog("SportsCog")
+        interaction = DummyInteraction()
+        choice = app_commands.Choice(name="Compact", value="compact")
+        await sports_cog.SportsCog.bigdumper.callback(cog, interaction, type=choice)
+        assert interaction.followup.sent[0][0].startswith("```")
+        await bot.close()
+
+    asyncio.run(inner())
+
+
+def test_bigdumper_full_default(monkeypatch):
+    async def fake_gather(*args, **kwargs):
+        return sample_data
+
+    monkeypatch.setattr(big_dumper_espn, "gather_big_dumper_data", fake_gather)
+
+    async def inner():
+        intents = discord.Intents.none()
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        await bot.load_extension("gentlebot.cogs.sports_cog")
+        cog = bot.get_cog("SportsCog")
+        interaction = DummyInteraction()
+        await sports_cog.SportsCog.bigdumper.callback(cog, interaction, type=None)
+        content, kwargs = interaction.followup.sent[0]
+        assert content is None
+        embed = kwargs.get("embed")
+        assert isinstance(embed, discord.Embed)
+        assert embed.title.startswith("Big Dumper — Season Snapshot")
+        await bot.close()
+
+    asyncio.run(inner())

--- a/tests/test_stats_timeout.py
+++ b/tests/test_stats_timeout.py
@@ -1,44 +1,13 @@
-import types
+import asyncio
 
-import pytest
 from gentlebot.cogs.bigdumper_watcher_cog import BigDumperWatcherCog
-from gentlebot.cogs.sports_cog import SportsCog, STATS_TIMEOUT
+from gentlebot.cogs.sports_cog import STATS_TIMEOUT
 
 
-class DummyResp:
-    def __init__(self, data=None):
-        self._data = data or {"stats": [{"splits": [{"stat": {"homeRuns": 7}}]}]}
+def test_session_timeout_default():
+    async def run_test():
+        cog = BigDumperWatcherCog(bot=None)
+        assert cog.session.timeout.total == STATS_TIMEOUT
+        await cog.session.close()
 
-    def raise_for_status(self):
-        pass
-
-    def json(self):
-        return self._data
-
-
-def test_fetch_hr_uses_timeout(monkeypatch):
-    cog = BigDumperWatcherCog(bot=None)
-    called = {}
-
-    def fake_get(url, params=None, timeout=None):
-        called['timeout'] = timeout
-        return DummyResp()
-
-    monkeypatch.setattr(cog.session, 'get', fake_get)
-    hr = cog._fetch_hr()
-    assert hr == 7
-    assert called['timeout'] == STATS_TIMEOUT
-
-
-def test_fetch_season_stats_uses_timeout(monkeypatch):
-    cog = SportsCog(bot=None)
-    called = {}
-
-    def fake_get(url, params=None, timeout=None):
-        called['timeout'] = timeout
-        return DummyResp()
-
-    monkeypatch.setattr(cog.session, 'get', fake_get)
-    stats = cog.fetch_season_stats()
-    assert called['timeout'] == STATS_TIMEOUT
-    assert stats.get('homeRuns') == 7
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- switch /bigdumper to ESPN endpoints with support for rich or compact views
- expose new `/bigdumper type` option (compact or full)
- cover Big Dumper command with unit tests
- refactor Big Dumper watcher to use async HTTP for non-blocking HR checks
- ensure Big Dumper watcher cancels loop and closes HTTP session on unload

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68c78e3db098832b96beeded0a1c4adb