### PR TITLE
Avoid duplicate Mariners game posts and refine summary formatting

### DIFF
--- a/gentlebot/cogs/mariners_game_cog.py
+++ b/gentlebot/cogs/mariners_game_cog.py
@@ -10,12 +10,14 @@ import asyncio
 import requests
 from requests.adapters import HTTPAdapter, Retry
 import pytz
+import asyncpg
 
 import discord
 from discord.ext import commands, tasks
 
 from .sports_cog import TEAM_ID, STATS_TIMEOUT, PST_TZ
 from .. import bot_config as cfg
+from ..db import get_pool
 
 log = logging.getLogger(f"gentlebot.{__name__}")
 
@@ -26,8 +28,19 @@ class MarinersGameCog(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
         self.posted: set[int] = set()
+        self.pool: asyncpg.Pool | None = None
 
     async def cog_load(self) -> None:  # pragma: no cover - startup
+        try:
+            self.pool = await get_pool()
+            await self._ensure_table()
+            await self._load_posted()
+        except Exception as exc:
+            log.warning(
+                "Database unavailable; MarinersGameCog state will not persist: %s",
+                exc,
+            )
+            self.pool = None
         self.game_task.start()
 
     async def cog_unload(self) -> None:  # pragma: no cover - cleanup
@@ -38,6 +51,35 @@ class MarinersGameCog(commands.Cog):
         today = datetime.now(PST_TZ).date()
         yesterday = today - timedelta(days=1)
         return [today.isoformat(), yesterday.isoformat()]
+
+    async def _ensure_table(self) -> None:
+        if not self.pool:
+            return
+        await self.pool.execute(
+            """
+            CREATE TABLE IF NOT EXISTS mariners_posted (
+                game_pk BIGINT PRIMARY KEY,
+                posted_at TIMESTAMPTZ NOT NULL DEFAULT now()
+            )
+            """
+        )
+
+    async def _load_posted(self) -> None:
+        if not self.pool:
+            return
+        rows = await self.pool.fetch("SELECT game_pk FROM mariners_posted")
+        self.posted.update(int(r[0]) for r in rows)
+
+    async def _save_posted(self, game_pk: int) -> None:
+        if not self.pool:
+            return
+        try:
+            await self.pool.execute(
+                "INSERT INTO mariners_posted (game_pk) VALUES ($1) ON CONFLICT DO NOTHING",
+                game_pk,
+            )
+        except Exception as exc:  # pragma: no cover - database
+            log.warning("Failed to record posted game %s: %s", game_pk, exc)
 
     def fetch_game_summary(self) -> Optional[Dict[str, Any]]:
         """Return a summary dict for the most recent final game.
@@ -144,15 +186,28 @@ class MarinersGameCog(commands.Cog):
         record_line = ""
         alwest_line = ""
         try:
+            def _ordinal(n: str) -> str:
+                try:
+                    num = int(n)
+                except ValueError:
+                    return n
+                if 10 <= num % 100 <= 20:
+                    suffix = "th"
+                else:
+                    suffix = {1: "st", 2: "nd", 3: "rd"}.get(num % 10, "th")
+                return f"{num}{suffix}"
+
             team_record = None
             leader_abbr = ""
+            second_abbr = ""
+            second_gb = ""
             for rec in standings.get("records", []):
                 teams_rec = rec.get("teamRecords", [])
-                leader_abbr = (
-                    teams_rec[0].get("team", {}).get("abbreviation", "")
-                    if teams_rec
-                    else ""
-                )
+                if teams_rec:
+                    leader_abbr = teams_rec[0].get("team", {}).get("abbreviation", "")
+                    if len(teams_rec) > 1:
+                        second_abbr = teams_rec[1].get("team", {}).get("abbreviation", "")
+                        second_gb = teams_rec[1].get("gamesBack", "")
                 for tr in teams_rec:
                     if tr.get("team", {}).get("id") == TEAM_ID:
                         team_record = tr
@@ -174,9 +229,15 @@ class MarinersGameCog(commands.Cog):
                     ),
                     "",
                 )
-                alwest_line = (
-                    f"{div_rank} • {gb} GB of {leader_abbr} • Last 10: {last_ten}"
-                )
+                rank_ord = _ordinal(div_rank)
+                if div_rank == "1":
+                    alwest_line = (
+                        f"{rank_ord} • {second_gb} GA of {second_abbr} • Last 10: {last_ten}"
+                    )
+                else:
+                    alwest_line = (
+                        f"{rank_ord} • {gb} GB of {leader_abbr} • Last 10: {last_ten}"
+                    )
         except Exception:  # pragma: no cover - defensive
             pass
         # Top performers: simple hitter and pitcher selection
@@ -242,21 +303,21 @@ class MarinersGameCog(commands.Cog):
         """Format the game summary into a Discord message."""
         start_fmt = summary["start_pst"].strftime("%a %b %d, %-I:%M %p PT")
         header = f"{summary['away_abbr']} @ {summary['home_abbr']}"
-        top_header = f"⚾️ *{header} — {start_fmt}*"
+        top_header = f"⚾️ **{header} — {start_fmt}**"
         final_line = (
-            f"**Final**: Mariners {summary['mariners_score']} — {summary['opp_name']} {summary['opp_score']}"
+            f"*Final*: Mariners {summary['mariners_score']} — {summary['opp_name']} {summary['opp_score']}"
         )
         highlights_line = (
-            "**Highlights**: " + "; ".join(summary.get("highlights", []))
+            "*Highlights*: " + "; ".join(summary.get("highlights", []))
             if summary.get("highlights")
             else ""
         )
-        record_line = f"**Record**: {summary.get('record', '')}"
-        al_line = f"**AL West**: {summary.get('al_west', '')}"
+        record_line = f"*Record*: {summary.get('record', '')}"
+        al_line = f"*AL West*: {summary.get('al_west', '')}"
         lines = [top_header, final_line]
         if highlights_line:
             lines.append(highlights_line)
-        lines.extend([record_line, al_line, "", "**Top Performers**"])
+        lines.extend([record_line, al_line, "", "*Top Performers*"])
         sea_perf = summary.get("top_performers", {}).get("SEA", "")
         opp_perf = summary.get("top_performers", {}).get(summary.get("opp_abbr", ""), "")
         lines.append(f"SEA — {sea_perf}")
@@ -277,11 +338,13 @@ class MarinersGameCog(commands.Cog):
         if not isinstance(channel, discord.TextChannel):
             log.error("Sports channel not found")
             self.posted.add(gid)
+            await self._save_posted(gid)
             return
         try:
             msg = self.build_message(summary)
             await channel.send(msg)
             self.posted.add(gid)
+            await self._save_posted(gid)
         except Exception as exc:  # pragma: no cover - network
             log.exception("Failed to post game summary: %s", exc)
 

--- a/tests/test_mariners_game_cog.py
+++ b/tests/test_mariners_game_cog.py
@@ -4,8 +4,10 @@ from datetime import datetime
 
 import discord
 from discord.ext import commands
+import asyncpg
 
 from gentlebot.cogs import mariners_game_cog
+from gentlebot import db
 
 
 SUMMARY = {
@@ -37,26 +39,49 @@ def test_build_message():
     bot = commands.Bot(command_prefix="!", intents=intents)
     cog = mariners_game_cog.MarinersGameCog(bot)
     msg = cog.build_message(SUMMARY)
-    assert "SEA @ HOU" in msg
-    assert "Mariners 5 — Astros 3" in msg
-    assert "Top Performers" in msg
+    lines = msg.splitlines()
+    assert lines[0] == "⚾️ **SEA @ HOU — Tue Sep 17, 1:10 PM PT**"
+    assert lines[1] == "*Final*: Mariners 5 — Astros 3"
+    assert (
+        lines[2]
+        == "*Highlights*: Rodríguez 2-run HR (7th); Crawford 2B; Muñoz nails down the save."
+    )
+    assert lines[3] == "*Record*: 82–66 (W2)"
+    assert lines[4] == "*AL West*: 2nd • 1.5 GB of HOU • Last 10: 7–3"
+    assert lines[6] == "*Top Performers*"
 
 
 def test_posts_summary(monkeypatch):
     async def run_test():
+        pool = DummyPool()
+
+        async def fake_create_pool(url, *args, **kwargs):
+            assert url.startswith("postgresql://")
+            return pool
+
+        monkeypatch.setattr(db.asyncpg, "create_pool", fake_create_pool)
+        db._pool = None
+        monkeypatch.setenv("PG_DSN", "postgresql+asyncpg://u:p@localhost/db")
+
         intents = discord.Intents.none()
         bot = commands.Bot(command_prefix="!", intents=intents)
         cog = mariners_game_cog.MarinersGameCog(bot)
+        monkeypatch.setattr(cog.game_task, "start", lambda: None)
+        await cog.cog_load()
         monkeypatch.setattr(cog, "fetch_game_summary", lambda: SUMMARY)
 
         sent = []
+
         class DummyChannel(SimpleNamespace):
             async def send(self, content):
                 sent.append(content)
+
         monkeypatch.setattr(bot, "get_channel", lambda cid: DummyChannel())
         monkeypatch.setattr(discord, "TextChannel", DummyChannel)
+
         async def dummy_wait():
             return None
+
         monkeypatch.setattr(bot, "wait_until_ready", dummy_wait)
 
         await mariners_game_cog.MarinersGameCog.game_task.coro(cog)
@@ -64,3 +89,96 @@ def test_posts_summary(monkeypatch):
         assert "Mariners 5 — Astros 3" in sent[0]
 
     asyncio.run(run_test())
+
+
+def test_no_repeat_across_sessions(monkeypatch):
+    async def run_test():
+        pool = DummyPool()
+
+        async def fake_create_pool(url, *args, **kwargs):
+            return pool
+
+        monkeypatch.setattr(db.asyncpg, "create_pool", fake_create_pool)
+        db._pool = None
+        monkeypatch.setenv("PG_DSN", "postgresql+asyncpg://u:p@localhost/db")
+
+        intents = discord.Intents.none()
+
+        # First session posts the summary and stores game_pk in DB
+        bot1 = commands.Bot(command_prefix="!", intents=intents)
+        cog1 = mariners_game_cog.MarinersGameCog(bot1)
+        monkeypatch.setattr(cog1.game_task, "start", lambda: None)
+        await cog1.cog_load()
+        monkeypatch.setattr(cog1, "fetch_game_summary", lambda: SUMMARY)
+        sent1 = []
+
+        class DummyChannel(SimpleNamespace):
+            async def send(self, content):
+                sent1.append(content)
+
+        monkeypatch.setattr(bot1, "get_channel", lambda cid: DummyChannel())
+        monkeypatch.setattr(discord, "TextChannel", DummyChannel)
+
+        async def dummy_wait():
+            return None
+
+        monkeypatch.setattr(bot1, "wait_until_ready", dummy_wait)
+        await mariners_game_cog.MarinersGameCog.game_task.coro(cog1)
+        assert sent1
+
+        # Second session should read DB and skip reposting
+        bot2 = commands.Bot(command_prefix="!", intents=intents)
+        cog2 = mariners_game_cog.MarinersGameCog(bot2)
+        monkeypatch.setattr(cog2.game_task, "start", lambda: None)
+        await cog2.cog_load()
+        monkeypatch.setattr(cog2, "fetch_game_summary", lambda: SUMMARY)
+        sent2 = []
+        monkeypatch.setattr(bot2, "get_channel", lambda cid: DummyChannel())
+        monkeypatch.setattr(discord, "TextChannel", DummyChannel)
+        monkeypatch.setattr(bot2, "wait_until_ready", dummy_wait)
+        await mariners_game_cog.MarinersGameCog.game_task.coro(cog2)
+        assert not sent2
+
+    asyncio.run(run_test())
+
+
+def test_cog_load_starts_without_db(monkeypatch):
+    async def run_test():
+        async def raise_error():
+            raise asyncpg.PostgresError("boom")
+
+        monkeypatch.setattr(mariners_game_cog, "get_pool", raise_error)
+
+        intents = discord.Intents.none()
+        bot = commands.Bot(command_prefix="!", intents=intents)
+        cog = mariners_game_cog.MarinersGameCog(bot)
+
+        started = False
+
+        def fake_start():
+            nonlocal started
+            started = True
+
+        monkeypatch.setattr(cog.game_task, "start", fake_start)
+        await cog.cog_load()
+
+        assert started
+        assert cog.pool is None
+
+    asyncio.run(run_test())
+
+
+class DummyPool:
+    def __init__(self):
+        self.data = set()
+
+    async def close(self):
+        pass
+
+    async def fetch(self, query, *args):
+        return [(pk,) for pk in self.data]
+
+    async def execute(self, query, *args):
+        if "INSERT" in query:
+            self.data.add(args[0])
+        return ""


### PR DESCRIPTION
## Summary
- persist Mariners game IDs in Postgres instead of a local file
- update Mariners post-game message formatting and AL West standings logic
- add tests for new formatting and persistence
- ensure Mariners cog still starts and logs when the database is unavailable

## Testing
- `python -m pytest -q`
- `python test_harness.py`


------
https://chatgpt.com/codex/tasks/task_e_68c79371270c832bbda04dbaf8b8f11a