### PR TITLE
Add LLM provider abstraction layer and tool definitions

### DIFF
--- a/gentlebot/llm/providers/base.py
+++ b/gentlebot/llm/providers/base.py
@@ -1,0 +1,179 @@
+"""Abstract base class for LLM providers.
+
+This module defines the provider interface that all LLM implementations
+must follow. It enables swapping providers (Gemini, Claude, OpenAI) without
+changing the router or cog code.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class Message:
+    """Provider-agnostic message format.
+
+    Attributes:
+        role: Message role - "user", "assistant", or "system"
+        content: The message text content
+        name: Optional name for the message sender
+        tool_calls: List of tool invocations requested by the model
+        tool_call_id: ID linking a tool result to its invocation
+    """
+    role: str
+    content: str
+    name: Optional[str] = None
+    tool_calls: Optional[List["ToolCall"]] = None
+    tool_call_id: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        d: Dict[str, Any] = {"role": self.role, "content": self.content}
+        if self.name:
+            d["name"] = self.name
+        if self.tool_calls:
+            d["tool_calls"] = [tc.to_dict() for tc in self.tool_calls]
+        if self.tool_call_id:
+            d["tool_call_id"] = self.tool_call_id
+        return d
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Message":
+        """Create a Message from a dictionary."""
+        tool_calls = None
+        if data.get("tool_calls"):
+            tool_calls = [ToolCall.from_dict(tc) for tc in data["tool_calls"]]
+        return cls(
+            role=data.get("role", "user"),
+            content=data.get("content", ""),
+            name=data.get("name"),
+            tool_calls=tool_calls,
+            tool_call_id=data.get("tool_call_id"),
+        )
+
+
+@dataclass
+class ToolCall:
+    """Represents a tool invocation request from the model.
+
+    Attributes:
+        id: Unique identifier for this tool call
+        name: Name of the tool to invoke
+        arguments: Arguments to pass to the tool
+    """
+    id: str
+    name: str
+    arguments: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "arguments": self.arguments,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ToolCall":
+        """Create a ToolCall from a dictionary."""
+        return cls(
+            id=data.get("id", ""),
+            name=data.get("name", ""),
+            arguments=data.get("arguments", {}),
+        )
+
+
+@dataclass
+class GenerationResult:
+    """Provider-agnostic generation result.
+
+    Attributes:
+        text: The generated text response
+        tool_calls: List of tool invocations requested
+        usage: Token usage statistics (input, output, total)
+        finish_reason: Why generation stopped (stop, length, tool_calls, etc.)
+        raw_response: The original provider-specific response object
+    """
+    text: str
+    tool_calls: List[ToolCall] = field(default_factory=list)
+    usage: Optional[Dict[str, int]] = None
+    finish_reason: Optional[str] = None
+    raw_response: Any = None
+
+    @property
+    def has_tool_calls(self) -> bool:
+        """Check if the response contains tool calls."""
+        return bool(self.tool_calls)
+
+
+class LLMProvider(ABC):
+    """Abstract base class for LLM providers.
+
+    All LLM providers (Gemini, Claude, OpenAI, etc.) must implement this
+    interface to work with the router.
+    """
+
+    @abstractmethod
+    def generate(
+        self,
+        model: str,
+        messages: List[Message],
+        temperature: float = 0.6,
+        max_tokens: Optional[int] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        system_instruction: Optional[str] = None,
+        json_mode: bool = False,
+        **kwargs: Any,
+    ) -> GenerationResult:
+        """Generate a completion from the model.
+
+        Args:
+            model: Model identifier (e.g., "gemini-2.5-pro", "claude-3-opus")
+            messages: List of conversation messages
+            temperature: Sampling temperature (0.0 to 2.0)
+            max_tokens: Maximum tokens to generate
+            tools: List of tool schemas in provider-agnostic format
+            system_instruction: System prompt to guide the model
+            json_mode: Whether to force JSON output
+            **kwargs: Provider-specific options
+
+        Returns:
+            GenerationResult with text and/or tool calls
+        """
+        pass
+
+    @abstractmethod
+    def convert_tool_schema(self, tool: "Tool") -> Dict[str, Any]:
+        """Convert a provider-agnostic tool to provider-specific format.
+
+        Args:
+            tool: A Tool instance from gentlebot.llm.tools
+
+        Returns:
+            Tool schema in the provider's expected format
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Provider name for logging and identification."""
+        pass
+
+    def estimate_tokens(self, text: str) -> int:
+        """Estimate token count for the given text.
+
+        Default implementation uses character-based heuristic (~4 chars/token).
+        Providers should override with their own tokenizers for accuracy.
+        """
+        if not text:
+            return 0
+        return max(1, len(text) // 4)
+
+
+# Import Tool here to avoid circular imports, but make it available
+# for type hints in convert_tool_schema
+if False:  # TYPE_CHECKING equivalent that works at runtime
+    from ..tools import Tool

--- a/gentlebot/llm/providers/gemini.py
+++ b/gentlebot/llm/providers/gemini.py
@@ -1,31 +1,40 @@
+"""Gemini LLM provider implementation.
+
+This module provides the Gemini-specific implementation of the LLMProvider
+interface, wrapping the google-genai SDK.
+"""
+from __future__ import annotations
+
 import logging
-from typing import List, Dict, Any
+from typing import Any, Dict, List, Optional
 from types import SimpleNamespace
+
+from .base import LLMProvider, Message, GenerationResult, ToolCall
 
 try:
     from google import genai  # type: ignore
 except Exception:  # pragma: no cover - optional dependency
     class _DummyClient:
-        def __init__(self, *a, **k):
+        def __init__(self, *a: Any, **k: Any) -> None:
             pass
 
         class models:
             @staticmethod
-            def generate_content(*a, **k):
+            def generate_content(*a: Any, **k: Any) -> Any:
                 raise RuntimeError("google-genai library not installed")
 
     class _DummyTypes:
         class GenerateContentConfig:
-            def __init__(self, *a, **k):
+            def __init__(self, *a: Any, **k: Any) -> None:
                 pass
 
         class ThinkingConfig:
-            def __init__(self, *a, **k):
+            def __init__(self, *a: Any, **k: Any) -> None:
                 pass
 
         class Part:
             @staticmethod
-            def from_bytes(data: bytes, mime_type: str):
+            def from_bytes(data: bytes, mime_type: str) -> bytes:
                 return data
 
     genai = SimpleNamespace(Client=_DummyClient, types=_DummyTypes)  # type: ignore
@@ -35,24 +44,23 @@ log = logging.getLogger(f"gentlebot.{__name__}")
 
 # Gemini accepts only ``user`` or ``model`` roles; map assistant messages to
 # ``model`` and treat all others as ``user``.
-ROLE_MAP = {"user": "user", "assistant": "model"}
+ROLE_MAP = {"user": "user", "assistant": "model", "system": "user"}
 
 
-class GeminiClient:
-    """Wrapper around the google-genai client."""
+class GeminiProvider(LLMProvider):
+    """Gemini LLM provider implementing the abstract interface.
+
+    This is the preferred way to use Gemini. It implements the LLMProvider
+    interface for consistency with other providers.
+    """
 
     def __init__(self, api_key: str | None) -> None:
-        """Create a Gemini API client.
+        """Create a Gemini provider.
 
-        Parameters
-        ----------
-        api_key:
-            API key used to authenticate with Gemini.  When not provided the
-            client is still created with a dummy key so imports don't fail,
-            but requests will error.  This method logs a warning in that case
-            to make configuration issues easier to spot.
+        Args:
+            api_key: API key for Gemini. If not provided, a placeholder is used
+                     but requests will fail.
         """
