### PR TITLE
Add contextual system prompts for LLM responses

### DIFF
--- a/gentlebot/cogs/gemini_cog.py
+++ b/gentlebot/cogs/gemini_cog.py
@@ -6,14 +6,14 @@ import random
 import asyncio
 import logging
 from collections import defaultdict
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 import asyncpg
 import discord
 from discord import app_commands
 from discord.ext import commands
 from ..util import chan_name, user_name
-from ..llm.router import router, SafetyBlocked
+from ..llm.router import SafetyBlocked, SYSTEM_INSTRUCTION, router
 from ..infra.quotas import RateLimited
 from ..db import get_pool
 
@@ -32,10 +32,6 @@ class GeminiCog(commands.Cog):
 
         # === Mention strings (populated after on_ready) ===
         self.mention_strs: list[str] = []
-
-        # === Conversation memory: channel_id → list of {role, content} ===
-        self.histories: dict[int, list[dict]] = defaultdict(list)
-        self.max_turns = 19  # keep last N user+assistant turns
 
         # === Rate‑limiting: user_id → last_timestamp ===
         self.cooldowns: dict[int, float] = defaultdict(lambda: 0)
@@ -101,24 +97,96 @@ class GeminiCog(commands.Cog):
         return prompt
 
 
-    async def call_llm(self, channel_id: int, user_prompt: str) -> str:
-        """Send chat history to Gemini and return the reply."""
-        channel = self.bot.get_channel(channel_id)
+    async def _build_chat_history_block(
+        self, channel: discord.abc.Messageable | None, exclude: discord.Message | None
+    ) -> str:
+        """Return a formatted sliding window of recent channel messages."""
 
-        history = self.histories[channel_id]
+        if not channel or not hasattr(channel, "history"):
+            return "No recent chat history."
 
