### PR TITLE
Stop Yahoo fantasy recap after season end

### DIFF
--- a/gentlebot/tasks/yahoo_fantasy_weekly.py
+++ b/gentlebot/tasks/yahoo_fantasy_weekly.py
@@ -139,6 +139,9 @@ class YahooFantasyWeeklyCog(commands.Cog):
             )
             context = extract_league_context(payload)
             target_week = determine_target_week(context)
+            if target_week is None:
+                log.info("Yahoo Fantasy season appears complete; skipping recap")
+                return None
 
             recap: WeeklyRecap | None = None
             try:


### PR DESCRIPTION
### Motivation
- Prevent posting weekly Yahoo Fantasy recaps after the league season has finished by detecting season end in the Yahoo payload.
- Use league metadata from the API response rather than an environment variable toggle to decide whether to skip recaps.
- Reduce false positives from scheduled recap postings when the league `current_week` has passed the league `end_week`.

### Description
- Add an `end_week` field to `LeagueContext` and extract `end_week` in `extract_league_context` in `gentlebot/tasks/yahoo_fantasy.py`.
- Update `determine_target_week` to return `None` when the season appears complete and to cap the target week to `end_week` when present.
- In `gentlebot/tasks/yahoo_fantasy_weekly.py`, check `target_week` after calling `determine_target_week` and log/return early with `"Yahoo Fantasy season appears complete; skipping recap"` when `target_week` is `None` to avoid posting.
- Modified files: `gentlebot/tasks/yahoo_fantasy.py` and `gentlebot/tasks/yahoo_fantasy_weekly.py` to implement the above logic.

### Testing
- No automated tests were run for this change.
- To verify locally run `python -m pytest -q` and `python test_harness.py` as recommended by the repository guide.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d40db5698832b98878e161f06916e)