-
         if not api_key:
             log.warning("GEMINI_API_KEY not configured; using placeholder key")
             api_key = "test"
@@ -61,23 +69,158 @@ class GeminiClient:
 
         self.client = genai.Client(api_key=api_key)
 
-    def _convert_messages(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """Translate internal message format to Gemini's expected structure.
+    @property
+    def name(self) -> str:
+        """Provider name for logging."""
+        return "gemini"
 
-        The Gemini SDK expects each message as a ``Content`` object with parts that
-        are ``Part`` instances (or dictionaries with a ``text`` field).  Previously
-        we passed the raw string directly which caused pydantic validation errors
-        like ``Input should be a valid dictionary``.  This method now wraps each
-        message content in a ``{"text": ...}`` part so the request validates
-        correctly.
+    def _convert_messages(self, messages: List[Message] | List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Convert messages to Gemini's expected format.
+
+        Gemini expects messages as Content objects with parts containing text.
         """
-
         converted: List[Dict[str, Any]] = []
         for m in messages:
-            role = ROLE_MAP.get(m.get("role", "user"), "user")
-            content = m.get("content", "")
+            if isinstance(m, Message):
+                role = ROLE_MAP.get(m.role, "user")
+                content = m.content
+            else:
+                role = ROLE_MAP.get(m.get("role", "user"), "user")
+                content = m.get("content", "")
             converted.append({"role": role, "parts": [{"text": content}]})
         return converted
+
+    def _extract_tool_calls(self, response: Any) -> List[ToolCall]:
+        """Extract tool calls from Gemini response."""
+        calls: List[ToolCall] = []
+        for candidate in getattr(response, "candidates", []) or []:
+            parts = getattr(getattr(candidate, "content", None), "parts", []) or []
+            for i, part in enumerate(parts):
+                func = getattr(part, "function_call", None)
+                if not func and isinstance(part, dict):
+                    func = part.get("function_call")
+                if not func:
+                    continue
+                name = getattr(func, "name", None) or (func.get("name") if isinstance(func, dict) else None)
+                if not name:
+                    continue
+                args = getattr(func, "args", None) or (func.get("args") if isinstance(func, dict) else None)
+                calls.append(ToolCall(
+                    id=f"call_{i}",
+                    name=name,
+                    arguments=args or {},
+                ))
+        return calls
+
+    def convert_tool_schema(self, tool: Any) -> Dict[str, Any]:
+        """Convert a Tool to Gemini's function declaration format."""
+        # Import here to avoid circular imports
+        from ..tools import Tool
+        if isinstance(tool, Tool):
+            return tool.to_gemini_schema()
+        # Already in dict format
+        return tool
+
+    def generate(
+        self,
+        model: str,
+        messages: List[Message] | List[Dict[str, Any]],
+        temperature: float = 0.6,
+        max_tokens: Optional[int] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        system_instruction: Optional[str] = None,
+        json_mode: bool = False,
+        **kwargs: Any,
+    ) -> GenerationResult:
+        """Generate a completion from Gemini.
+
+        Args:
+            model: Gemini model name (e.g., "gemini-2.5-pro")
+            messages: Conversation messages
+            temperature: Sampling temperature
+            max_tokens: Maximum tokens to generate (not used by Gemini directly)
+            tools: Tool schemas in Gemini format
+            system_instruction: System prompt
+            json_mode: Force JSON output
+            **kwargs: Additional options (thinking_budget supported)
+
+        Returns:
+            GenerationResult with text and/or tool calls
+        """
+        thinking_budget = kwargs.get("thinking_budget", 0)
+
+        config = genai.types.GenerateContentConfig(
+            temperature=temperature,
+            system_instruction=system_instruction,
+        )
+        if json_mode:
+            config.response_mime_type = "application/json"
+        if thinking_budget:
+            config.thinking = genai.types.ThinkingConfig(budget_tokens=thinking_budget)
+        if tools:
+            config.tools = tools
+
+        content = self._convert_messages(messages)
+
+        try:
+            response = self.client.models.generate_content(
+                model=model, contents=content, config=config
+            )
+        except Exception as exc:  # pragma: no cover
+            log.exception("Gemini API call failed: %s", exc)
+            raise
+
+        # Extract text
+        text = getattr(response, "text", "") or ""
+
+        # Extract tool calls
+        tool_calls = self._extract_tool_calls(response) if tools else []
+
+        # Extract usage
+        usage_meta = getattr(response, "usage_metadata", None)
+        usage = None
+        if usage_meta:
+            usage = {
+                "input_tokens": getattr(usage_meta, "prompt_token_count", 0),
+                "output_tokens": getattr(usage_meta, "candidates_token_count", 0),
+            }
+
+        return GenerationResult(
+            text=text,
+            tool_calls=tool_calls,
+            usage=usage,
+            raw_response=response,
+        )
+
+    def generate_image(self, model: str, prompt: str, *images: bytes) -> Any:
+        """Request an image from Gemini.
+
+        Args:
+            model: Image generation model
+            prompt: Image generation prompt
+            *images: Optional input images
+
+        Returns:
+            Raw Gemini response with image data
+        """
+        parts: List[Any] = [prompt]
+        for img in images:
+            parts.append(genai.types.Part.from_bytes(img, mime_type="image/png"))
+        config = genai.types.GenerateContentConfig(
+            response_modalities=["TEXT", "IMAGE"]
+        )
+        response = self.client.models.generate_content(
+            model=model, contents=parts, config=config
+        )
+        return response
+
+
+# Backward compatibility alias
+class GeminiClient(GeminiProvider):
+    """Legacy alias for GeminiProvider.
+
+    Deprecated: Use GeminiProvider instead.
+    """
 
     def generate(
         self,
@@ -89,35 +232,18 @@ class GeminiClient:
         system_instruction: str | None = None,
         tools: list[dict[str, Any]] | None = None,
     ) -> Any:
-        config = genai.types.GenerateContentConfig(
-            temperature=temperature, system_instruction=system_instruction
-        )
-        if json_mode:
-            config.response_mime_type = "application/json"
-        if thinking_budget:
-            config.thinking = genai.types.ThinkingConfig(budget_tokens=thinking_budget)
-        if tools:
-            config.tools = tools
-        content = self._convert_messages(messages)
-        try:
-            response = self.client.models.generate_content(
-                model=model, contents=content, config=config
-            )
-        except Exception as exc:  # pragma: no cover - optional logging
-            log.exception("Gemini API call failed: %s", exc)
-            raise
-        return response
+        """Generate completion (legacy interface).
 
-    def generate_image(self, model: str, prompt: str, *images: bytes) -> Any:
-        """Request an image from Gemini, asking for both text and image outputs."""
-
-        parts = [prompt]
-        for img in images:
-            parts.append(genai.types.Part.from_bytes(img, mime_type="image/png"))
-        config = genai.types.GenerateContentConfig(
-            response_modalities=["TEXT", "IMAGE"]
+        Returns the raw Gemini response for backward compatibility.
+        """
+        result = super().generate(
+            model=model,
+            messages=messages,
+            temperature=temperature,
+            tools=tools,
+            system_instruction=system_instruction,
+            json_mode=json_mode,
+            thinking_budget=thinking_budget,
         )
-        response = self.client.models.generate_content(
-            model=model, contents=parts, config=config
-        )
-        return response
+        # Return raw response for backward compatibility
+        return result.raw_response

--- a/gentlebot/llm/tokenizer.py
+++ b/gentlebot/llm/tokenizer.py
@@ -1,0 +1,172 @@
+"""Token estimation utilities for LLM providers.
+
+This module provides token counting/estimation for different LLM providers.
+Accurate token counting is important for staying within context limits
+and estimating costs.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+def estimate_tokens(text: str) -> int:
+    """Estimate token count using character-based heuristic.
+
+    Most modern LLMs (GPT, Claude, Gemini) use roughly 4 characters per token
+    for English text. This is more accurate than word count, which varies
+    wildly based on word length and punctuation.
+
+    Args:
+        text: The text to estimate tokens for
+
+    Returns:
+        Estimated token count (minimum 1 for non-empty text)
+
+    Example:
+        >>> estimate_tokens("Hello, world!")  # 13 chars
+        3
+        >>> estimate_tokens("")
+        0
+    """
+    if not text:
+        return 0
+    # Roughly 4 characters per token for English text
+    # This is a good approximation for Gemini, GPT-4, and Claude
+    return max(1, len(text) // 4)
+
+
+def estimate_tokens_for_messages(
+    messages: List[Dict[str, Any]],
+    system_instruction: str | None = None,
+) -> int:
+    """Estimate total tokens for a list of messages.
+
+    Includes overhead for message formatting (role tags, separators).
+
+    Args:
+        messages: List of message dicts with "content" field
+        system_instruction: Optional system prompt
+
+    Returns:
+        Estimated total token count
+    """
+    total = 0
+
+    # System instruction
+    if system_instruction:
+        total += estimate_tokens(system_instruction)
+        total += 4  # Overhead for system role marker
+
+    # Messages
+    for msg in messages:
+        content = msg.get("content", "")
+        total += estimate_tokens(content)
+        total += 4  # Overhead for role marker and separators
+
+    return total
+
+
+def estimate_tokens_for_tool_calls(tool_calls: List[Dict[str, Any]]) -> int:
+    """Estimate tokens for tool call formatting.
+
+    Tool calls include the function name, arguments as JSON, and
+    formatting overhead.
+
+    Args:
+        tool_calls: List of tool call dicts
+
+    Returns:
+        Estimated token count for tool calls
+    """
+    import json
+
+    total = 0
+    for call in tool_calls:
+        name = call.get("name", "")
+        args = call.get("args", {}) or call.get("arguments", {})
+
+        total += estimate_tokens(name)
+        total += estimate_tokens(json.dumps(args, default=str))
+        total += 10  # Overhead for function call formatting
+
+    return total
+
+
+def truncate_to_token_budget(
+    text: str,
+    max_tokens: int,
+    preserve_end: bool = False,
+) -> str:
+    """Truncate text to fit within a token budget.
+
+    Args:
+        text: Text to truncate
+        max_tokens: Maximum tokens allowed
+        preserve_end: If True, keep the end of the text instead of the start
+
+    Returns:
+        Truncated text that fits within the budget
+    """
+    if not text:
+        return text
+
+    estimated = estimate_tokens(text)
+    if estimated <= max_tokens:
+        return text
+
+    # Calculate approximate character limit
+    # Use 4 chars per token as our heuristic
+    char_limit = max_tokens * 4
+
+    if preserve_end:
+        return text[-char_limit:]
+    return text[:char_limit]
+
+
+def split_by_token_budget(
+    text: str,
+    max_tokens_per_chunk: int,
+) -> List[str]:
+    """Split text into chunks that fit within token budgets.
+
+    Tries to split on sentence boundaries when possible.
+
+    Args:
+        text: Text to split
+        max_tokens_per_chunk: Maximum tokens per chunk
+
+    Returns:
+        List of text chunks
+    """
+    if not text:
+        return []
+
+    estimated = estimate_tokens(text)
+    if estimated <= max_tokens_per_chunk:
+        return [text]
+
+    # Calculate approximate character limit per chunk
+    char_limit = max_tokens_per_chunk * 4
+
+    chunks: List[str] = []
+    remaining = text
+
+    while remaining:
+        if len(remaining) <= char_limit:
+            chunks.append(remaining)
+            break
+
+        # Try to find a sentence boundary
+        chunk = remaining[:char_limit]
+
+        # Look for sentence-ending punctuation
+        for punct in [". ", "! ", "? ", "\n\n", "\n"]:
+            last_punct = chunk.rfind(punct)
+            if last_punct > char_limit // 2:  # Don't split too early
+                chunk = remaining[:last_punct + len(punct)]
+                break
+
+        chunks.append(chunk.strip())
+        remaining = remaining[len(chunk):].strip()
+
+    return chunks

--- a/gentlebot/llm/tools.py
+++ b/gentlebot/llm/tools.py
@@ -1,0 +1,253 @@
+"""Provider-agnostic tool definitions.
+
+This module defines tools in a format that can be converted to any
+LLM provider's expected schema (Gemini, Claude, OpenAI).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class ToolParameter:
+    """Definition for a single tool parameter.
+
+    Attributes:
+        name: Parameter name
+        type: JSON Schema type ("string", "integer", "boolean", "object", "array")
+        description: Human-readable description of the parameter
+        required: Whether the parameter is required
+        enum: List of allowed values (for string parameters)
+        minimum: Minimum value (for numeric parameters)
+        maximum: Maximum value (for numeric parameters)
+        default: Default value if not provided
+    """
+    name: str
+    type: str
+    description: str
+    required: bool = True
+    enum: Optional[List[str]] = None
+    minimum: Optional[int] = None
+    maximum: Optional[int] = None
+    default: Any = None
+
+
+@dataclass
+class Tool:
+    """Provider-agnostic tool definition.
+
+    Tools are defined once and can be converted to any provider's format.
+
+    Example:
+        >>> tool = Tool(
+        ...     name="calculate",
+        ...     description="Evaluate a math expression",
+        ...     parameters=[
+        ...         ToolParameter("expression", "string", "The math expression")
+        ...     ]
+        ... )
+        >>> gemini_schema = tool.to_gemini_schema()
+        >>> openai_schema = tool.to_openai_schema()
+    """
+    name: str
+    description: str
+    parameters: List[ToolParameter] = field(default_factory=list)
+
+    def _build_properties(self) -> tuple[Dict[str, Any], List[str]]:
+        """Build JSON Schema properties and required list."""
+        properties: Dict[str, Any] = {}
+        required: List[str] = []
+
+        for param in self.parameters:
+            prop: Dict[str, Any] = {
+                "type": param.type,
+                "description": param.description,
+            }
+            if param.enum:
+                prop["enum"] = param.enum
+            if param.minimum is not None:
+                prop["minimum"] = param.minimum
+            if param.maximum is not None:
+                prop["maximum"] = param.maximum
+            if param.default is not None:
+                prop["default"] = param.default
+
+            properties[param.name] = prop
+            if param.required:
+                required.append(param.name)
+
+        return properties, required
+
+    def to_openai_schema(self) -> Dict[str, Any]:
+        """Convert to OpenAI/Claude function calling format.
+
+        This format is used by OpenAI and Anthropic Claude.
+
+        Returns:
+            Tool schema in OpenAI function calling format
+        """
+        properties, required = self._build_properties()
+
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": {
+                    "type": "object",
+                    "properties": properties,
+                    "required": required,
+                },
+            },
+        }
+
+    def to_gemini_schema(self) -> Dict[str, Any]:
+        """Convert to Gemini function declaration format.
+
+        Gemini uses a slightly different structure from OpenAI.
+
+        Returns:
+            Tool schema in Gemini function declaration format
+        """
+        properties, required = self._build_properties()
+
+        return {
+            "name": self.name,
+            "description": self.description,
+            "parameters": {
+                "type": "object",
+                "properties": properties,
+                "required": required,
+            },
+        }
+
+    def to_claude_schema(self) -> Dict[str, Any]:
+        """Convert to Claude tool_use format.
+
+        Claude's format is similar to OpenAI but has some differences.
+
+        Returns:
+            Tool schema in Claude tool_use format
+        """
+        properties, required = self._build_properties()
+
+        return {
+            "name": self.name,
+            "description": self.description,
+            "input_schema": {
+                "type": "object",
+                "properties": properties,
+                "required": required,
+            },
+        }
+
+
+# ============================================================================
+# Built-in Tool Definitions
+# ============================================================================
+
+WEB_SEARCH = Tool(
+    name="web_search",
+    description=(
+        "Search the public web for up-to-date answers when local knowledge "
+        "is insufficient. Use this for current events, recent information, "
+        "or facts that may have changed since training."
+    ),
+    parameters=[
+        ToolParameter(
+            name="query",
+            type="string",
+            description="Keywords or question to search for",
+        ),
+        ToolParameter(
+            name="max_results",
+            type="integer",
+            description="Maximum number of results to return",
+            required=False,
+            minimum=1,
+            maximum=5,
+            default=3,
+        ),
+    ],
+)
+
+CALCULATE = Tool(
+    name="calculate",
+    description=(
+        "Safely evaluate a math expression including arithmetic, percentages, "
+        "and common functions (sqrt, log, sin, cos, tan, abs, round). "
+        "Use this instead of estimating or calculating mentally."
+    ),
+    parameters=[
+        ToolParameter(
+            name="expression",
+            type="string",
+            description="Math expression such as '((42 * 1.08) - 5) / 3' or 'sqrt(144)'",
+        ),
+    ],
+)
+
+READ_FILE = Tool(
+    name="read_file",
+    description=(
+        "Read a short snippet from a project file for citations or extra context. "
+        "Files must be within the Gentlebot repository. Use for referencing code, "
+        "configuration, or documentation."
+    ),
+    parameters=[
+        ToolParameter(
+            name="path",
+            type="string",
+            description="Relative path inside the repository to read",
+        ),
+        ToolParameter(
+            name="limit",
+            type="integer",
+            description="Maximum number of characters to return",
+            required=False,
+            minimum=100,
+            maximum=4000,
+            default=1200,
+        ),
+        ToolParameter(
+            name="offset",
+            type="integer",
+            description="Character offset to start reading from",
+            required=False,
+            minimum=0,
+            maximum=20_000,
+            default=0,
+        ),
+    ],
+)
+
+# All available tools
+ALL_TOOLS = [WEB_SEARCH, CALCULATE, READ_FILE]
+
+# Tool lookup by name
+TOOLS_BY_NAME: Dict[str, Tool] = {tool.name: tool for tool in ALL_TOOLS}
+
+
+def get_tool(name: str) -> Tool | None:
+    """Get a tool by name."""
+    return TOOLS_BY_NAME.get(name)
+
+
+def get_all_gemini_schemas() -> List[Dict[str, Any]]:
+    """Get all tool schemas in Gemini format.
+
+    Returns:
+        List wrapped in function_declarations for Gemini API
+    """
+    return [{"function_declarations": [tool.to_gemini_schema() for tool in ALL_TOOLS]}]
+
+
+def get_all_openai_schemas() -> List[Dict[str, Any]]:
+    """Get all tool schemas in OpenAI format."""
+    return [tool.to_openai_schema() for tool in ALL_TOOLS]
+
+
+def get_all_claude_schemas() -> List[Dict[str, Any]]:
+    """Get all tool schemas in Claude format."""
+    return [tool.to_claude_schema() for tool in ALL_TOOLS]

