### PR TITLE
feat: anchor Mariners recaps to future games

### DIFF
--- a/db/versions/b1e4d1ffebd6_create_mariners_schedule_state.py
+++ b/db/versions/b1e4d1ffebd6_create_mariners_schedule_state.py
@@ -1,0 +1,43 @@
+"""Create Mariners schedule state table.
+
+Revision ID: b1e4d1ffebd6
+Revises: f493dfd9bc5b
+Create Date: 2025-03-06 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b1e4d1ffebd6"
+down_revision: Union[str, None] = "f493dfd9bc5b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "mariners_schedule_state",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "tracking_since",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        schema="discord",
+    )
+    op.execute(
+        """
+        INSERT INTO discord.mariners_schedule_state (id, tracking_since)
+        VALUES (1, now())
+        ON CONFLICT (id) DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("mariners_schedule_state", schema="discord")

--- a/db/versions/f493dfd9bc5b_create_mariners_schedule_table.py
+++ b/db/versions/f493dfd9bc5b_create_mariners_schedule_table.py
@@ -1,7 +1,7 @@
 """create mariners schedule table
 
 Revision ID: f493dfd9bc5b
-Revises: 5da39b923f95
+Revises: 4b58c5e66f5d
 Create Date: 2025-03-02 00:00:00.000000
 
 """
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = 'f493dfd9bc5b'
-down_revision: Union[str, None] = '5da39b923f95'
+down_revision: Union[str, None] = '4b58c5e66f5d'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/db/versions/f493dfd9bc5b_create_mariners_schedule_table.py
+++ b/db/versions/f493dfd9bc5b_create_mariners_schedule_table.py
@@ -1,0 +1,56 @@
+"""create mariners schedule table
+
+Revision ID: f493dfd9bc5b
+Revises: 5da39b923f95
+Create Date: 2025-03-02 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f493dfd9bc5b'
+down_revision: Union[str, None] = '5da39b923f95'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "mariners_schedule",
+        sa.Column("event_id", sa.String(length=32), primary_key=True),
+        sa.Column("season_year", sa.Integer, nullable=False),
+        sa.Column("game_date", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("home_away", sa.String(length=4), nullable=False),
+        sa.Column("opponent_abbr", sa.String(length=8), nullable=False),
+        sa.Column("opponent_name", sa.String(length=128), nullable=False),
+        sa.Column("venue", sa.String(length=128), nullable=True),
+        sa.Column("short_name", sa.String(length=32), nullable=True),
+        sa.Column("state", sa.String(length=16), nullable=False, server_default="pre"),
+        sa.Column("mariners_score", sa.Integer, nullable=True),
+        sa.Column("opponent_score", sa.Integer, nullable=True),
+        sa.Column("summary", sa.JSON, nullable=True),
+        sa.Column("message_id", sa.BigInteger, nullable=True),
+        sa.Column("message_posted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        schema="discord",
+    )
+    op.create_index(
+        "ix_mariners_schedule_season",
+        "mariners_schedule",
+        ["season_year", "game_date"],
+        schema="discord",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_mariners_schedule_season", table_name="mariners_schedule", schema="discord")
+    op.drop_table("mariners_schedule", schema="discord")

--- a/gentlebot/cogs/mariners_game_cog.py
+++ b/gentlebot/cogs/mariners_game_cog.py
@@ -74,7 +74,7 @@ class MarinersGameCog(commands.Cog):
             return
         await self.pool.execute(
             """