-        system_directive = (
-            "Speak like a helpful and concise robot interacting with a Discord server of friends."
+        lines: list[str] = []
+
+        async for msg in channel.history(limit=15):
+            if exclude and msg.id == exclude.id:
+                continue
+            if not msg.content and not msg.attachments:
+                continue
+            timestamp = msg.created_at.astimezone(timezone.utc).isoformat()
+            author = user_name(msg.author)
+            content = msg.clean_content.strip()
+            if not content and msg.attachments:
+                content = ", ".join(att.filename for att in msg.attachments)
+            lines.append(f"[{timestamp}] {author}: {content}")
+
+        lines.reverse()
+        token_lengths = [len(line.split()) for line in lines]
+        total_tokens = sum(token_lengths)
+        while lines and total_tokens > 1000:
+            total_tokens -= token_lengths.pop(0)
+            lines.pop(0)
+
+        if not lines:
+            return "No recent chat history."
+
+        return "\n".join(lines)
+
+    async def _build_system_prompt(
+        self,
+        channel: discord.abc.Messageable | None,
+        user: discord.abc.User | None,
+        exclude: discord.Message | None,
+    ) -> str:
+        """Assemble the system prompt with context and core rules."""
+
+        current_time = datetime.now(timezone.utc).isoformat()
+
+        channel_name = getattr(channel, "name", None) if channel else None
+        channel_name = channel_name or "direct-message"
+        topic = getattr(channel, "topic", None) or "General"
+
+        user_display = user.display_name if user else "Unknown"
+        roles: list[str] = []
+        if isinstance(user, discord.Member):
+            roles = [r.name for r in user.roles if not r.is_default()]
+        user_roles = ", ".join(roles) if roles else "Member"
+
+        history_block = await self._build_chat_history_block(channel, exclude)
+
+        _, _, remainder = SYSTEM_INSTRUCTION.partition("\n")
+        core_instructions = remainder.lstrip("\n") if remainder else SYSTEM_INSTRUCTION
+
+        return (
+            "You are Gentlebot, a Discord copilot/robot for the Gentlefolk community.\n"
+            "# CONTEXT LAYER\n"
+            f"- **Time:** {current_time}\n"
+            f"- **Channel:** #{channel_name} (Topic: {topic})\n"
+            f"- **User:** {user_display} (Roles: {user_roles})\n"
+            "- **Recent Chat History:**\n"
+            f"{history_block}\n\n"
+            "# CORE INSTRUCTIONS\n"
+            f"{core_instructions}"
         )
 
-        messages = []
-        messages.extend(history[-(self.max_turns * 2):])
-        messages.append({"role": "system", "content": system_directive})
-        messages.append({"role": "user", "content": user_prompt})
+    async def call_llm(
+        self,
+        channel: discord.abc.Messageable | None,
+        user: discord.abc.User | None,
+        user_prompt: str,
+        exclude: discord.Message | None = None,
+    ) -> str:
+        """Send context-aware prompts to Gemini and return the reply."""
+
+        system_prompt = await self._build_system_prompt(channel, user, exclude)
+        messages = [{"role": "user", "content": user_prompt}]
 
         try:
             reply = await asyncio.to_thread(
-                router.generate, "general", messages, self.temperature
+                router.generate,
+                "general",
+                messages,
+                self.temperature,
+                system_instruction=system_prompt,
             )
         except RateLimited:
             return "Let me get back to you on this... I'm a bit busy right now."
@@ -128,12 +196,11 @@ class GeminiCog(commands.Cog):
             log.exception("Model call failed")
             return "Something's wrong... I need a mechanic."
 
-        history.append({"role": "user", "content": user_prompt})
-        history.append({"role": "assistant", "content": reply})
-        if len(history) > self.max_turns * 2:
-            self.histories[channel_id] = history[-(self.max_turns * 2):]
-
-        log.info("Model response in channel %s: %s", chan_name(channel), reply)
+        log.info(
+            "Model response in channel %s: %s",
+            chan_name(channel) if channel else "unknown",
+            reply,
+        )
         return reply
 
     async def _get_context_from_archive(self, channel_id: int) -> str:
@@ -179,7 +246,7 @@ class GeminiCog(commands.Cog):
         )
         try:
             # Use dummy channel to avoid polluting histories
-            response = (await self.call_llm(0, prompt)).strip()
+            response = (await self.call_llm(None, None, prompt)).strip()
             for emoji in custom_emojis:
                 if emoji in response:
                     return emoji
@@ -267,6 +334,8 @@ class GeminiCog(commands.Cog):
                 log.info("Rejected prompt: too long, empty, or disallowed mentions.")
                 return
 
+        await message.channel.trigger_typing()
+
         # 9) Build user_prompt with optional context
         is_ambient = (
             prompt == content
@@ -305,7 +374,9 @@ class GeminiCog(commands.Cog):
         # 10) Typing indicator while fetching
         async with message.channel.typing():
             try:
-                response = await self.call_llm(message.channel.id, user_prompt)
+                response = await self.call_llm(
+                    message.channel, message.author, user_prompt, message
+                )
             except Exception as e:
                 log.exception("Model call failed: %s", e)
                 return
@@ -330,7 +401,9 @@ class GeminiCog(commands.Cog):
             log.info("Rejected prompt for /ask: too long, empty, or disallowed mentions.")
             return
         try:
-                response = await self.call_llm(interaction.channel_id, sanitized)
+            response = await self.call_llm(
+                interaction.channel, interaction.user, sanitized
+            )
         except Exception as e:
             log.exception("Model call failed in /ask: %s", e)
             return


### PR DESCRIPTION
## Summary
- build a contextual system prompt that includes server time, channel details, user roles, and recent chat history before each LLM call
- add chat history window formatting with token-aware truncation and reuse the existing core instruction set
- trigger typing indicators earlier and pass dynamic system prompts through the router with fallback support

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930e2a5211c832b96807adb6be18d87)