--- a/tests/test_llm_providers_base.py
+++ b/tests/test_llm_providers_base.py
@@ -1,0 +1,132 @@
+"""Tests for the LLM provider base classes."""
+
+from __future__ import annotations
+
+import pytest
+
+from gentlebot.llm.providers.base import (
+    Message,
+    ToolCall,
+    GenerationResult,
+    LLMProvider,
+)
+
+
+class TestMessage:
+    """Tests for the Message dataclass."""
+
+    def test_basic_message(self) -> None:
+        msg = Message(role="user", content="Hello")
+        assert msg.role == "user"
+        assert msg.content == "Hello"
+        assert msg.name is None
+        assert msg.tool_calls is None
+
+    def test_to_dict(self) -> None:
+        msg = Message(role="user", content="Hello")
+        d = msg.to_dict()
+        assert d == {"role": "user", "content": "Hello"}
+
+    def test_to_dict_with_name(self) -> None:
+        msg = Message(role="user", content="Hello", name="Alice")
+        d = msg.to_dict()
+        assert d["name"] == "Alice"
+
+    def test_from_dict(self) -> None:
+        d = {"role": "assistant", "content": "Hi there"}
+        msg = Message.from_dict(d)
+        assert msg.role == "assistant"
+        assert msg.content == "Hi there"
+
+    def test_from_dict_with_tool_calls(self) -> None:
+        d = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "1", "name": "calculate", "arguments": {"expression": "2+2"}}
+            ],
+        }
+        msg = Message.from_dict(d)
+        assert len(msg.tool_calls) == 1
+        assert msg.tool_calls[0].name == "calculate"
+
+
+class TestToolCall:
+    """Tests for the ToolCall dataclass."""
+
+    def test_basic_tool_call(self) -> None:
+        tc = ToolCall(id="call_1", name="calculate", arguments={"expression": "2+2"})
+        assert tc.id == "call_1"
+        assert tc.name == "calculate"
+        assert tc.arguments == {"expression": "2+2"}
+
+    def test_to_dict(self) -> None:
+        tc = ToolCall(id="call_1", name="calculate", arguments={"expression": "2+2"})
+        d = tc.to_dict()
+        assert d == {
+            "id": "call_1",
+            "name": "calculate",
+            "arguments": {"expression": "2+2"},
+        }
+
+    def test_from_dict(self) -> None:
+        d = {"id": "call_1", "name": "web_search", "arguments": {"query": "test"}}
+        tc = ToolCall.from_dict(d)
+        assert tc.id == "call_1"
+        assert tc.name == "web_search"
+
+
+class TestGenerationResult:
+    """Tests for the GenerationResult dataclass."""
+
+    def test_basic_result(self) -> None:
+        result = GenerationResult(text="Hello, world!")
+        assert result.text == "Hello, world!"
+        assert result.tool_calls == []
+        assert result.usage is None
+
+    def test_has_tool_calls(self) -> None:
+        result = GenerationResult(text="")
+        assert result.has_tool_calls is False
+
+        result = GenerationResult(
+            text="",
+            tool_calls=[ToolCall(id="1", name="test", arguments={})],
+        )
+        assert result.has_tool_calls is True
+
+    def test_with_usage(self) -> None:
+        result = GenerationResult(
+            text="Hello",
+            usage={"input_tokens": 10, "output_tokens": 5},
+        )
+        assert result.usage["input_tokens"] == 10
+        assert result.usage["output_tokens"] == 5
+
+
+class TestLLMProviderInterface:
+    """Tests to verify the LLMProvider interface requirements."""
+
+    def test_abstract_methods(self) -> None:
+        # Verify that LLMProvider cannot be instantiated directly
+        with pytest.raises(TypeError):
+            LLMProvider()
+
+    def test_estimate_tokens_default(self) -> None:
+        # Create a concrete implementation to test default methods
+        class ConcreteProvider(LLMProvider):
+            @property
+            def name(self) -> str:
+                return "test"
+
+            def generate(self, *args, **kwargs):
+                return GenerationResult(text="test")
+
+            def convert_tool_schema(self, tool):
+                return {}
+
+        provider = ConcreteProvider()
+
+        # Test default token estimation
+        assert provider.estimate_tokens("Hello") >= 1
+        assert provider.estimate_tokens("") == 0

