### PR TITLE
Add engagement streaks and monthly recap features

### DIFF
--- a/db/versions/a1b2c3d4e5f6_create_user_streak_table.py
+++ b/db/versions/a1b2c3d4e5f6_create_user_streak_table.py
@@ -1,0 +1,60 @@
+"""Create user_streak table for engagement tracking.
+
+This table tracks consecutive daily engagement streaks for each user,
+enabling milestone role rewards based on streak length.
+
+Revision ID: a1b2c3d4e5f6
+Revises: fb67328ce99c
+Create Date: 2026-01-24 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "fb67328ce99c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_streak",
+        sa.Column("user_id", sa.BigInteger, nullable=False),
+        sa.Column("current_streak", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("longest_streak", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("last_active_date", sa.Date, nullable=False),
+        sa.Column("streak_started_date", sa.Date, nullable=True),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("user_id"),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["discord.user.user_id"],
+            name="fk_user_streak_user_id",
+        ),
+        schema="discord",
+    )
+    op.create_index(
+        "ix_user_streak_current",
+        "user_streak",
+        ["current_streak"],
+        schema="discord",
+        postgresql_using="btree",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_user_streak_current",
+        table_name="user_streak",
+        schema="discord",
+    )
+    op.drop_table("user_streak", schema="discord")

--- a/db/versions/b2c3d4e5f6a7_create_recap_preference_table.py
+++ b/db/versions/b2c3d4e5f6a7_create_recap_preference_table.py
@@ -1,0 +1,45 @@
+"""Create user_recap_pref table for monthly recap opt-in preferences.
+
+This table tracks user preferences for receiving monthly personalized
+recap DMs with engagement statistics.
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-01-24 00:00:01.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "b2c3d4e5f6a7"
+down_revision: Union[str, None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_recap_pref",
+        sa.Column("user_id", sa.BigInteger, nullable=False),
+        sa.Column("opted_in", sa.Boolean, nullable=False, server_default="false"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("user_id"),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["discord.user.user_id"],
+            name="fk_user_recap_pref_user_id",
+        ),
+        schema="discord",
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_recap_pref", schema="discord")

--- a/gentlebot/bot_config.py
+++ b/gentlebot/bot_config.py
@@ -130,6 +130,20 @@ else:
 INACTIVE_DAYS = int_env("INACTIVE_DAYS", 14)
 DAILY_PROMPT_ENABLED = bool_env("DAILY_PROMPT_ENABLED", False)
 
+# ─── Streak milestone roles ───────────────────────────────────────────────────
+# Create these roles in Discord and add the IDs via env vars.
+# Milestones: 7, 14, 30, 60, 100 consecutive days of activity.
+STREAK_ROLES: dict[int, int] = {
+    7: int_env("ROLE_STREAK_7", 0),     # Week Warrior
+    14: int_env("ROLE_STREAK_14", 0),   # Fortnight Fighter
+    30: int_env("ROLE_STREAK_30", 0),   # Month Master
+    60: int_env("ROLE_STREAK_60", 0),   # Iron Will
+    100: int_env("ROLE_STREAK_100", 0), # Century Club
+}
+
+# Whether streak roles are cumulative (all lower tiers) or exclusive (highest only)
+STREAK_ROLES_CUMULATIVE = bool_env("STREAK_ROLES_CUMULATIVE", False)
+
 # IDs of roles automatically assigned by RolesCog
 AUTO_ROLE_IDS = {
     ROLE_GHOST,

--- a/gentlebot/cogs/monthly_recap_cog.py
+++ b/gentlebot/cogs/monthly_recap_cog.py
@@ -1,0 +1,453 @@
+"""Monthly personal recaps for Gentlebot.
+
+Sends personalized monthly engagement recap DMs to opted-in users on the 1st
+of each month, summarizing their previous month's activity.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from calendar import month_name
+from datetime import date, timedelta
+from typing import TYPE_CHECKING
+
+import discord
+import pytz
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+from discord import app_commands
+from discord.ext import commands
+
+from .. import bot_config as cfg
+from ..infra import PoolAwareCog, alert_task_failure, idempotent_task, monthly_key
+from ..llm.router import SafetyBlocked, router
+from ..infra.quotas import RateLimited
+
+if TYPE_CHECKING:
+    import asyncpg
+
+log = logging.getLogger(f"gentlebot.{__name__}")
+
+LA = pytz.timezone("America/Los_Angeles")
+
+PROMPT_TEMPLATE = """You are Gentlebot composing a friendly monthly recap DM to {user_name}.
+
+Stats for {month_name}:
+- Messages sent: {message_count}
+- Reactions received: {reactions_received}
+- Top channels: {top_channels}
+- Current engagement streak: {current_streak} days
+- Best streak ever: {longest_streak} days
+
+Write a 2-3 sentence personalized recap that highlights their engagement.
+Be warm and encouraging. If they have a notable streak, mention it.
+If they were particularly active in certain channels, acknowledge it.
+End with a brief positive note about the new month.
+
+Output only the message text. No markdown formatting, no quotation marks."""
+
+FALLBACK_TEMPLATE = """Hey {user_name}! Your Gentlefolk recap for {month_name}: You sent {message_count} messages and earned {reactions_received} reactions. {streak_note}Keep the vibes going! \U0001f916 Gentlebot"""
+
+
+class MonthlyRecapCog(PoolAwareCog):
+    """Sends personalized monthly recap DMs to opted-in users."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        super().__init__(bot)
+        self.scheduler: AsyncIOScheduler | None = None
+        self.temperature = 0.7
+
+    async def cog_load(self) -> None:
+        await super().cog_load()
+        self.scheduler = AsyncIOScheduler(timezone=LA)
+        # Run at 10:00 AM Pacific on the 1st of each month
+        trigger = CronTrigger(day=1, hour=10, minute=0, timezone=LA)
+        self.scheduler.add_job(self._send_recaps_safe, trigger)
+        self.scheduler.start()
+        log.info("MonthlyRecapCog scheduler started")
+
+    async def cog_unload(self) -> None:
+        if self.scheduler:
+            self.scheduler.shutdown(wait=False)
+            self.scheduler = None
+        await super().cog_unload()
+
+    # ── Database Operations ────────────────────────────────────────────────
+
+    async def _get_opted_in_users(self) -> list[int]:
+        """Get all users who have opted in to monthly recaps."""
+        if not self.pool:
+            return []
+
+        rows = await self.pool.fetch(
+            """
+            SELECT user_id FROM discord.user_recap_pref
+            WHERE opted_in = TRUE
+            """
+        )
+        return [r["user_id"] for r in rows]
+
+    async def _set_opted_in(self, user_id: int, value: bool) -> None:
+        """Set or update a user's recap opt-in preference."""
+        if not self.pool:
+            return
+
+        await self.pool.execute(
+            """
+            INSERT INTO discord.user_recap_pref (user_id, opted_in, created_at)
+            VALUES ($1, $2, now())
+            ON CONFLICT (user_id) DO UPDATE SET opted_in = EXCLUDED.opted_in
+            """,
+            user_id,
+            value,
+        )
+
+    async def _is_opted_in(self, user_id: int) -> bool:
+        """Check if a user is opted in to recaps."""
+        if not self.pool:
+            return False
+
+        row = await self.pool.fetchrow(
+            """
+            SELECT opted_in FROM discord.user_recap_pref
+            WHERE user_id = $1
+            """,
+            user_id,
+        )
+        return bool(row and row["opted_in"])
+
+    async def _gather_user_stats(
+        self, user_id: int, start: date, end: date
+    ) -> dict:
+        """Aggregate user's stats for the given date range."""
+        if not self.pool:
+            return {
+                "message_count": 0,
+                "reactions_received": 0,
+                "top_channels": [],
+                "current_streak": 0,
+                "longest_streak": 0,
+            }
+
+        # Message count
+        msg_row = await self.pool.fetchrow(
+            """
+            SELECT COUNT(*) as cnt
+            FROM discord.message m
+            WHERE m.author_id = $1
+              AND m.created_at >= $2
+              AND m.created_at < $3
+            """,
+            user_id,
+            start,
+            end,
+        )
+        message_count = msg_row["cnt"] if msg_row else 0
+
+        # Reactions received
+        react_row = await self.pool.fetchrow(
+            """
+            SELECT COUNT(*) as cnt
+            FROM discord.reaction_event r
+            JOIN discord.message m ON r.message_id = m.message_id
+            WHERE m.author_id = $1
+              AND r.reaction_action = 'MESSAGE_REACTION_ADD'
+              AND r.event_at >= $2
+              AND r.event_at < $3
+            """,
+            user_id,
+            start,
+            end,
+        )
+        reactions_received = react_row["cnt"] if react_row else 0
+
+        # Top channels
+        channel_rows = await self.pool.fetch(
+            """
+            SELECT c.name, COUNT(*) as cnt
+            FROM discord.message m
+            JOIN discord.channel c ON m.channel_id = c.channel_id
+            WHERE m.author_id = $1
+              AND m.created_at >= $2
+              AND m.created_at < $3
+            GROUP BY c.name
+            ORDER BY cnt DESC
+            LIMIT 3
+            """,
+            user_id,
+            start,
+            end,
+        )
+        top_channels = [r["name"] for r in channel_rows]
+
+        # Current streak
+        streak_row = await self.pool.fetchrow(
+            """
+            SELECT current_streak, longest_streak
+            FROM discord.user_streak
+            WHERE user_id = $1
+            """,
+            user_id,
+        )
+        current_streak = streak_row["current_streak"] if streak_row else 0
+        longest_streak = streak_row["longest_streak"] if streak_row else 0
+
+        return {
+            "message_count": message_count,
+            "reactions_received": reactions_received,
+            "top_channels": top_channels,
+            "current_streak": current_streak,
+            "longest_streak": longest_streak,
+        }
+
+    # ── Message Generation ─────────────────────────────────────────────────
+
+    def _build_prompt(
+        self, user_name: str, month_str: str, stats: dict
+    ) -> str:
+        """Build the LLM prompt for recap generation."""
+        channels_str = (
+            ", ".join(f"#{c}" for c in stats["top_channels"])
+            if stats["top_channels"]
+            else "various channels"
+        )
+        return PROMPT_TEMPLATE.format(
+            user_name=user_name,
+            month_name=month_str,
+            message_count=stats["message_count"],
+            reactions_received=stats["reactions_received"],
+            top_channels=channels_str,
+            current_streak=stats["current_streak"],
+            longest_streak=stats["longest_streak"],
+        )
+
+    def _fallback_message(
+        self, user_name: str, month_str: str, stats: dict
+    ) -> str:
+        """Generate a fallback message without LLM."""
+        streak_note = ""
+        if stats["current_streak"] >= 7:
+            streak_note = f"You're on a {stats['current_streak']}-day streak! "
+        elif stats["longest_streak"] >= 7:
+            streak_note = f"Your best streak was {stats['longest_streak']} days. "
+
+        return FALLBACK_TEMPLATE.format(
+            user_name=user_name,
+            month_name=month_str,
+            message_count=stats["message_count"],
+            reactions_received=stats["reactions_received"],
+            streak_note=streak_note,
+        )
+
+    async def _generate_recap_message(
+        self, user_name: str, month_str: str, stats: dict
+    ) -> str:
+        """Generate personalized recap message using LLM with fallback."""
+        prompt = self._build_prompt(user_name, month_str, stats)
+
+        try:
+            text = await asyncio.to_thread(
+                router.generate,
+                "scheduled",
+                [{"role": "user", "content": prompt}],
+                self.temperature,
+            )
+            text = text.strip().replace("\n", " ")
+            if len(text) < 20:
+                # Too short, use fallback
+                return self._fallback_message(user_name, month_str, stats)
+            return text
+        except (RateLimited, SafetyBlocked) as e:
+            log.warning("Recap generation blocked: %s", e)
+            return self._fallback_message(user_name, month_str, stats)
+        except Exception as e:
+            log.exception("Recap generation failed: %s", e)
+            return self._fallback_message(user_name, month_str, stats)
+
+    # ── Scheduled Task ─────────────────────────────────────────────────────
+
+    async def _send_recaps_safe(self) -> None:
+        """Wrapper for _send_recaps with error handling."""
+        try:
+            await self._send_recaps()
+        except Exception as exc:
+            log.exception("Monthly recap task failed: %s", exc)
+            await alert_task_failure(
+                self.bot,
+                "monthly_recap",
+                exc,
+                context={"month": monthly_key(self)},
+            )
+
+    @idempotent_task("monthly_recap", monthly_key)
+    async def _send_recaps(self) -> str:
+        """Send monthly recap DMs to all opted-in users."""
+        await self.bot.wait_until_ready()
+
+        if not self.pool:
+            return "error:no_pool"
+
+        guild = self.bot.get_guild(cfg.GUILD_ID)
+        if not guild:
+            log.error("Guild not found")
+            return "error:guild_not_found"
+
+        # Calculate previous month's date range
+        today = date.today()
+        first_of_this_month = today.replace(day=1)
+        last_of_prev_month = first_of_this_month - timedelta(days=1)
+        first_of_prev_month = last_of_prev_month.replace(day=1)
+        month_str = month_name[last_of_prev_month.month]
+
+        log.info(
+            "Sending monthly recaps for %s (%s to %s)",
+            month_str,
+            first_of_prev_month,
+            last_of_prev_month,
+        )
+
+        opted_in_users = await self._get_opted_in_users()
+        log.info("Found %d opted-in users", len(opted_in_users))
+
+        sent_count = 0
+        failed_count = 0
+
+        for user_id in opted_in_users:
+            member = guild.get_member(user_id)
+            if not member:
+                continue
+
+            stats = await self._gather_user_stats(
+                user_id, first_of_prev_month, first_of_this_month
+            )
+
+            # Skip users with no activity
+            if stats["message_count"] == 0:
+                continue
+
+            message = await self._generate_recap_message(
+                member.display_name, month_str, stats
+            )
+
+            try:
+                await member.send(message)
+                log.info("Sent monthly recap to %s", member.display_name)
+                sent_count += 1
+            except discord.HTTPException as e:
+                log.warning("Failed to send recap to %s: %s", member.display_name, e)
+                failed_count += 1
+
+            # Rate limit: small delay between DMs
+            await asyncio.sleep(1)
+
+        result = f"sent:{sent_count},failed:{failed_count}"
+        log.info("Monthly recap task complete: %s", result)
+        return result
+
+    # ── Slash Commands ─────────────────────────────────────────────────────
+
+    recap_group = app_commands.Group(
+        name="recap", description="Monthly recap preferences"
+    )
+
+    @recap_group.command(name="optin", description="Opt in to monthly recap DMs")
+    async def recap_optin(self, interaction: discord.Interaction) -> None:
+        """Enable monthly recap DMs for the user."""
+        await self._set_opted_in(interaction.user.id, True)
+        await interaction.response.send_message(
+            "\u2705 You're now opted in to monthly recap DMs! "
+            "You'll receive a personalized summary on the 1st of each month.",
+            ephemeral=True,
+        )
+
+    @recap_group.command(name="optout", description="Opt out of monthly recap DMs")
+    async def recap_optout(self, interaction: discord.Interaction) -> None:
+        """Disable monthly recap DMs for the user."""
+        await self._set_opted_in(interaction.user.id, False)
+        await interaction.response.send_message(
+            "\u274c You've opted out of monthly recap DMs. "
+            "You can opt back in anytime with `/recap optin`.",
+            ephemeral=True,
+        )
+
+    @recap_group.command(name="view", description="Preview your current month's stats")
+    async def recap_view(self, interaction: discord.Interaction) -> None:
+        """Show a preview of the user's current month stats."""
+        if not self.pool:
+            await interaction.response.send_message(
+                "Database unavailable.", ephemeral=True
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True)
+
+        today = date.today()
+        first_of_month = today.replace(day=1)
+        month_str = month_name[today.month]
+
+        stats = await self._gather_user_stats(
+            interaction.user.id, first_of_month, today + timedelta(days=1)
+        )
+
+        opted_in = await self._is_opted_in(interaction.user.id)
+        opt_status = "\u2705 Opted in" if opted_in else "\u274c Not opted in"
+
+        channels_str = (
+            ", ".join(f"#{c}" for c in stats["top_channels"])
+            if stats["top_channels"]
+            else "None yet"
+        )
+
+        embed = discord.Embed(
+            title=f"\U0001f4ca {month_str} Stats Preview",
+            color=discord.Color.blue(),
+        )
+        embed.add_field(
+            name="Messages", value=str(stats["message_count"]), inline=True
+        )
+        embed.add_field(
+            name="Reactions Received",
+            value=str(stats["reactions_received"]),
+            inline=True,
+        )
+        embed.add_field(name="Top Channels", value=channels_str, inline=False)
+        embed.add_field(
+            name="Current Streak",
+            value=f"{stats['current_streak']} days",
+            inline=True,
+        )
+        embed.add_field(
+            name="Best Streak",
+            value=f"{stats['longest_streak']} days",
+            inline=True,
+        )
+        embed.add_field(name="Recap DMs", value=opt_status, inline=True)
+
+        embed.set_footer(
+            text="This shows your activity so far this month. "
+            "Full recaps are sent on the 1st."
+        )
+
+        await interaction.followup.send(embed=embed, ephemeral=True)
+
+    @recap_group.command(name="status", description="Check your recap opt-in status")
+    async def recap_status(self, interaction: discord.Interaction) -> None:
+        """Check the user's current opt-in status."""
+        opted_in = await self._is_opted_in(interaction.user.id)
+
+        if opted_in:
+            await interaction.response.send_message(
+                "\u2705 You're opted in to monthly recap DMs. "
+                "Use `/recap optout` to disable.",
+                ephemeral=True,
+            )
+        else:
+            await interaction.response.send_message(
+                "\u274c You're not opted in to monthly recap DMs. "
+                "Use `/recap optin` to enable.",
+                ephemeral=True,
+            )
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(MonthlyRecapCog(bot))

--- a/gentlebot/cogs/streak_cog.py
+++ b/gentlebot/cogs/streak_cog.py
@@ -1,0 +1,532 @@
+"""Engagement streak tracking for Gentlebot.
+
+Tracks consecutive daily engagement streaks and awards milestone roles:
+- 7 days: Week Warrior
+- 14 days: Fortnight Fighter
+- 30 days: Month Master
+- 60 days: Iron Will
+- 100 days: Century Club
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+from typing import TYPE_CHECKING
+
+import discord
+import pytz
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+from discord import app_commands
+from discord.ext import commands
+
+from .. import bot_config as cfg
+from ..infra import PoolAwareCog, alert_task_failure, daily_key, idempotent_task
+
+if TYPE_CHECKING:
+    import asyncpg
+
+log = logging.getLogger(f"gentlebot.{__name__}")
+
+LA = pytz.timezone("America/Los_Angeles")
+
+# Streak milestone thresholds
+MILESTONES = sorted(cfg.STREAK_ROLES.keys())  # [7, 14, 30, 60, 100]
+
+# Role names for logging
+MILESTONE_NAMES = {
+    7: "Week Warrior",
+    14: "Fortnight Fighter",
+    30: "Month Master",
+    60: "Iron Will",
+    100: "Century Club",
+}
+
+
+class StreakCog(PoolAwareCog):
+    """Tracks engagement streaks and assigns milestone roles."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        super().__init__(bot)
+        self.scheduler: AsyncIOScheduler | None = None
+
+    async def cog_load(self) -> None:
+        await super().cog_load()
+        self.scheduler = AsyncIOScheduler(timezone=LA)
+        # Run at 12:05 AM Pacific daily
+        trigger = CronTrigger(hour=0, minute=5, timezone=LA)
+        self.scheduler.add_job(self._maintain_streaks_safe, trigger)
+        self.scheduler.start()
+        log.info("StreakCog scheduler started")
+
+    async def cog_unload(self) -> None:
+        if self.scheduler:
+            self.scheduler.shutdown(wait=False)
+            self.scheduler = None
+        await super().cog_unload()
+
+    # ── Helper Methods ─────────────────────────────────────────────────────
+
+    def _streak_emoji(self, streak: int) -> str:
+        """Return emoji based on streak length."""
+        if streak >= 100:
+            return "\U0001f451"  # Crown
+        elif streak >= 60:
+            return "\U0001f4aa"  # Flexed biceps
+        elif streak >= 30:
+            return "\u2b50"      # Star
+        elif streak >= 14:
+            return "\U0001f525\U0001f525"  # Double fire
+        elif streak >= 7:
+            return "\U0001f525"  # Fire
+        elif streak >= 3:
+            return "\U0001f31f"  # Glowing star
+        else:
+            return "\U0001f331"  # Seedling
+
+    def _streak_color(self, streak: int) -> discord.Color:
+        """Return embed color based on streak length."""
+        if streak >= 100:
+            return discord.Color.gold()
+        elif streak >= 60:
+            return discord.Color.purple()
+        elif streak >= 30:
+            return discord.Color.blue()
+        elif streak >= 14:
+            return discord.Color.orange()
+        elif streak >= 7:
+            return discord.Color.red()
+        else:
+            return discord.Color.green()
+
+    def _next_milestone(self, current: int) -> int | None:
+        """Return the next milestone to reach, or None if at max."""
+        for ms in MILESTONES:
+            if current < ms:
+                return ms
+        return None
+
+    # ── Database Operations ────────────────────────────────────────────────
+
+    async def _get_user_streak(self, user_id: int) -> dict:
+        """Fetch streak info for a user."""
+        if not self.pool:
+            return {"current": 0, "longest": 0, "last_active": None, "started": None}
+
+        row = await self.pool.fetchrow(
+            """
+            SELECT current_streak, longest_streak, last_active_date, streak_started_date
+            FROM discord.user_streak
+            WHERE user_id = $1
+            """,
+            user_id,
+        )
+        if row:
+            return {
+                "current": row["current_streak"],
+                "longest": row["longest_streak"],
+                "last_active": row["last_active_date"],
+                "started": row["streak_started_date"],
+            }
+        return {"current": 0, "longest": 0, "last_active": None, "started": None}
+
+    async def _get_active_users_yesterday(self) -> list[int]:
+        """Find users who posted at least one message yesterday (LA timezone)."""
+        if not self.pool:
+            return []
+
+        today_la = date.today()
+        yesterday_la = today_la - timedelta(days=1)
+
+        rows = await self.pool.fetch(
+            """
+            SELECT DISTINCT m.author_id
+            FROM discord.message m
+            JOIN discord."user" u ON m.author_id = u.user_id
+            WHERE m.created_at >= $1::date AT TIME ZONE 'America/Los_Angeles'
+              AND m.created_at < $2::date AT TIME ZONE 'America/Los_Angeles'
+              AND u.is_bot IS NOT TRUE
+            """,
+            yesterday_la,
+            today_la,
+        )
+        return [r["author_id"] for r in rows]
+
+    async def _update_streak(
+        self,
+        user_id: int,
+        new_streak: int,
+        longest: int,
+        active_date: date,
+        started_date: date | None,
+    ) -> None:
+        """Update or insert a user's streak record."""
+        if not self.pool:
+            return
+
+        await self.pool.execute(
+            """
+            INSERT INTO discord.user_streak (
+                user_id, current_streak, longest_streak, last_active_date, streak_started_date, updated_at
+            ) VALUES ($1, $2, $3, $4, $5, now())
+            ON CONFLICT (user_id) DO UPDATE SET
+                current_streak = EXCLUDED.current_streak,
+                longest_streak = EXCLUDED.longest_streak,
+                last_active_date = EXCLUDED.last_active_date,
+                streak_started_date = EXCLUDED.streak_started_date,
+                updated_at = now()
+            """,
+            user_id,
+            new_streak,
+            longest,
+            active_date,
+            started_date,
+        )
+
+    async def _reset_streak(self, user_id: int) -> None:
+        """Reset a user's current streak to 0."""
+        if not self.pool:
+            return
+
+        await self.pool.execute(
+            """
+            UPDATE discord.user_streak
+            SET current_streak = 0, streak_started_date = NULL, updated_at = now()
+            WHERE user_id = $1
+            """,
+            user_id,
+        )
+
+    # ── Role Sync ──────────────────────────────────────────────────────────
+
+    async def _sync_streak_roles(
+        self, guild: discord.Guild, user_id: int, streak: int
+    ) -> None:
+        """Assign appropriate streak roles based on current streak."""
+        member = guild.get_member(user_id)
+        if not member:
+            try:
+                member = await guild.fetch_member(user_id)
+            except discord.HTTPException:
+                return
+
+        if cfg.STREAK_ROLES_CUMULATIVE:
+            # Cumulative: Add all roles up to current streak, remove higher ones
+            for milestone in MILESTONES:
+                role_id = cfg.STREAK_ROLES.get(milestone, 0)
+                if role_id == 0:
+                    continue
+                role = guild.get_role(role_id)
+                if not role:
+                    continue
+
+                if streak >= milestone and role not in member.roles:
+                    try:
+                        await member.add_roles(
+                            role, reason=f"Streak milestone: {milestone} days"
+                        )
+                        log.info(
+                            "Assigned %s role to %s (streak: %d)",
+                            MILESTONE_NAMES.get(milestone, str(milestone)),
+                            member.display_name,
+                            streak,
+                        )
+                    except discord.HTTPException as e:
+                        log.warning(
+                            "Failed to assign streak role %d to %s: %s",
+                            milestone,
+                            member.display_name,
+                            e,
+                        )
+                elif streak < milestone and role in member.roles:
+                    try:
+                        await member.remove_roles(role, reason="Streak reset")
+                        log.info(
+                            "Removed %s role from %s (streak reset)",
+                            MILESTONE_NAMES.get(milestone, str(milestone)),
+                            member.display_name,
+                        )
+                    except discord.HTTPException as e:
+                        log.warning(
+                            "Failed to remove streak role %d from %s: %s",
+                            milestone,
+                            member.display_name,
+                            e,
+                        )
+        else:
+            # Exclusive: Only the highest earned role
+            earned = max((m for m in MILESTONES if streak >= m), default=0)
+
+            for milestone in MILESTONES:
+                role_id = cfg.STREAK_ROLES.get(milestone, 0)
+                if role_id == 0:
+                    continue
+                role = guild.get_role(role_id)
+                if not role:
+                    continue
+
+                should_have = milestone == earned
+
+                if should_have and role not in member.roles:
+                    try:
+                        await member.add_roles(
+                            role, reason=f"Streak milestone: {milestone} days"
+                        )
+                        log.info(
+                            "Assigned %s role to %s (streak: %d)",
+                            MILESTONE_NAMES.get(milestone, str(milestone)),
+                            member.display_name,
+                            streak,
+                        )
+                    except discord.HTTPException as e:
+                        log.warning(
+                            "Failed to assign streak role %d to %s: %s",
+                            milestone,
+                            member.display_name,
+                            e,
+                        )
+                elif not should_have and role in member.roles:
+                    try:
+                        await member.remove_roles(role, reason="Streak level changed")
+                        log.info(
+                            "Removed %s role from %s (upgraded to higher tier)",
+                            MILESTONE_NAMES.get(milestone, str(milestone)),
+                            member.display_name,
+                        )
+                    except discord.HTTPException as e:
+                        log.warning(
+                            "Failed to remove streak role %d from %s: %s",
+                            milestone,
+                            member.display_name,
+                            e,
+                        )
+
+    async def _remove_all_streak_roles(
+        self, guild: discord.Guild, user_id: int
+    ) -> None:
+        """Remove all streak roles from a user (on streak reset)."""
+        member = guild.get_member(user_id)
+        if not member:
+            return
+
+        for milestone in MILESTONES:
+            role_id = cfg.STREAK_ROLES.get(milestone, 0)
+            if role_id == 0:
+                continue
+            role = guild.get_role(role_id)
+            if role and role in member.roles:
+                try:
+                    await member.remove_roles(role, reason="Streak reset")
+                    log.info(
+                        "Removed %s role from %s (streak reset)",
+                        MILESTONE_NAMES.get(milestone, str(milestone)),
+                        member.display_name,
+                    )
+                except discord.HTTPException as e:
+                    log.warning(
+                        "Failed to remove streak role from %s: %s",
+                        member.display_name,
+                        e,
+                    )
+
+    # ── Scheduled Task ─────────────────────────────────────────────────────
+
+    async def _maintain_streaks_safe(self) -> None:
+        """Wrapper for _maintain_streaks with error handling."""
+        try:
+            await self._maintain_streaks()
+        except Exception as exc:
+            log.exception("Streak maintenance task failed: %s", exc)
+            await alert_task_failure(
+                self.bot,
+                "streak_maintenance",
+                exc,
+                context={"date": date.today().isoformat()},
+            )
+
+    @idempotent_task("streak_maintenance", daily_key)
+    async def _maintain_streaks(self) -> str:
+        """Daily task to update all streaks and sync roles."""
+        await self.bot.wait_until_ready()
+
+        if not self.pool:
+            return "error:no_pool"
+
+        guild = self.bot.get_guild(cfg.GUILD_ID)
+        if not guild:
+            log.error("Guild not found")
+            return "error:guild_not_found"
+
+        today_la = date.today()
+        yesterday_la = today_la - timedelta(days=1)
+
+        # Get users who were active yesterday
+        active_users = await self._get_active_users_yesterday()
+        active_set = set(active_users)
+
+        log.info("Processing streaks for %d active users", len(active_users))
+
+        # Get all existing streak records
+        rows = await self.pool.fetch(
+            """
+            SELECT user_id, current_streak, longest_streak, last_active_date, streak_started_date
+            FROM discord.user_streak
+            """
+        )
+
+        updated = 0
+        reset = 0
+        new_milestones = 0
+
+        # Update existing streaks
+        for row in rows:
+            user_id = row["user_id"]
+            current = row["current_streak"]
+            longest = row["longest_streak"]
+            last_active = row["last_active_date"]
+            started = row["streak_started_date"]
+
+            if user_id in active_set:
+                # User was active yesterday
+                if last_active == yesterday_la - timedelta(days=1):
+                    # Continuing streak
+                    new_streak = current + 1
+                    new_longest = max(longest, new_streak)
+                    await self._update_streak(
+                        user_id, new_streak, new_longest, yesterday_la, started
+                    )
+
+                    # Check for new milestone
+                    old_milestone = max((m for m in MILESTONES if current >= m), default=0)
+                    new_milestone = max((m for m in MILESTONES if new_streak >= m), default=0)
+                    if new_milestone > old_milestone:
+                        new_milestones += 1
+                        log.info(
+                            "User %d reached %d-day milestone!",
+                            user_id,
+                            new_milestone,
+                        )
+
+                    await self._sync_streak_roles(guild, user_id, new_streak)
+                    updated += 1
+                elif last_active != yesterday_la:
+                    # Streak was broken, starting fresh
+                    await self._update_streak(user_id, 1, longest, yesterday_la, yesterday_la)
+                    await self._remove_all_streak_roles(guild, user_id)
+                    reset += 1
+                # else: already processed today (last_active == yesterday_la)
+
+                active_set.discard(user_id)
+            else:
+                # User was NOT active yesterday
+                if current > 0 and last_active < yesterday_la:
+                    # Streak broken
+                    await self._reset_streak(user_id)
+                    await self._remove_all_streak_roles(guild, user_id)
+                    reset += 1
+
+        # Create records for newly active users
+        for user_id in active_set:
+            await self._update_streak(user_id, 1, 1, yesterday_la, yesterday_la)
+            updated += 1
+
+        result = f"updated:{updated},reset:{reset},milestones:{new_milestones}"
+        log.info("Streak maintenance complete: %s", result)
+        return result
+
+    # ── Slash Commands ─────────────────────────────────────────────────────
+
+    @app_commands.command(name="streak", description="Check your engagement streak")
+    @app_commands.describe(user="User to check (defaults to yourself)")
+    async def streak(
+        self, interaction: discord.Interaction, user: discord.Member | None = None
+    ) -> None:
+        """Display streak info for self or mentioned user."""
+        target = user or interaction.user
+        streak_info = await self._get_user_streak(target.id)
+
+        current = streak_info["current"]
+        longest = streak_info["longest"]
+        next_ms = self._next_milestone(current)
+
+        embed = discord.Embed(
+            title=f"{self._streak_emoji(current)} {target.display_name}'s Streak",
+            color=self._streak_color(current),
+        )
+        embed.add_field(name="Current", value=f"{current} days", inline=True)
+        embed.add_field(name="Best Ever", value=f"{longest} days", inline=True)
+
+        if next_ms:
+            days_to_go = next_ms - current
+            embed.add_field(
+                name="Next Milestone",
+                value=f"{MILESTONE_NAMES.get(next_ms, f'{next_ms} days')} ({days_to_go} to go)",
+                inline=True,
+            )
+        elif current >= max(MILESTONES):
+            embed.add_field(
+                name="Status",
+                value="\U0001f451 Century Club member!",
+                inline=True,
+            )
+
+        if streak_info["started"]:
+            embed.set_footer(text=f"Streak started: {streak_info['started']}")
+
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+
+    @app_commands.command(name="streakboard", description="Show top streak holders")
+    async def streakboard(self, interaction: discord.Interaction) -> None:
+        """Display streak leaderboard."""
+        if not self.pool:
+            await interaction.response.send_message(
+                "Database unavailable.", ephemeral=True
+            )
+            return
+
+        rows = await self.pool.fetch(
+            """
+            SELECT user_id, current_streak, longest_streak
+            FROM discord.user_streak
+            WHERE current_streak > 0
+            ORDER BY current_streak DESC, longest_streak DESC
+            LIMIT 10
+            """
+        )
+
+        if not rows:
+            await interaction.response.send_message(
+                "No active streaks yet! Start posting to build your streak.",
+                ephemeral=True,
+            )
+            return
+
+        guild = interaction.guild
+        lines = []
+        for i, row in enumerate(rows, 1):
+            user_id = row["user_id"]
+            current = row["current_streak"]
+            longest = row["longest_streak"]
+
+            member = guild.get_member(user_id) if guild else None
+            name = member.display_name if member else f"User {user_id}"
+
+            medal = {1: "\U0001f947", 2: "\U0001f948", 3: "\U0001f949"}.get(i, f"{i}.")
+            emoji = self._streak_emoji(current)
+
+            lines.append(
+                f"{medal} {emoji} **{name}** - {current} days (best: {longest})"
+            )
+
+        embed = discord.Embed(
+            title="\U0001f525 Streak Leaderboard",
+            description="\n".join(lines),
+            color=discord.Color.orange(),
+        )
+        embed.set_footer(text="Keep posting daily to climb the board!")
+
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(StreakCog(bot))

--- a/gentlebot/infra/__init__.py
+++ b/gentlebot/infra/__init__.py
@@ -17,7 +17,7 @@ from .logging import (
     get_logger,
     structured_log,
 )
-from .idempotent import daily_key, idempotent_task, weekly_key
+from .idempotent import daily_key, idempotent_task, monthly_key, weekly_key
 from .quotas import Limit, QuotaGuard, RateLimited
 from .retries import async_retry, call_with_backoff, with_retry
 from .state_cache import StateCache, get_state_cache
@@ -45,6 +45,7 @@ __all__ = [
     # Idempotency
     "daily_key",
     "idempotent_task",
+    "monthly_key",
     "weekly_key",
     # Logging
     "LogContext",

--- a/gentlebot/infra/idempotent.py
+++ b/gentlebot/infra/idempotent.py
@@ -164,3 +164,17 @@ def weekly_key(self: Any) -> str:
     """Key function for weekly tasks: returns year-week string."""
     today = date.today()
     return f"{today.year}-W{today.isocalendar()[1]:02d}"
+
+
+def monthly_key(self: Any) -> str:
+    """Key function for monthly tasks: returns year-month of the previous month.
+
+    This is used for tasks that run at the beginning of a month and process
+    data from the previous month (e.g., monthly recaps).
+    """
+    from datetime import timedelta
+
+    today = date.today()
+    first_of_month = today.replace(day=1)
+    prev_month = first_of_month - timedelta(days=1)
+    return f"{prev_month.year}-{prev_month.month:02d}"


### PR DESCRIPTION
## Summary

- **Engagement Streaks**: Track consecutive daily activity with 5 milestone role tiers (7, 14, 30, 60, 100 days)
- **Monthly Recaps**: Opt-in personalized stats DMs on the 1st of each month
- **Infrastructure**: Add `monthly_key` idempotency helper and streak role configuration

## Features

### Engagement Streaks (`/streak`, `/streakboard`)
| Milestone | Role Name | Emoji |
|-----------|-----------|-------|
| 7 days | Week Warrior | 🔥 |
| 14 days | Fortnight Fighter | 🔥🔥 |
| 30 days | Month Master | ⭐ |
| 60 days | Iron Will | 💪 |
| 100 days | Century Club | 👑 |

- Daily maintenance task at 12:05am PT
- Configurable cumulative vs exclusive role assignment

### Monthly Recaps (`/recap optin|optout|view|status`)
- LLM-generated personalized messages with fallback templates
- Stats include: message count, reactions received, top channels, streak info
- Runs on 1st of each month at 10am PT

## Database Migrations
- `discord.user_streak` - tracks current/longest streaks per user
- `discord.user_recap_pref` - stores opt-in preferences

## Test plan
- [ ] Run `alembic upgrade head` to apply migrations
- [ ] Create 5 streak milestone roles in Discord and configure env vars
- [ ] Start bot and verify scheduler logs appear
- [ ] Test `/streak` command shows correct data
- [ ] Test `/streakboard` displays leaderboard
- [ ] Test `/recap optin` and verify preference saved
- [ ] Test `/recap view` shows current month stats
- [ ] Test `/recap optout` and verify preference cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)