### PR TITLE
Fix console logging when LOG_LEVEL suppresses INFO output

### DIFF
--- a/tests/test_logging_configuration.py
+++ b/tests/test_logging_configuration.py
@@ -1,0 +1,17 @@
+import logging
+
+import gentlebot.__main__ as main
+
+
+def test_console_logging_remains_verbose(monkeypatch):
+    """Ensure raising LOG_LEVEL does not disable INFO logs for gentlebot."""
+
+    monkeypatch.setenv("LOG_LEVEL", "ERROR")
+    main.configure_logging()
+
+    log = logging.getLogger("gentlebot.test_console")
+    assert log.isEnabledFor(logging.INFO)
+
+    # Restore default configuration for subsequent tests.
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    main.configure_logging()


### PR DESCRIPTION
## Summary
- refactor logging setup into configure_logging so gentlebot loggers keep an INFO-level console handler regardless of LOG_LEVEL
- add level configuration for database and file handlers while preventing duplicate console output
- add a regression test covering the raised LOG_LEVEL scenario

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ef0793d8f0832b96b7b18a794f5839