--- a/tests/test_llm_tools.py
+++ b/tests/test_llm_tools.py
@@ -1,0 +1,150 @@
+"""Tests for the provider-agnostic tool definitions."""
+
+from __future__ import annotations
+
+import pytest
+
+from gentlebot.llm.tools import (
+    Tool,
+    ToolParameter,
+    ALL_TOOLS,
+    WEB_SEARCH,
+    CALCULATE,
+    READ_FILE,
+    get_tool,
+    get_all_gemini_schemas,
+    get_all_openai_schemas,
+    get_all_claude_schemas,
+)
+
+
+class TestToolParameter:
+    """Tests for ToolParameter dataclass."""
+
+    def test_required_parameter(self) -> None:
+        param = ToolParameter(
+            name="query",
+            type="string",
+            description="Search query",
+        )
+        assert param.name == "query"
+        assert param.required is True
+
+    def test_optional_parameter(self) -> None:
+        param = ToolParameter(
+            name="limit",
+            type="integer",
+            description="Max results",
+            required=False,
+            default=10,
+        )
+        assert param.required is False
+        assert param.default == 10
+
+
+class TestTool:
+    """Tests for Tool dataclass and schema conversions."""
+
+    def test_to_gemini_schema(self) -> None:
+        tool = Tool(
+            name="test_tool",
+            description="A test tool",
+            parameters=[
+                ToolParameter("arg1", "string", "First argument"),
+            ],
+        )
+        schema = tool.to_gemini_schema()
+
+        assert schema["name"] == "test_tool"
+        assert schema["description"] == "A test tool"
+        assert "parameters" in schema
+        assert schema["parameters"]["type"] == "object"
+        assert "arg1" in schema["parameters"]["properties"]
+        assert schema["parameters"]["required"] == ["arg1"]
+
+    def test_to_openai_schema(self) -> None:
+        tool = Tool(
+            name="test_tool",
+            description="A test tool",
+            parameters=[
+                ToolParameter("arg1", "string", "First argument"),
+            ],
+        )
+        schema = tool.to_openai_schema()
+
+        assert schema["type"] == "function"
+        assert schema["function"]["name"] == "test_tool"
+        assert "parameters" in schema["function"]
+
+    def test_to_claude_schema(self) -> None:
+        tool = Tool(
+            name="test_tool",
+            description="A test tool",
+            parameters=[
+                ToolParameter("arg1", "string", "First argument"),
+            ],
+        )
+        schema = tool.to_claude_schema()
+
+        assert schema["name"] == "test_tool"
+        assert "input_schema" in schema
+        assert schema["input_schema"]["type"] == "object"
+
+    def test_optional_parameters_not_in_required(self) -> None:
+        tool = Tool(
+            name="test",
+            description="Test",
+            parameters=[
+                ToolParameter("required_arg", "string", "Required"),
+                ToolParameter("optional_arg", "string", "Optional", required=False),
+            ],
+        )
+        schema = tool.to_gemini_schema()
+
+        assert "required_arg" in schema["parameters"]["required"]
+        assert "optional_arg" not in schema["parameters"]["required"]
+
+
+class TestBuiltinTools:
+    """Tests for the built-in tool definitions."""
+
+    def test_all_tools_count(self) -> None:
+        assert len(ALL_TOOLS) == 3
+
+    def test_web_search_definition(self) -> None:
+        assert WEB_SEARCH.name == "web_search"
+        assert len(WEB_SEARCH.parameters) == 2  # query, max_results
+
+    def test_calculate_definition(self) -> None:
+        assert CALCULATE.name == "calculate"
+        assert len(CALCULATE.parameters) == 1  # expression
+
+    def test_read_file_definition(self) -> None:
+        assert READ_FILE.name == "read_file"
+        assert len(READ_FILE.parameters) == 3  # path, limit, offset
+
+    def test_get_tool(self) -> None:
+        assert get_tool("web_search") is WEB_SEARCH
+        assert get_tool("calculate") is CALCULATE
+        assert get_tool("read_file") is READ_FILE
+        assert get_tool("nonexistent") is None
+
+
+class TestSchemaGenerators:
+    """Tests for bulk schema generation functions."""
+
+    def test_get_all_gemini_schemas(self) -> None:
+        schemas = get_all_gemini_schemas()
+        assert len(schemas) == 1
+        assert "function_declarations" in schemas[0]
+        assert len(schemas[0]["function_declarations"]) == 3
+
+    def test_get_all_openai_schemas(self) -> None:
+        schemas = get_all_openai_schemas()
+        assert len(schemas) == 3
+        assert all(s["type"] == "function" for s in schemas)
+
+    def test_get_all_claude_schemas(self) -> None:
+        schemas = get_all_claude_schemas()
+        assert len(schemas) == 3
+        assert all("input_schema" in s for s in schemas)

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,0 +1,107 @@
+"""Tests for the token estimation utilities."""
+
+from __future__ import annotations
+
+import pytest
+
+from gentlebot.llm.tokenizer import (
+    estimate_tokens,
+    estimate_tokens_for_messages,
+    truncate_to_token_budget,
+    split_by_token_budget,
+)
+
+
+class TestEstimateTokens:
+    """Tests for the estimate_tokens function."""
+
+    def test_empty_string(self) -> None:
+        assert estimate_tokens("") == 0
+
+    def test_short_string(self) -> None:
+        # "Hello" is 5 chars, should be ~1-2 tokens
+        result = estimate_tokens("Hello")
+        assert result >= 1
+
+    def test_longer_string(self) -> None:
+        # 100 chars should be ~25 tokens (100 / 4)
+        text = "a" * 100
+        result = estimate_tokens(text)
+        assert result == 25
+
+    def test_realistic_sentence(self) -> None:
+        # "Hello, world!" is 13 chars, should be ~3 tokens
+        result = estimate_tokens("Hello, world!")
+        assert result == 3
+
+
+class TestEstimateTokensForMessages:
+    """Tests for the estimate_tokens_for_messages function."""
+
+    def test_empty_messages(self) -> None:
+        result = estimate_tokens_for_messages([])
+        assert result == 0
+
+    def test_single_message(self) -> None:
+        messages = [{"content": "Hello world"}]
+        result = estimate_tokens_for_messages(messages)
+        # 11 chars / 4 = 2-3 tokens + 4 overhead
+        assert result >= 5
+
+    def test_with_system_instruction(self) -> None:
+        messages = [{"content": "Hello"}]
+        system = "You are a helpful assistant."
+        result = estimate_tokens_for_messages(messages, system)
+        # Should include both message and system tokens
+        assert result > estimate_tokens_for_messages(messages)
+
+    def test_multiple_messages(self) -> None:
+        messages = [
+            {"content": "Hello"},
+            {"content": "World"},
+        ]
+        result = estimate_tokens_for_messages(messages)
+        # Each message adds overhead
+        assert result >= 8  # At least 2 tokens + 2*4 overhead
+
+
+class TestTruncateToTokenBudget:
+    """Tests for the truncate_to_token_budget function."""
+
+    def test_within_budget(self) -> None:
+        text = "Short text"
+        result = truncate_to_token_budget(text, 100)
+        assert result == text
+
+    def test_exceeds_budget(self) -> None:
+        text = "a" * 100  # 25 tokens
+        result = truncate_to_token_budget(text, 10)  # 40 chars
+        assert len(result) == 40
+
+    def test_preserve_end(self) -> None:
+        text = "start_middle_end"
+        result = truncate_to_token_budget(text, 2, preserve_end=True)
+        assert result.endswith("end")
+
+    def test_empty_string(self) -> None:
+        result = truncate_to_token_budget("", 100)
+        assert result == ""
+
+
+class TestSplitByTokenBudget:
+    """Tests for the split_by_token_budget function."""
+
+    def test_within_budget(self) -> None:
+        text = "Short text"
+        result = split_by_token_budget(text, 100)
+        assert result == ["Short text"]
+
+    def test_splits_long_text(self) -> None:
+        text = "a" * 200  # 50 tokens
+        result = split_by_token_budget(text, 10)  # Split into ~5 chunks
+        assert len(result) > 1
+        assert "".join(result) == text
+
+    def test_empty_string(self) -> None:
+        result = split_by_token_budget("", 100)
+        assert result == []


### PR DESCRIPTION
This lays the foundation for multi-provider LLM support:

- Add abstract LLMProvider interface with Message, ToolCall, GenerationResult
- Add provider-agnostic Tool definitions with schema converters for Gemini, OpenAI, and Claude formats
- Add character-based token estimation (more accurate than word count)
- Update GeminiProvider to implement LLMProvider interface
- Keep GeminiClient as backward-compatible alias
- Add comprehensive tests for all new modules

The abstractions enable future Claude/OpenAI integration without changing router or cog code.