-            CREATE TABLE IF NOT EXISTS mariners_schedule (
+            CREATE TABLE IF NOT EXISTS discord.mariners_schedule (
                 event_id TEXT PRIMARY KEY,
                 season_year INTEGER NOT NULL,
                 game_date TIMESTAMPTZ NOT NULL,
@@ -96,12 +96,12 @@ class MarinersGameCog(commands.Cog):
         await self.pool.execute(
             """
             CREATE INDEX IF NOT EXISTS ix_mariners_schedule_season
-            ON mariners_schedule (season_year, game_date)
+            ON discord.mariners_schedule (season_year, game_date)
             """
         )
         await self.pool.execute(
             """
-            CREATE TABLE IF NOT EXISTS mariners_schedule_state (
+            CREATE TABLE IF NOT EXISTS discord.mariners_schedule_state (
                 id INTEGER PRIMARY KEY,
                 tracking_since TIMESTAMPTZ NOT NULL DEFAULT now()
             )
@@ -113,7 +113,7 @@ class MarinersGameCog(commands.Cog):
             return
         try:
             row = await self.pool.fetchrow(
-                "SELECT tracking_since FROM mariners_schedule_state WHERE id = 1"
+                "SELECT tracking_since FROM discord.mariners_schedule_state WHERE id = 1"
             )
         except Exception as exc:  # pragma: no cover - database
             log.warning("Failed to load Mariners tracking state: %s", exc)
@@ -129,7 +129,7 @@ class MarinersGameCog(commands.Cog):
         try:
             await self.pool.execute(
                 """
-                INSERT INTO mariners_schedule_state (id, tracking_since)
+                INSERT INTO discord.mariners_schedule_state (id, tracking_since)
                 VALUES (1, $1)
                 ON CONFLICT (id) DO NOTHING
                 """,
@@ -144,7 +144,7 @@ class MarinersGameCog(commands.Cog):
         if not self.pool:
             return
         rows = await self.pool.fetch(
-            "SELECT event_id FROM mariners_schedule WHERE message_id IS NOT NULL"
+            "SELECT event_id FROM discord.mariners_schedule WHERE message_id IS NOT NULL"
         )
         self.posted.update(str(r[0]) for r in rows)
 
@@ -179,7 +179,7 @@ class MarinersGameCog(commands.Cog):
             try:
                 await self.pool.execute(
                     """
-                    INSERT INTO mariners_schedule (
+                    INSERT INTO discord.mariners_schedule (
                         event_id,
                         season_year,
                         game_date,
@@ -297,7 +297,7 @@ class MarinersGameCog(commands.Cog):
         try:
             await self.pool.execute(
                 """
-                UPDATE mariners_schedule
+                UPDATE discord.mariners_schedule
                 SET message_id = $1,
                     message_posted_at = now(),
                     updated_at = now()
@@ -328,7 +328,7 @@ class MarinersGameCog(commands.Cog):
                    game_date,
                    season_year,
                    short_name
-            FROM mariners_schedule
+            FROM discord.mariners_schedule
             WHERE state = 'post'
               AND message_id IS NULL
               AND game_date >= $1
@@ -351,7 +351,7 @@ class MarinersGameCog(commands.Cog):
         try:
             await self.pool.execute(
                 """
-                UPDATE mariners_schedule
+                UPDATE discord.mariners_schedule
                 SET summary = $1,
                     mariners_score = $2,
                     opponent_score = $3,

--- a/gentlebot/cogs/mariners_game_cog.py
+++ b/gentlebot/cogs/mariners_game_cog.py
@@ -44,29 +44,25 @@ class MarinersGameCog(commands.Cog):
     async def cog_load(self) -> None:  # pragma: no cover - startup
         pool: asyncpg.Pool | None = None
         try:
-            self.pool = await get_pool()
+            pool = await get_pool()
+            self.pool = pool
             await self._ensure_table()
             await self._ensure_tracking_state()
             await self._sync_schedule()
             await self._load_posted()
         except Exception as exc:  # pragma: no cover - database init
+            self.pool = None
             log.warning(
                 "MarinersGameCog disabled database persistence: %s", exc
             )
-        else:
-            try:
-                self.pool = pool
-                await self._ensure_table()
-                await self._load_posted()
-            except Exception as exc:  # pragma: no cover - defensive
-                self.pool = None
-                log.warning(
-                    "MarinersGameCog disabled database persistence: %s", exc
-                )
+            if pool is not None:
                 try:
                     await pool.close()
                 except Exception:  # pragma: no cover - defensive
-                    log.debug("Failed closing Mariners DB pool after setup error", exc_info=True)
+                    log.debug(
+                        "Failed closing Mariners DB pool after setup error",
+                        exc_info=True,
+                    )
         self.game_task.start()
 
     async def cog_unload(self) -> None:  # pragma: no cover - cleanup

--- a/gentlebot/cogs/mariners_game_cog.py
+++ b/gentlebot/cogs/mariners_game_cog.py
@@ -3,23 +3,33 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta
-from typing import Any, Dict, Optional
+from datetime import datetime
+from typing import Any, Dict, Iterable, Optional
 
 import asyncio
-import requests
-from requests.adapters import HTTPAdapter, Retry
-import pytz
 import asyncpg
+import pytz
+import requests
+from dateutil import parser
+from requests.adapters import HTTPAdapter, Retry
 
 import discord
 from discord.ext import commands, tasks
 
-from .sports_cog import TEAM_ID, STATS_TIMEOUT, PST_TZ
+from .sports_cog import PST_TZ, STATS_TIMEOUT
 from .. import bot_config as cfg
 from ..db import get_pool
 
 log = logging.getLogger(f"gentlebot.{__name__}")
+
+ESPN_SCHEDULE_URL = (
+    "https://site.api.espn.com/apis/site/v2/sports/baseball/mlb/teams/sea/schedule"
+)
+ESPN_SUMMARY_URL = (
+    "https://site.api.espn.com/apis/site/v2/sports/baseball/mlb/summary"
+)
+DIVISION_GROUP_ID = 3
+TEAM_ABBR = "SEA"
 
 
 class MarinersGameCog(commands.Cog):
@@ -27,15 +37,18 @@ class MarinersGameCog(commands.Cog):
 
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
-        self.posted: set[int] = set()
+        self.posted: set[str] = set()
         self.pool: asyncpg.Pool | None = None
+        self.tracking_since: datetime = datetime.now(tz=pytz.utc)
 
     async def cog_load(self) -> None:  # pragma: no cover - startup
         try:
             self.pool = await get_pool()
             await self._ensure_table()
+            await self._ensure_tracking_state()
+            await self._sync_schedule()
             await self._load_posted()
-        except Exception as exc:
+        except Exception as exc:  # pragma: no cover - database init
             log.warning(
                 "Database unavailable; MarinersGameCog state will not persist: %s",
                 exc,
@@ -47,257 +60,589 @@ class MarinersGameCog(commands.Cog):
         self.game_task.cancel()
 
     # ------------------------------------------------------------------ helpers
-    def _schedule_dates(self) -> list[str]:
-        today = datetime.now(PST_TZ).date()
-        yesterday = today - timedelta(days=1)
-        return [today.isoformat(), yesterday.isoformat()]
-
     async def _ensure_table(self) -> None:
         if not self.pool:
             return
         await self.pool.execute(
             """
-            CREATE TABLE IF NOT EXISTS mariners_posted (
-                game_pk BIGINT PRIMARY KEY,
-                posted_at TIMESTAMPTZ NOT NULL DEFAULT now()
+            CREATE TABLE IF NOT EXISTS mariners_schedule (
+                event_id TEXT PRIMARY KEY,
+                season_year INTEGER NOT NULL,
+                game_date TIMESTAMPTZ NOT NULL,
+                home_away TEXT NOT NULL,
+                opponent_abbr TEXT NOT NULL,
+                opponent_name TEXT NOT NULL,
+                venue TEXT,
+                short_name TEXT,
+                state TEXT NOT NULL DEFAULT 'pre',
+                mariners_score INTEGER,
+                opponent_score INTEGER,
+                summary JSONB,
+                message_id BIGINT,
+                message_posted_at TIMESTAMPTZ,
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+            )
+            """
+        )
+        await self.pool.execute(
+            """
+            CREATE INDEX IF NOT EXISTS ix_mariners_schedule_season
+            ON mariners_schedule (season_year, game_date)
+            """
+        )
+        await self.pool.execute(
+            """
+            CREATE TABLE IF NOT EXISTS mariners_schedule_state (
+                id INTEGER PRIMARY KEY,
+                tracking_since TIMESTAMPTZ NOT NULL DEFAULT now()
             )
             """
         )
 
+    async def _ensure_tracking_state(self) -> None:
+        if not self.pool:
+            return
+        try:
+            row = await self.pool.fetchrow(
+                "SELECT tracking_since FROM mariners_schedule_state WHERE id = 1"
+            )
+        except Exception as exc:  # pragma: no cover - database
+            log.warning("Failed to load Mariners tracking state: %s", exc)
+            return
+        if row:
+            tracking = row["tracking_since"]
+            if isinstance(tracking, datetime):
+                if tracking.tzinfo is None:
+                    tracking = pytz.utc.localize(tracking)
+                self.tracking_since = tracking
+            return
+        now_utc = datetime.now(tz=pytz.utc)
+        try:
+            await self.pool.execute(
+                """
+                INSERT INTO mariners_schedule_state (id, tracking_since)
+                VALUES (1, $1)
+                ON CONFLICT (id) DO NOTHING
+                """,
+                now_utc,
+            )
+        except Exception as exc:  # pragma: no cover - database
+            log.warning("Failed to initialize Mariners tracking state: %s", exc)
+            return
+        self.tracking_since = now_utc
+
     async def _load_posted(self) -> None:
         if not self.pool:
             return
-        rows = await self.pool.fetch("SELECT game_pk FROM mariners_posted")
-        self.posted.update(int(r[0]) for r in rows)
+        rows = await self.pool.fetch(
+            "SELECT event_id FROM mariners_schedule WHERE message_id IS NOT NULL"
+        )
+        self.posted.update(str(r[0]) for r in rows)
 
-    async def _save_posted(self, game_pk: int) -> None:
+    def _build_session(self) -> requests.Session:
+        session = requests.Session()
+        retries = Retry(
+            total=3,
+            backoff_factor=1,
+            status_forcelist=[500, 502, 503, 504],
+            allowed_methods=["GET"],
+        )
+        adapter = HTTPAdapter(max_retries=retries)
+        session.mount("https://", adapter)
+        session.mount("http://", adapter)
+        return session
+
+    async def _sync_schedule(self) -> None:
+        if not self.pool:
+            return
+        schedule = await asyncio.to_thread(self._fetch_schedule)
+        if not schedule:
+            return
+        for row in schedule:
+            game_date = row.get("game_date")
+            if isinstance(game_date, datetime):
+                if game_date.tzinfo is None:
+                    game_date = pytz.utc.localize(game_date)
+            else:
+                continue
+            if game_date < self.tracking_since:
+                continue
+            try:
+                await self.pool.execute(
+                    """
+                    INSERT INTO mariners_schedule (
+                        event_id,
+                        season_year,
+                        game_date,
+                        home_away,
+                        opponent_abbr,
+                        opponent_name,
+                        venue,
+                        short_name,
+                        state,
+                        mariners_score,
+                        opponent_score,
+                        updated_at
+                    ) VALUES (
+                        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, now()
+                    )
+                    ON CONFLICT (event_id) DO UPDATE SET
+                        season_year = EXCLUDED.season_year,
+                        game_date = EXCLUDED.game_date,
+                        home_away = EXCLUDED.home_away,
+                        opponent_abbr = EXCLUDED.opponent_abbr,
+                        opponent_name = EXCLUDED.opponent_name,
+                        venue = EXCLUDED.venue,
+                        short_name = EXCLUDED.short_name,
+                        state = EXCLUDED.state,
+                        mariners_score = EXCLUDED.mariners_score,
+                        opponent_score = EXCLUDED.opponent_score,
+                        updated_at = now()
+                    """,
+                    row["event_id"],
+                    row["season_year"],
+                    game_date,
+                    row["home_away"],
+                    row["opponent_abbr"],
+                    row["opponent_name"],
+                    row["venue"],
+                    row["short_name"],
+                    row["state"],
+                    row["mariners_score"],
+                    row["opponent_score"],
+                )
+            except Exception as exc:  # pragma: no cover - database
+                log.warning("Failed to upsert Mariners schedule %s: %s", row["event_id"], exc)
+
+    def _fetch_schedule(self) -> list[dict[str, Any]]:
+        rows: list[dict[str, Any]] = []
+        try:
+            with self._build_session() as session:
+                resp = session.get(ESPN_SCHEDULE_URL, timeout=STATS_TIMEOUT)
+                resp.raise_for_status()
+                data = resp.json()
+        except Exception as exc:  # pragma: no cover - network
+            log.warning("Failed to fetch Mariners schedule: %s", exc)
+            return rows
+        for event in data.get("events", []):
+            competitions = event.get("competitions", [])
+            if not competitions:
+                continue
+            comp = competitions[0]
+            competitors = comp.get("competitors", [])
+            try:
+                sea_comp = next(
+                    c for c in competitors if c.get("team", {}).get("abbreviation") == TEAM_ABBR
+                )
+                opp_comp = next(c for c in competitors if c is not sea_comp)
+            except StopIteration:
+                continue
+            try:
+                start = parser.isoparse(comp.get("date"))
+            except (TypeError, ValueError):
+                start = datetime.now(tz=pytz.utc)
+            state = comp.get("status", {}).get("type", {}).get("state", "pre")
+            mariners_score = (
+                int(float(sea_comp.get("score", "0"))) if state == "post" else None
+            )
+            opponent_score = (
+                int(float(opp_comp.get("score", "0"))) if state == "post" else None
+            )
+            rows.append(
+                {
+                    "event_id": str(event.get("id")),
+                    "season_year": event.get("season", {}).get("year", start.year),
+                    "game_date": start,
+                    "home_away": sea_comp.get("homeAway", "home"),
+                    "opponent_abbr": opp_comp.get("team", {}).get("abbreviation", ""),
+                    "opponent_name": opp_comp.get("team", {}).get("displayName", "Opponent"),
+                    "venue": comp.get("venue", {}).get("fullName", ""),
+                    "short_name": event.get("shortName", ""),
+                    "state": state,
+                    "mariners_score": mariners_score,
+                    "opponent_score": opponent_score,
+                }
+            )
+        return rows
+
+    def _serialize_summary(self, summary: Dict[str, Any]) -> Dict[str, Any]:
+        payload = dict(summary)
+        start = payload.get("start_pst")
+        if isinstance(start, datetime):
+            payload["start_pst"] = start.isoformat()
+        return payload
+
+    def _deserialize_summary(self, summary: Dict[str, Any]) -> Dict[str, Any]:
+        payload = dict(summary)
+        start = payload.get("start_pst")
+        if isinstance(start, str):
+            try:
+                payload["start_pst"] = datetime.fromisoformat(start)
+            except ValueError:
+                payload["start_pst"] = datetime.now(tz=PST_TZ)
+        return payload
+
+    async def _mark_posted(self, event_id: str, message_id: Optional[int]) -> None:
         if not self.pool:
             return
         try:
             await self.pool.execute(
-                "INSERT INTO mariners_posted (game_pk) VALUES ($1) ON CONFLICT DO NOTHING",
-                game_pk,
+                """
+                UPDATE mariners_schedule
+                SET message_id = $1,
+                    message_posted_at = now(),
+                    updated_at = now()
+                WHERE event_id = $2
+                """,
+                message_id,
+                event_id,
             )
         except Exception as exc:  # pragma: no cover - database
-            log.warning("Failed to record posted game %s: %s", game_pk, exc)
+            log.warning("Failed to record Mariners post %s: %s", event_id, exc)
 
-    def fetch_game_summary(self) -> Optional[Dict[str, Any]]:
-        """Return a summary dict for the most recent final game.
-
-        The dict contains fields consumed by :meth:`build_message`. Network
-        errors return ``None``.
-        """
+    async def fetch_game_summary(self) -> Optional[Dict[str, Any]]:
+        if not self.pool:
+            return None
         try:
-            with requests.Session() as session:
-                retries = Retry(
-                    total=3,
-                    backoff_factor=1,
-                    status_forcelist=[500, 502, 503, 504],
-                    allowed_methods=["GET"],
-                )
-                adapter = HTTPAdapter(max_retries=retries)
-                session.mount("https://", adapter)
-                session.mount("http://", adapter)
-
-                for date in self._schedule_dates():
-                    url = (
-                        "https://statsapi.mlb.com/api/v1/schedule"
-                        f"?sportId=1&teamId={TEAM_ID}&date={date}"
-                    )
-                    resp = session.get(url, timeout=STATS_TIMEOUT)
-                    resp.raise_for_status()
-                    data = resp.json()
-                    for d in data.get("dates", []):
-                        for game in d.get("games", []):
-                            if game.get("status", {}).get("detailedState") != "Final":
-                                continue
-                            game_pk = game.get("gamePk")
-                            if game_pk in self.posted:
-                                continue
-                            feed_url = (
-                                "https://statsapi.mlb.com/api/v1.1/game/"
-                                f"{game_pk}/feed/live"
-                            )
-                            feed = session.get(
-                                feed_url, timeout=STATS_TIMEOUT
-                            ).json()
-                            standings_url = (
-                                "https://statsapi.mlb.com/api/v1/standings"
-                                f"?leagueId=103&season={datetime.now().year}"
-                            )
-                            standings = session.get(
-                                standings_url, timeout=STATS_TIMEOUT
-                            ).json()
-                            return self._build_summary(game, feed, standings)
-        except Exception as exc:  # pragma: no cover - network
-            log.warning("Failed to fetch game summary: %s", exc)
-        return None
-
-    def _build_summary(
-        self, game: Dict[str, Any], feed: Dict[str, Any], standings: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        """Construct a summary dictionary from API responses."""
-        game_pk = game.get("gamePk")
-        gd = feed.get("gameData", {})
-        ld = feed.get("liveData", {})
-        teams = gd.get("teams", {})
-        away = teams.get("away", {})
-        home = teams.get("home", {})
-        mariners_home = home.get("id") == TEAM_ID
-        mariners = home if mariners_home else away
-        opponent = away if mariners_home else home
-        away_abbr = away.get("abbreviation", "")
-        home_abbr = home.get("abbreviation", "")
-        start_iso = gd.get("datetime", {}).get("dateTime")
-        start = (
-            datetime.fromisoformat(start_iso.replace("Z", "+00:00"))
-            if start_iso
-            else datetime.now(tz=pytz.utc)
+            await self._sync_schedule()
+        except Exception as exc:  # pragma: no cover - defensive
+            log.warning("Failed to refresh Mariners schedule: %s", exc)
+        row = await self.pool.fetchrow(
+            """
+            SELECT event_id,
+                   summary,
+                   mariners_score,
+                   opponent_score,
+                   home_away,
+                   opponent_abbr,
+                   opponent_name,
+                   game_date,
+                   season_year,
+                   short_name
+            FROM mariners_schedule
+            WHERE state = 'post'
+              AND message_id IS NULL
+              AND game_date >= $1
+            ORDER BY game_date DESC
+            LIMIT 1
+            """,
+            self.tracking_since,
         )
-        start_pst = start.astimezone(PST_TZ)
-        linescore = ld.get("linescore", {})
-        away_score = linescore.get("teams", {}).get("away", {}).get("runs", 0)
-        home_score = linescore.get("teams", {}).get("home", {}).get("runs", 0)
-        mariners_score = home_score if mariners_home else away_score
-        opp_score = away_score if mariners_home else home_score
-        # Highlights - brief description + inning
-        scoring_indices = ld.get("plays", {}).get("scoringPlays", [])
-        all_plays = ld.get("plays", {}).get("allPlays", [])
-        highlights: list[str] = []
-        for idx in scoring_indices[:3]:
-            try:
-                play = all_plays[idx]
-                desc = play.get("result", {}).get("description", "")
-                inning = play.get("about", {}).get("inning")
-                half = play.get("about", {}).get("halfInning", "")
-                suffix = "th"
-                if inning in {1, 21}:
-                    suffix = "st"
-                elif inning in {2, 22}:
-                    suffix = "nd"
-                elif inning in {3, 23}:
-                    suffix = "rd"
-                highlights.append(
-                    f"{desc} ({inning}{suffix})"
-                )
-            except Exception:  # pragma: no cover - defensive
-                continue
-        # Standings info for record and AL West line
-        record_line = ""
-        alwest_line = ""
+        if not row:
+            return None
+        event_id = str(row["event_id"])
+        summary = row["summary"]
+        if summary:
+            data = self._deserialize_summary(summary)
+            data.setdefault("event_id", event_id)
+            return data
+        data = await asyncio.to_thread(self._build_summary_from_event, event_id, dict(row))
+        if not data:
+            return None
         try:
-            def _ordinal(n: str) -> str:
-                try:
-                    num = int(n)
-                except ValueError:
-                    return n
-                if 10 <= num % 100 <= 20:
-                    suffix = "th"
-                else:
-                    suffix = {1: "st", 2: "nd", 3: "rd"}.get(num % 10, "th")
-                return f"{num}{suffix}"
-
-            team_record = None
-            leader_abbr = ""
-            second_abbr = ""
-            second_gb = ""
-            for rec in standings.get("records", []):
-                teams_rec = rec.get("teamRecords", [])
-                if teams_rec:
-                    leader_abbr = teams_rec[0].get("team", {}).get("abbreviation", "")
-                    if len(teams_rec) > 1:
-                        second_abbr = teams_rec[1].get("team", {}).get("abbreviation", "")
-                        second_gb = teams_rec[1].get("gamesBack", "")
-                for tr in teams_rec:
-                    if tr.get("team", {}).get("id") == TEAM_ID:
-                        team_record = tr
-                        break
-                if team_record:
-                    break
-            if team_record:
-                wins = team_record.get("wins", 0)
-                losses = team_record.get("losses", 0)
-                streak = team_record.get("streak", {}).get("streakCode", "")
-                record_line = f"{wins}–{losses} ({streak})"
-                div_rank = team_record.get("divisionRank", "")
-                gb = team_record.get("gamesBack", "")
-                last_ten = next(
-                    (
-                        f"{sr.get('wins')}–{sr.get('losses')}"
-                        for sr in team_record.get("records", {}).get("splitRecords", [])
-                        if sr.get("type") == "lastTen"
-                    ),
-                    "",
-                )
-                rank_ord = _ordinal(div_rank)
-                if div_rank == "1":
-                    alwest_line = (
-                        f"{rank_ord} • {second_gb} GA of {second_abbr} • Last 10: {last_ten}"
-                    )
-                else:
-                    alwest_line = (
-                        f"{rank_ord} • {gb} GB of {leader_abbr} • Last 10: {last_ten}"
-                    )
-        except Exception:  # pragma: no cover - defensive
-            pass
-        # Top performers: simple hitter and pitcher selection
-        top_perf: Dict[str, str] = {}
-        for key, team in ("home", home), ("away", away):
-            players = ld.get("boxscore", {}).get("teams", {}).get(key, {}).get(
-                "players", {}
+            await self.pool.execute(
+                """
+                UPDATE mariners_schedule
+                SET summary = $1,
+                    mariners_score = $2,
+                    opponent_score = $3,
+                    updated_at = now()
+                WHERE event_id = $4
+                """,
+                self._serialize_summary(data),
+                data.get("mariners_score"),
+                data.get("opp_score"),
+                event_id,
             )
-            hitter = None
-            pitcher = None
-            for p in players.values():
-                stats = p.get("stats", {})
-                bat = stats.get("batting", {})
-                pit = stats.get("pitching", {})
-                if bat.get("atBats", 0) > 0:
-                    if not hitter or bat.get("hits", 0) > hitter.get("stats", {}).get("batting", {}).get("hits", 0):
-                        hitter = p
-                if pit.get("inningsPitched") and pit.get("outs", 0) > 0:
-                    if not pitcher or pit.get("outs", 0) > pitcher.get("stats", {}).get("pitching", {}).get("outs", 0):
-                        pitcher = p
-            def _fmt_line(player: Dict[str, Any]) -> str:
-                if not player:
-                    return ""
-                info = player.get("person", {}).get("fullName", "")
-                bat = player.get("stats", {}).get("batting", {})
-                pit = player.get("stats", {}).get("pitching", {})
-                if bat.get("atBats", 0) > 0:
-                    line = f"{bat.get('hits',0)}-{bat.get('atBats',0)}"
-                    if bat.get("homeRuns", 0):
-                        line += f", HR ({bat.get('homeRuns')})"
-                    if bat.get("rbi", 0):
-                        line += f", {bat.get('rbi')} RBI"
-                else:
-                    line = (
-                        f"{pit.get('inningsPitched','0.0')} IP, {pit.get('strikeOuts',0)} K, {pit.get('earnedRuns',0)} ER"
-                    )
-                return f"{info}: {line}"
-            parts = []
-            if hitter:
-                parts.append(_fmt_line(hitter))
-            if pitcher:
-                parts.append(_fmt_line(pitcher))
-            abbr = team.get("abbreviation", "")
-            top_perf[abbr] = " | ".join(parts)
-        summary = {
-            "game_pk": game_pk,
+        except Exception as exc:  # pragma: no cover - database
+            log.warning("Failed to store Mariners summary %s: %s", event_id, exc)
+        return data
+
+    def _build_summary_from_event(
+        self, event_id: str, row: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        try:
+            with self._build_session() as session:
+                summary_resp = session.get(
+                    ESPN_SUMMARY_URL,
+                    params={"event": event_id, "region": "us", "lang": "en"},
+                    timeout=STATS_TIMEOUT,
+                )
+                summary_resp.raise_for_status()
+                summary = summary_resp.json()
+                comp = summary.get("header", {}).get("competitions", [{}])[0]
+                competitors = comp.get("competitors", [])
+                sea_comp = next(
+                    c for c in competitors if c.get("team", {}).get("abbreviation") == TEAM_ABBR
+                )
+                opp_comp = next(c for c in competitors if c is not sea_comp)
+                away_comp = next(
+                    c for c in competitors if c.get("homeAway") == "away"
+                )
+                home_comp = next(
+                    c for c in competitors if c.get("homeAway") == "home"
+                )
+                start = parser.isoparse(comp.get("date"))
+                start_pst = start.astimezone(PST_TZ)
+                mariners_home = sea_comp is home_comp
+                mariners_score = int(float(sea_comp.get("score", "0")))
+                opp_score = int(float(opp_comp.get("score", "0")))
+                away_abbr = away_comp.get("team", {}).get("abbreviation", "")
+                home_abbr = home_comp.get("team", {}).get("abbreviation", "")
+                highlights = self._collect_highlights(summary.get("plays", []))
+                season_year = row.get("season_year", start.year)
+                record_info = self._fetch_record_info(session, season_year)
+                standings = self._fetch_division_standings(session, season_year)
+                record_line = record_info["summary"]
+                if record_info["streak"]:
+                    record_line = f"{record_line} ({record_info['streak']})" if record_line else record_info["streak"]
+                al_west_line = self._format_division_line(standings, record_info["last_ten"])
+                performers = self._top_performers(summary.get("boxscore", {}), opp_comp)
+        except Exception as exc:  # pragma: no cover - network parsing
+            log.warning("Failed to build Mariners summary for %s: %s", event_id, exc)
+            return None
+        return {
+            "event_id": event_id,
             "mariners_home": mariners_home,
             "away_abbr": away_abbr,
             "home_abbr": home_abbr,
             "mariners_score": mariners_score,
             "opp_score": opp_score,
-            "opp_name": opponent.get("teamName", "Opponent"),
-            "opp_abbr": opponent.get("abbreviation", ""),
+            "opp_name": opp_comp.get("team", {}).get("displayName", "Opponent"),
+            "opp_abbr": opp_comp.get("team", {}).get("abbreviation", ""),
             "start_pst": start_pst,
             "highlights": highlights,
             "record": record_line,
-            "al_west": alwest_line,
-            "top_performers": top_perf,
+            "al_west": al_west_line,
+            "top_performers": performers,
         }
-        return summary
+
+    def _collect_highlights(self, plays: Iterable[dict[str, Any]]) -> list[str]:
+        lines: list[str] = []
+        for play in plays:
+            if not play.get("scoringPlay"):
+                continue
+            text = play.get("text", "")
+            period = play.get("period", {})
+            inning = period.get("number")
+            half = period.get("type", "")
+            if inning:
+                text = f"{text} ({half.title()} {self._ordinal(inning)})"
+            lines.append(text)
+            if len(lines) == 3:
+                break
+        return lines
+
+    def _ordinal(self, value: int) -> str:
+        try:
+            num = int(value)
+        except (TypeError, ValueError):
+            return str(value)
+        if 10 <= num % 100 <= 20:
+            suffix = "th"
+        else:
+            suffix = {1: "st", 2: "nd", 3: "rd"}.get(num % 10, "th")
+        return f"{num}{suffix}"
+
+    def _fetch_record_info(self, session: requests.Session, season_year: int) -> dict[str, str]:
+        info = {"summary": "", "streak": "", "last_ten": ""}
+        try:
+            team = session.get(
+                f"https://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/{season_year}/teams/sea",
+                params={"lang": "en", "region": "us"},
+                timeout=STATS_TIMEOUT,
+            ).json()
+            record = session.get(team["record"]["$ref"], timeout=STATS_TIMEOUT).json()
+            total = next((item for item in record.get("items", []) if item.get("type") == "total"), None)
+            last_ten = next(
+                (item for item in record.get("items", []) if item.get("type") == "lasttengames"),
+                None,
+            )
+            if total:
+                info["summary"] = total.get("summary", "")
+                stats = {s["name"]: s.get("displayValue") or s.get("value") for s in total.get("stats", [])}
+                info["streak"] = stats.get("streak", "") or ""
+            if last_ten:
+                info["last_ten"] = last_ten.get("summary", "")
+        except Exception:  # pragma: no cover - defensive
+            pass
+        return info
+
+    def _fetch_division_standings(
+        self, session: requests.Session, season_year: int
+    ) -> list[dict[str, str]]:
+        teams: list[dict[str, str]] = []
+        try:
+            group = session.get(
+                f"http://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/{season_year}/types/2/groups/{DIVISION_GROUP_ID}",
+                params={"lang": "en", "region": "us"},
+                timeout=STATS_TIMEOUT,
+            ).json()
+            standings = session.get(group["standings"]["$ref"], timeout=STATS_TIMEOUT).json()
+            overall_ref = None
+            for item in standings.get("items", []):
+                if item.get("name") == "overall":
+                    overall_ref = item.get("$ref")
+                    break
+            if not overall_ref:
+                return teams
+            overall = session.get(overall_ref, timeout=STATS_TIMEOUT).json()
+            for team_entry in overall.get("standings", []):
+                team_info = session.get(team_entry["team"]["$ref"], timeout=STATS_TIMEOUT).json()
+                total = next(
+                    (rec for rec in team_entry.get("records", []) if rec.get("type") == "total"),
+                    None,
+                )
+                stats = (
+                    {s["name"]: s.get("displayValue") or s.get("value") for s in total.get("stats", [])}
+                    if total
+                    else {}
+                )
+                teams.append(
+                    {
+                        "abbr": team_info.get("abbreviation", ""),
+                        "gamesBehind": stats.get("gamesBehind", ""),
+                    }
+                )
+        except Exception:  # pragma: no cover - defensive
+            return teams
+        return teams
+
+    def _format_division_line(
+        self, standings: list[dict[str, str]], last_ten: str
+    ) -> str:
+        if not standings:
+            return f"Last 10: {last_ten}" if last_ten else ""
+        try:
+            sea_index = next(i for i, entry in enumerate(standings) if entry.get("abbr") == TEAM_ABBR)
+        except StopIteration:
+            return f"Last 10: {last_ten}" if last_ten else ""
+        rank = sea_index + 1
+        ordinal_rank = self._ordinal(rank)
+        if rank == 1 and len(standings) > 1:
+            ga = standings[1].get("gamesBehind", "0")
+            parts = [ordinal_rank, f"{ga} GA of {standings[1].get('abbr', '')}"]
+        elif standings:
+            leader = standings[0]
+            gb = standings[sea_index].get("gamesBehind", "")
+            parts = [ordinal_rank, f"{gb} GB of {leader.get('abbr', '')}"]
+        else:
+            parts = [ordinal_rank]
+        if last_ten:
+            parts.append(f"Last 10: {last_ten}")
+        return " • ".join(part for part in parts if part)
+
+    def _top_performers(
+        self, boxscore: Dict[str, Any], opponent_comp: Dict[str, Any]
+    ) -> Dict[str, str]:
+        performers: Dict[str, str] = {}
+        players = {entry.get("team", {}).get("abbreviation", ""): entry for entry in boxscore.get("players", [])}
+        sea_entry = players.get(TEAM_ABBR)
+        opp_abbr = opponent_comp.get("team", {}).get("abbreviation", "")
+        opp_entry = players.get(opp_abbr)
+        if sea_entry:
+            performers[TEAM_ABBR] = self._format_team_performers(sea_entry)
+        if opp_abbr and opp_entry:
+            performers[opp_abbr] = self._format_team_performers(opp_entry)
+        return performers
+
+    def _format_team_performers(self, entry: Dict[str, Any]) -> str:
+        batting = next(
+            (stat for stat in entry.get("statistics", []) if stat.get("type") == "batting"),
+            None,
+        )
+        pitching = next(
+            (stat for stat in entry.get("statistics", []) if stat.get("type") == "pitching"),
+            None,
+        )
+        parts: list[str] = []
+        hitter = self._select_hitter(batting) if batting else ""
+        pitcher = self._select_pitcher(pitching) if pitching else ""
+        if hitter:
+            parts.append(hitter)
+        if pitcher:
+            parts.append(pitcher)
+        return " | ".join(parts)
+
+    def _select_hitter(self, stat: Dict[str, Any]) -> str:
+        keys = stat.get("keys", [])
+        best: tuple[str, str, int, int] | None = None
+        best_hits = -1
+        best_rbi = -1
+        for athlete in stat.get("athletes", []):
+            stats = athlete.get("stats", [])
+            data = {keys[i]: stats[i] for i in range(min(len(keys), len(stats)))}
+            hits = self._to_int(data.get("hits"))
+            at_bats = self._to_int(data.get("atBats"))
+            rbi = self._to_int(data.get("RBIs"))
+            hr = self._to_int(data.get("homeRuns"))
+            if at_bats == 0 and hits == 0 and rbi == 0 and hr == 0:
+                continue
+            if hits > best_hits or (hits == best_hits and rbi > best_rbi):
+                best = (
+                    athlete.get("athlete", {}).get("displayName", ""),
+                    data.get("hits-atBats", ""),
+                    hr,
+                    rbi,
+                )
+                best_hits = hits
+                best_rbi = rbi
+        if not best:
+            return ""
+        name, slash, hr, rbi = best
+        line = slash
+        if hr:
+            line += f", HR ({hr})"
+        if rbi:
+            line += f", {rbi} RBI"
+        return f"{name}: {line}"
+
+    def _select_pitcher(self, stat: Dict[str, Any]) -> str:
+        keys = stat.get("keys", [])
+        best: tuple[str, str, int, int] | None = None
+        best_outs = -1
+        best_ks = -1
+        for athlete in stat.get("athletes", []):
+            stats = athlete.get("stats", [])
+            data = {keys[i]: stats[i] for i in range(min(len(keys), len(stats)))}
+            ip = data.get("fullInnings.partInnings", "0.0")
+            outs = self._outs_from_ip(ip)
+            strikeouts = self._to_int(data.get("strikeouts"))
+            er = self._to_int(data.get("earnedRuns"))
+            if outs == 0 and strikeouts == 0:
+                continue
+            if outs > best_outs or (outs == best_outs and strikeouts > best_ks):
+                best = (
+                    athlete.get("athlete", {}).get("displayName", ""),
+                    ip,
+                    strikeouts,
+                    er,
+                )
+                best_outs = outs
+                best_ks = strikeouts
+        if not best:
+            return ""
+        name, ip, strikeouts, er = best
+        return f"{name}: {ip} IP, {strikeouts} K, {er} ER"
+
+    def _outs_from_ip(self, value: Optional[str]) -> int:
+        if not value:
+            return 0
+        try:
+            if "." in value:
+                whole, frac = value.split(".", 1)
+                outs = int(whole) * 3 + int(frac)
+            else:
+                outs = int(value) * 3
+            return outs
+        except ValueError:
+            return 0
+
+    def _to_int(self, value: Any) -> int:
+        try:
+            return int(float(str(value)))
+        except (TypeError, ValueError):
+            return 0
 
     def build_message(self, summary: Dict[str, Any]) -> str:
         """Format the game summary into a Discord message."""
@@ -318,9 +663,9 @@ class MarinersGameCog(commands.Cog):
         if highlights_line:
             lines.append(highlights_line)
         lines.extend([record_line, al_line, "", "*Top Performers*"])
-        sea_perf = summary.get("top_performers", {}).get("SEA", "")
+        sea_perf = summary.get("top_performers", {}).get(TEAM_ABBR, "")
         opp_perf = summary.get("top_performers", {}).get(summary.get("opp_abbr", ""), "")
-        lines.append(f"SEA — {sea_perf}")
+        lines.append(f"{TEAM_ABBR} — {sea_perf}")
         lines.append(f"{summary.get('opp_abbr','')} — {opp_perf}")
         return "\n".join(lines)
 
@@ -328,23 +673,23 @@ class MarinersGameCog(commands.Cog):
     @tasks.loop(minutes=10)
     async def game_task(self) -> None:
         await self.bot.wait_until_ready()
-        summary = await asyncio.to_thread(self.fetch_game_summary)
+        summary = await self.fetch_game_summary()
         if not summary:
             return
-        gid = summary.get("game_pk")
-        if gid in self.posted:
+        event_id = summary.get("event_id")
+        if not event_id or event_id in self.posted:
             return
         channel = self.bot.get_channel(getattr(cfg, "SPORTS_CHANNEL_ID", 0))
         if not isinstance(channel, discord.TextChannel):
             log.error("Sports channel not found")
-            self.posted.add(gid)
-            await self._save_posted(gid)
             return
         try:
             msg = self.build_message(summary)
-            await channel.send(msg)
-            self.posted.add(gid)
-            await self._save_posted(gid)
+            message = await channel.send(msg)
+            message_id = getattr(message, "id", None)
+            stored_id = int(message_id) if message_id is not None else None
+            self.posted.add(event_id)
+            await self._mark_posted(event_id, stored_id)
         except Exception as exc:  # pragma: no cover - network
             log.exception("Failed to post game summary: %s", exc)
 


### PR DESCRIPTION
## Summary
- persist a `tracking_since` timestamp in the new `mariners_schedule_state` table and load it on cog startup so Mariners recaps only consider games after the feature is enabled
- skip schedule entries dated before the tracking anchor and require the same filter when fetching pending summaries to avoid backfilling earlier games
- update Mariners cog tests to configure the anchor and cover the case where older games are ignored

## Testing
- python -m pytest -q
- python test_harness.py *(expected offline warnings about missing Discord login)*

------
https://chatgpt.com/codex/tasks/task_e_68c8db38c0d8832ba4067a37bb5e07c3