### PR TITLE
Ensure direct mention messages receive replies

### DIFF
--- a/tests/test_gemini_cog.py
+++ b/tests/test_gemini_cog.py
@@ -259,3 +259,44 @@ def test_on_message_replaces_user_placeholder(monkeypatch):
     args, kwargs = message.reply.call_args
     assert args[0] == f"{message.author.mention} hello"
     assert kwargs["mention_author"] is True
+
+
+def test_on_message_replies_to_direct_mention_without_text(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "fake")
+    intents = discord.Intents.none()
+    bot = commands.Bot(command_prefix="!", intents=intents)
+    cog = GeminiCog(bot)
+    cog.mention_strs = ["<@123>"]
+
+    message = MagicMock(spec=discord.Message)
+    message.author.bot = False
+    message.author.id = 456
+    message.author.display_name = "Tester"
+    message.author.mention = "<@456>"
+    message.flags = MagicMock(ephemeral=False)
+    message.content = "<@123>"
+    message.guild = None
+    message.reference = None
+    message.channel = MagicMock()
+    message.channel.id = 789
+    message.channel.typing.return_value = dummy_typing()
+    message.reply = AsyncMock()
+
+    monkeypatch.setattr(gemini_cog.random, "random", lambda: 1)
+
+    captured: dict[str, str] = {}
+
+    async def fake_call(cid: int, prompt: str) -> str:
+        captured["prompt"] = prompt
+        return "Hello there!"
+
+    async def fake_context(_cid: int) -> str:
+        return ""
+
+    cog.call_llm = fake_call
+    cog._get_context_from_archive = fake_context
+
+    asyncio.run(cog.on_message(message))
+
+    assert "pinged you directly" in captured["prompt"]
+    message.reply.assert_called_once_with("Hello there!", mention_author=True)


### PR DESCRIPTION
## Summary
- ensure Gemini direct-mention prompts do not exit early when the mention strips all text
- provide a fallback instruction so mention-only messages still elicit a friendly response
- cover mention-only behavior with a dedicated unit test

## Testing
- python -m pytest -q
- python test_harness.py


------
https://chatgpt.com/codex/tasks/task_e_68c8e2e61c04832b8a00e6e6b9021973