### PR TITLE
Ensure Gemini image requests ask for text and image outputs

### DIFF
--- a/gentlebot/llm/providers/gemini.py
+++ b/gentlebot/llm/providers/gemini.py
@@ -106,8 +106,15 @@ class GeminiClient:
         return response
 
     def generate_image(self, model: str, prompt: str, *images: bytes) -> Any:
+        """Request an image from Gemini, asking for both text and image outputs."""
+
         parts = [prompt]
         for img in images:
             parts.append(genai.types.Part.from_bytes(img, mime_type="image/png"))
-        response = self.client.models.generate_content(model=model, contents=parts)
+        config = genai.types.GenerateContentConfig(
+            response_modalities=["TEXT", "IMAGE"]
+        )
+        response = self.client.models.generate_content(
+            model=model, contents=parts, config=config
+        )
         return response

--- a/tests/test_gemini_provider_image.py
+++ b/tests/test_gemini_provider_image.py
@@ -1,0 +1,42 @@
+"""Tests for the Gemini image helper."""
+
+from types import SimpleNamespace
+
+from gentlebot.llm.providers import gemini as gemini_module
+
+
+def test_generate_image_requests_text_and_image(monkeypatch):
+    """The image helper should ask Gemini for both text and image outputs."""
+
+    recorded: dict[str, object] = {}
+
+    class DummyModels:
+        def generate_content(self, **kwargs):
+            recorded.update(kwargs)
+            return SimpleNamespace()
+
+    class DummyClient:
+        def __init__(self, *args, **kwargs):
+            self.models = DummyModels()
+
+    def fake_from_bytes(data: bytes, mime_type: str) -> tuple[bytes, str]:
+        return (data, mime_type)
+
+    monkeypatch.setattr(
+        gemini_module,
+        "genai",
+        SimpleNamespace(
+            Client=DummyClient,
+            types=SimpleNamespace(
+                GenerateContentConfig=lambda **kwargs: SimpleNamespace(**kwargs),
+                Part=SimpleNamespace(from_bytes=fake_from_bytes),
+            ),
+        ),
+    )
+
+    client = gemini_module.GeminiClient("fake-key")
+    client.generate_image("gemini-image", "paint a dragon")
+
+    config = recorded["config"]
+    assert getattr(config, "response_modalities") == ["TEXT", "IMAGE"]
+    assert recorded["contents"][0] == "paint a dragon"


### PR DESCRIPTION
## Summary
- request Gemini image generations with both text and image modalities to satisfy newer models
- cover the image helper with a unit test that verifies the requested modalities

## Testing
- ✅ `python -m pytest -q`
- ⚠️ `python test_harness.py` *(expected offline runtime error from discord tasks without a logged-in client)*

------
https://chatgpt.com/codex/tasks/task_e_68c8c3165f18832b946d5d52bd343d26