### PR TITLE
Add Gemini tool calling pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ roles at 08:30 PT.
  - Gemini features require a `GEMINI_API_KEY`. Optional overrides like `MODEL_GENERAL`
    can customize which Gemini model is used.
  - Set `PG_DSN` (or PG_* creds) to enable writing bot logs to a Postgres database.
+ - The LLM router now exposes Gemini function-calling tools for web search, math, and
+   reading small file snippets. Each tool is rate limited separately and tool calls
+   are logged alongside model quota events to keep troubleshooting consistent.
 
 ## Contributing
 Each cog is self-contained. Add a new `*_cog.py` file under `cogs/` and it will be loaded automatically.

--- a/gentlebot/llm/providers/gemini.py
+++ b/gentlebot/llm/providers/gemini.py
@@ -87,6 +87,7 @@ class GeminiClient:
         json_mode: bool = False,
         thinking_budget: int = 0,
         system_instruction: str | None = None,
+        tools: list[dict[str, Any]] | None = None,
     ) -> Any:
         config = genai.types.GenerateContentConfig(
             temperature=temperature, system_instruction=system_instruction
@@ -95,6 +96,8 @@ class GeminiClient:
             config.response_mime_type = "application/json"
         if thinking_budget:
             config.thinking = genai.types.ThinkingConfig(budget_tokens=thinking_budget)
+        if tools:
+            config.tools = tools
         content = self._convert_messages(messages)
         try:
             response = self.client.models.generate_content(


### PR DESCRIPTION
## Summary
- enumerate available router tools in the system prompt and expose Gemini function schemas
- execute tool calls with rate-limited handlers for search, math, and file reads, looping results back to the model
- add documentation for the new tool behavior and pass tool definitions through the Gemini client

## Testing
- python -m pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930d52b8530832bb79c765a0dc54a31)