### PR TITLE
Fix failed cog imports for yahoo_fantasy_weekly and daily_digest

### DIFF
--- a/gentlebot/cogs/daily_digest_cog.py
+++ b/gentlebot/cogs/daily_digest_cog.py
@@ -12,28 +12,11 @@ from discord.ext import commands
 
 from .. import bot_config as cfg
 from ..util import build_db_url
+from ..tasks.daily_digest import assign_tiers
 
 log = logging.getLogger(f"gentlebot.{__name__}")
 
 LA = pytz.timezone("America/Los_Angeles")
-
-# ─── Helper Functions ──────────────────────────────────────────────────────
-
-def assign_tiers(rankings: list[int], roles: dict[str, int]) -> dict[int, int]:
-    """Return user→role mapping for tiered badges using fixed ranges."""
-
-    result: dict[int, int] = {}
-    tiers = (
-        ("gold", 0, 1),    # top 1
-        ("silver", 1, 2),  # next 1
-        ("bronze", 2, 4),  # next 2
-    )
-    for name, start, end in tiers:
-        role_id = roles.get(name, 0)
-        for idx in range(start, min(end, len(rankings))):
-            result[rankings[idx]] = role_id
-    return result
-
 
 class DailyDigestCog(commands.Cog):
     """Daily Digest scheduler for engagement badges."""

--- a/gentlebot/cogs/yahoo_fantasy_weekly_cog.py
+++ b/gentlebot/cogs/yahoo_fantasy_weekly_cog.py
@@ -17,7 +17,7 @@ from .. import bot_config as cfg
 from ..db import get_pool
 from ..infra import alert_task_failure, idempotent_task
 from ..util import chan_name, user_name
-from .yahoo_fantasy import (
+from ..tasks.yahoo_fantasy import (
     determine_target_week,
     extract_league_context,
     fetch_access_token,

--- a/gentlebot/tasks/daily_digest.py
+++ b/gentlebot/tasks/daily_digest.py
@@ -1,0 +1,18 @@
+"""Utility functions for daily digest features."""
+
+from __future__ import annotations
+
+
+def assign_tiers(rankings: list[int], roles: dict[str, int]) -> dict[int, int]:
+    """Return user→role mapping for tiered badges using fixed ranges."""
+    result: dict[int, int] = {}
+    tiers = (
+        ("gold", 0, 1),    # top 1
+        ("silver", 1, 2),  # next 1
+        ("bronze", 2, 4),  # next 2
+    )
+    for name, start, end in tiers:
+        role_id = roles.get(name, 0)
+        for idx in range(start, min(end, len(rankings))):
+            result[rankings[idx]] = role_id
+    return result

--- a/tests/test_daily_digest_bot_filter.py
+++ b/tests/test_daily_digest_bot_filter.py
@@ -2,7 +2,7 @@ import asyncio
 from types import SimpleNamespace
 import discord
 from discord.ext import commands
-from gentlebot.tasks import daily_digest
+from gentlebot.cogs import daily_digest_cog as daily_digest
 
 
 def test_sync_role_skips_bot_member(monkeypatch):


### PR DESCRIPTION
## Summary
- Fix `yahoo_fantasy_weekly_cog` import path (was looking for `yahoo_fantasy` in cogs instead of tasks)
- Extract `assign_tiers()` to new `gentlebot/tasks/daily_digest.py` module so `roles_cog` can import it
- Update test import to reference the cog module directly

## Test plan
- [ ] Run `docker compose up` and verify no "Bot starting with failed cogs" message
- [ ] Run `pytest tests/test_tier_assignment.py tests/test_daily_digest_bot_filter.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)