### PR TITLE
Add Hall of Fame for community-curated message archive

### DIFF
--- a/db/versions/d4e5f6a7b8c9_create_hall_of_fame_table.py
+++ b/db/versions/d4e5f6a7b8c9_create_hall_of_fame_table.py
@@ -1,0 +1,85 @@
+"""Create hall_of_fame table for community-curated message archive.
+
+This table tracks messages that receive high engagement and get nominated
+for the Hall of Fame. Community members vote on nominated messages, and
+those reaching the vote threshold are inducted (cross-posted to #hall-of-fame).
+
+Lifecycle:
+1. Message receives 10+ reactions -> nominated (entry created, inducted_at=NULL)
+2. Community taps trophy emoji to vote -> vote_count increments
+3. vote_count >= 3 -> inducted (inducted_at set, hof_message_id set)
+
+Revision ID: d4e5f6a7b8c9
+Revises: c3d4e5f6a7b8
+Create Date: 2026-02-02 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "d4e5f6a7b8c9"
+down_revision: Union[str, None] = "c3d4e5f6a7b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "hall_of_fame",
+        sa.Column("entry_id", sa.Integer, primary_key=True),
+        sa.Column("message_id", sa.BigInteger, nullable=False, unique=True),
+        sa.Column("channel_id", sa.BigInteger, nullable=False),
+        sa.Column("author_id", sa.BigInteger, nullable=False),
+        sa.Column(
+            "nominated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "inducted_at",
+            sa.DateTime(timezone=True),
+            nullable=True,  # NULL until votes reach threshold
+        ),
+        sa.Column("vote_count", sa.Integer, nullable=False, server_default="0"),
+        sa.Column(
+            "hof_message_id",
+            sa.BigInteger,
+            nullable=True,  # ID of cross-posted message in #hall-of-fame
+        ),
+        schema="discord",
+    )
+
+    # Index for finding non-inducted nominations (for voting)
+    op.create_index(
+        "ix_hall_of_fame_pending",
+        "hall_of_fame",
+        ["inducted_at"],
+        schema="discord",
+        postgresql_where=sa.text("inducted_at IS NULL"),
+    )
+
+    # Index for author statistics
+    op.create_index(
+        "ix_hall_of_fame_author",
+        "hall_of_fame",
+        ["author_id"],
+        schema="discord",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_hall_of_fame_author",
+        table_name="hall_of_fame",
+        schema="discord",
+    )
+    op.drop_index(
+        "ix_hall_of_fame_pending",
+        table_name="hall_of_fame",
+        schema="discord",
+    )
+    op.drop_table("hall_of_fame", schema="discord")

--- a/gentlebot/bot_config.py
+++ b/gentlebot/bot_config.py
@@ -182,6 +182,18 @@ LINK_SUMMARIZER_ENABLED = bool_env("LINK_SUMMARIZER_ENABLED", True)
 # Whether book enrichment is enabled (auto-detects books in #reading)
 BOOK_ENRICHMENT_ENABLED = bool_env("BOOK_ENRICHMENT_ENABLED", True)
 
+# ─── Hall of Fame ─────────────────────────────────────────────────────────
+# Community-curated archive of exceptional messages
+HALL_OF_FAME_ENABLED = bool_env("HALL_OF_FAME_ENABLED", True)
+# Channel ID where inducted messages are cross-posted (0 = disabled)
+HALL_OF_FAME_CHANNEL_ID = int_env("HALL_OF_FAME_CHANNEL_ID", 0)
+# Minimum total reactions for a message to be nominated
+HOF_NOMINATION_THRESHOLD = int_env("HOF_NOMINATION_THRESHOLD", 10)
+# Trophy votes needed for induction into Hall of Fame
+HOF_VOTE_THRESHOLD = int_env("HOF_VOTE_THRESHOLD", 3)
+# Emoji used for nominations and voting
+HOF_EMOJI = "\U0001f3c6"  # 🏆
+
 # IDs of roles automatically assigned by RolesCog
 AUTO_ROLE_IDS = {
     ROLE_GHOST,

--- a/gentlebot/cogs/hall_of_fame_cog.py
+++ b/gentlebot/cogs/hall_of_fame_cog.py
@@ -1,0 +1,428 @@
+"""Hall of Fame: Community-curated archive of exceptional messages.
+
+Messages that receive high engagement (10+ reactions) get automatically nominated
+with a trophy emoji. Community members vote by tapping the trophy, and messages
+reaching the vote threshold (3 votes) are inducted into the Hall of Fame.
+
+User Flow:
+1. Message gets 10+ reactions -> Bot adds trophy emoji (nomination)
+2. Community members tap trophy to vote
+3. 3 votes reached -> Cross-post to #hall-of-fame channel
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
+
+import discord
+import pytz
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+from discord.ext import commands
+
+from .. import bot_config as cfg
+from ..capabilities import (
+    Category,
+    CogCapabilities,
+    ReactionCapability,
+    ScheduledCapability,
+)
+from ..infra import PoolAwareCog, log_errors, require_pool
+
+if TYPE_CHECKING:
+    import asyncpg
+
+log = logging.getLogger(f"gentlebot.{__name__}")
+
+LA = pytz.timezone("America/Los_Angeles")
+
+
+class HallOfFameCog(PoolAwareCog):
+    """Tracks high-engagement messages and manages Hall of Fame induction."""
+
+    CAPABILITIES = CogCapabilities(
+        reactions=[
+            ReactionCapability(
+                emoji=cfg.HOF_EMOJI,
+                trigger="Nominated messages",
+                description="Vote to induct a message into the Hall of Fame",
+            ),
+        ],
+        scheduled=[
+            ScheduledCapability(
+                name="Hall of Fame Nominations",
+                schedule="Every 30 minutes",
+                description="Checks for messages with 10+ reactions and nominates them",
+                category=Category.SCHEDULED_DAILY,
+            ),
+        ],
+    )
+
+    def __init__(self, bot: commands.Bot) -> None:
+        super().__init__(bot)
+        self.scheduler: AsyncIOScheduler | None = None
+
+    async def cog_load(self) -> None:
+        await super().cog_load()
+
+        if not cfg.HALL_OF_FAME_ENABLED:
+            log.info("Hall of Fame feature is disabled")
+            return
+
+        # Start scheduler for periodic nomination checks
+        self.scheduler = AsyncIOScheduler(timezone=LA)
+        # Run every 30 minutes
+        trigger = CronTrigger(minute="*/30", timezone=LA)
+        self.scheduler.add_job(self._check_nominations_safe, trigger)
+        self.scheduler.start()
+        log.info("HallOfFameCog scheduler started")
+
+        # Run initial check after bot is ready
+        self.bot.loop.create_task(self._initial_nomination_check())
+
+    async def cog_unload(self) -> None:
+        if self.scheduler:
+            self.scheduler.shutdown(wait=False)
+            self.scheduler = None
+        await super().cog_unload()
+
+    async def _initial_nomination_check(self) -> None:
+        """Run nomination check once bot is ready."""
+        await self.bot.wait_until_ready()
+        if self.pool and cfg.HALL_OF_FAME_ENABLED:
+            try:
+                await self._check_nominations()
+            except Exception as exc:
+                log.exception("Initial nomination check failed: %s", exc)
+
+    # ── Nomination Detection ──────────────────────────────────────────────
+
+    async def _check_nominations_safe(self) -> None:
+        """Wrapper for _check_nominations with error handling."""
+        if not cfg.HALL_OF_FAME_ENABLED:
+            return
+        try:
+            await self._check_nominations()
+        except Exception as exc:
+            log.exception("Nomination check failed: %s", exc)
+
+    @require_pool
+    async def _check_nominations(self) -> None:
+        """Find messages with 10+ reactions and nominate them."""
+        await self.bot.wait_until_ready()
+
+        threshold = cfg.HOF_NOMINATION_THRESHOLD
+        lookback_days = 7  # Only check messages from last 7 days
+
+        # Find messages with enough reactions that aren't already nominated
+        # We count distinct reactions (user+emoji combos) per message
+        rows = await self.pool.fetch(
+            """
+            WITH reaction_counts AS (
+                SELECT
+                    re.message_id,
+                    COUNT(DISTINCT (re.user_id, re.emoji)) AS reaction_count
+                FROM discord.reaction_event re
+                WHERE re.reaction_action = 'add'
+                  AND re.event_at >= NOW() - INTERVAL '%s days'
+                  AND re.message_id IS NOT NULL
+                GROUP BY re.message_id
+                HAVING COUNT(DISTINCT (re.user_id, re.emoji)) >= $1
+            )
+            SELECT
+                rc.message_id,
+                rc.reaction_count,
+                m.channel_id,
+                m.author_id,
+                m.content
+            FROM reaction_counts rc
+            JOIN discord.message m ON rc.message_id = m.message_id
+            JOIN discord.channel c ON m.channel_id = c.channel_id
+            JOIN discord."user" u ON m.author_id = u.user_id
+            WHERE NOT EXISTS (
+                SELECT 1 FROM discord.hall_of_fame hof
+                WHERE hof.message_id = rc.message_id
+            )
+            AND c.is_private = FALSE
+            AND u.is_bot IS NOT TRUE
+            ORDER BY rc.reaction_count DESC
+            LIMIT 20
+            """ % lookback_days,
+            threshold,
+        )
+
+        if not rows:
+            log.debug("No new messages qualify for Hall of Fame nomination")
+            return
+
+        guild = self.bot.get_guild(cfg.GUILD_ID)
+        if not guild:
+            log.warning("Guild not found for Hall of Fame nominations")
+            return
+
+        nominated = 0
+        for row in rows:
+            message_id = row["message_id"]
+            channel_id = row["channel_id"]
+            author_id = row["author_id"]
+
+            try:
+                # Get the channel and message
+                channel = guild.get_channel(channel_id)
+                if not isinstance(channel, discord.TextChannel):
+                    continue
+
+                message = await channel.fetch_message(message_id)
+
+                # Add trophy reaction to nominate
+                await message.add_reaction(cfg.HOF_EMOJI)
+
+                # Record nomination in database
+                await self.pool.execute(
+                    """
+                    INSERT INTO discord.hall_of_fame (message_id, channel_id, author_id)
+                    VALUES ($1, $2, $3)
+                    ON CONFLICT (message_id) DO NOTHING
+                    """,
+                    message_id,
+                    channel_id,
+                    author_id,
+                )
+
+                log.info(
+                    "Nominated message %d for Hall of Fame (%d reactions)",
+                    message_id,
+                    row["reaction_count"],
+                )
+                nominated += 1
+
+            except discord.NotFound:
+                log.debug("Message %d not found, skipping nomination", message_id)
+            except discord.Forbidden:
+                log.warning("Cannot add reaction to message %d", message_id)
+            except Exception as exc:
+                log.warning("Failed to nominate message %d: %s", message_id, exc)
+
+        if nominated > 0:
+            log.info("Nominated %d messages for Hall of Fame", nominated)
+
+    # ── Vote Handling ─────────────────────────────────────────────────────
+
+    @commands.Cog.listener()
+    @log_errors("Hall of Fame vote handling failed")
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent) -> None:
+        """Handle trophy reactions for Hall of Fame voting."""
+        if not cfg.HALL_OF_FAME_ENABLED:
+            return
+
+        # Only process trophy emoji
+        if str(payload.emoji) != cfg.HOF_EMOJI:
+            return
+
+        # Ignore bot's own reactions
+        if payload.user_id == self.bot.user.id:
+            return
+
+        # Ignore DMs
+        if not payload.guild_id:
+            return
+
+        if not self.pool:
+            return
+
+        message_id = payload.message_id
+
+        # Check if this message is nominated but not yet inducted
+        row = await self.pool.fetchrow(
+            """
+            SELECT entry_id, vote_count, inducted_at, channel_id, author_id
+            FROM discord.hall_of_fame
+            WHERE message_id = $1
+            """,
+            message_id,
+        )
+
+        if not row:
+            # Message not nominated, ignore
+            return
+
+        if row["inducted_at"] is not None:
+            # Already inducted, ignore additional votes
+            return
+
+        # Increment vote count and check threshold
+        new_count = row["vote_count"] + 1
+        threshold = cfg.HOF_VOTE_THRESHOLD
+
+        if new_count >= threshold:
+            # Induct into Hall of Fame!
+            await self._induct_message(
+                message_id=message_id,
+                channel_id=row["channel_id"],
+                author_id=row["author_id"],
+                entry_id=row["entry_id"],
+                vote_count=new_count,
+            )
+        else:
+            # Just update vote count
+            await self.pool.execute(
+                """
+                UPDATE discord.hall_of_fame
+                SET vote_count = $1
+                WHERE entry_id = $2 AND inducted_at IS NULL
+                """,
+                new_count,
+                row["entry_id"],
+            )
+            log.debug(
+                "Vote recorded for message %d (%d/%d)",
+                message_id,
+                new_count,
+                threshold,
+            )
+
+    # ── Induction ─────────────────────────────────────────────────────────
+
+    async def _induct_message(
+        self,
+        message_id: int,
+        channel_id: int,
+        author_id: int,
+        entry_id: int,
+        vote_count: int,
+    ) -> None:
+        """Cross-post a message to the Hall of Fame channel."""
+        hof_channel_id = cfg.HALL_OF_FAME_CHANNEL_ID
+        if not hof_channel_id:
+            log.warning("Hall of Fame channel not configured, skipping induction")
+            return
+
+        guild = self.bot.get_guild(cfg.GUILD_ID)
+        if not guild:
+            return
+
+        hof_channel = guild.get_channel(hof_channel_id)
+        if not isinstance(hof_channel, discord.TextChannel):
+            log.warning("Hall of Fame channel %d not found or not a text channel", hof_channel_id)
+            return
+
+        # Fetch the original message
+        source_channel = guild.get_channel(channel_id)
+        if not isinstance(source_channel, discord.TextChannel):
+            log.warning("Source channel %d not found", channel_id)
+            return
+
+        try:
+            message = await source_channel.fetch_message(message_id)
+        except discord.NotFound:
+            log.warning("Original message %d not found, cannot induct", message_id)
+            # Mark as inducted anyway to prevent retries
+            await self.pool.execute(
+                """
+                UPDATE discord.hall_of_fame
+                SET inducted_at = NOW(), vote_count = $1
+                WHERE entry_id = $2
+                """,
+                vote_count,
+                entry_id,
+            )
+            return
+
+        # Count total reactions on the message
+        total_reactions = sum(r.count for r in message.reactions)
+
+        # Build the Hall of Fame embed
+        embed = discord.Embed(
+            title=f"{cfg.HOF_EMOJI} HALL OF FAME {cfg.HOF_EMOJI}",
+            color=discord.Color.gold(),
+            timestamp=message.created_at,
+        )
+
+        # Message content preview (max 500 chars)
+        content = message.content or ""
+        if len(content) > 500:
+            content = content[:497] + "..."
+
+        if content:
+            embed.description = content
+
+        # Handle attachments
+        if message.attachments:
+            first_attachment = message.attachments[0]
+            if first_attachment.content_type and first_attachment.content_type.startswith("image/"):
+                embed.set_image(url=first_attachment.url)
+
+        # Add author info
+        author = guild.get_member(author_id)
+        if author:
+            embed.set_author(
+                name=author.display_name,
+                icon_url=author.display_avatar.url,
+            )
+
+        # Footer with metadata
+        embed.add_field(
+            name="\u200b",  # Zero-width space for visual separator
+            value=(
+                f"\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n"
+                f"\U0001f4dd {message.author.mention} in {source_channel.mention}\n"
+                f"\U0001f517 [Jump to message]({message.jump_url})\n"
+                f"\u2764\ufe0f {total_reactions} reactions"
+            ),
+            inline=False,
+        )
+
+        try:
+            hof_message = await hof_channel.send(embed=embed)
+
+            # Update database with induction info
+            await self.pool.execute(
+                """
+                UPDATE discord.hall_of_fame
+                SET inducted_at = NOW(), vote_count = $1, hof_message_id = $2
+                WHERE entry_id = $3
+                """,
+                vote_count,
+                hof_message.id,
+                entry_id,
+            )
+
+            log.info(
+                "Inducted message %d into Hall of Fame (hof_message_id=%d)",
+                message_id,
+                hof_message.id,
+            )
+
+        except discord.Forbidden:
+            log.warning("Cannot send to Hall of Fame channel %d", hof_channel_id)
+        except Exception as exc:
+            log.exception("Failed to induct message %d: %s", message_id, exc)
+
+    # ── Message Deletion Handling ─────────────────────────────────────────
+
+    @commands.Cog.listener()
+    @log_errors("Hall of Fame message deletion handling failed")
+    async def on_raw_message_delete(self, payload: discord.RawMessageDeleteEvent) -> None:
+        """Remove nomination if the original message is deleted."""
+        if not cfg.HALL_OF_FAME_ENABLED:
+            return
+
+        if not self.pool:
+            return
+
+        # Check if this was a nominated message
+        result = await self.pool.execute(
+            """
+            DELETE FROM discord.hall_of_fame
+            WHERE message_id = $1 AND inducted_at IS NULL
+            """,
+            payload.message_id,
+        )
+
+        if result and "DELETE 1" in result:
+            log.info("Removed Hall of Fame nomination for deleted message %d", payload.message_id)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(HallOfFameCog(bot))

--- a/tests/test_hall_of_fame.py
+++ b/tests/test_hall_of_fame.py
@@ -1,0 +1,338 @@
+"""Tests for the Hall of Fame cog."""
+import asyncio
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def test_cog_initializes_with_disabled_scheduler():
+    """HallOfFameCog should initialize with scheduler as None."""
+    bot = types.SimpleNamespace()
+    from gentlebot.cogs.hall_of_fame_cog import HallOfFameCog
+
+    cog = HallOfFameCog(bot)
+    assert cog.scheduler is None
+    assert cog.pool is None
+
+
+def test_config_defaults_exist():
+    """Hall of Fame config values should have sensible defaults."""
+    from gentlebot import bot_config as cfg
+
+    assert hasattr(cfg, "HALL_OF_FAME_ENABLED")
+    assert hasattr(cfg, "HALL_OF_FAME_CHANNEL_ID")
+    assert hasattr(cfg, "HOF_NOMINATION_THRESHOLD")
+    assert hasattr(cfg, "HOF_VOTE_THRESHOLD")
+    assert hasattr(cfg, "HOF_EMOJI")
+
+    # Check default threshold values
+    assert cfg.HOF_NOMINATION_THRESHOLD >= 1
+    assert cfg.HOF_VOTE_THRESHOLD >= 1
+    assert cfg.HOF_EMOJI == "\U0001f3c6"  # Trophy emoji
+
+
+def test_capabilities_declared():
+    """HallOfFameCog should declare CAPABILITIES."""
+    from gentlebot.cogs.hall_of_fame_cog import HallOfFameCog
+    from gentlebot.capabilities import CogCapabilities
+
+    assert hasattr(HallOfFameCog, "CAPABILITIES")
+    assert isinstance(HallOfFameCog.CAPABILITIES, CogCapabilities)
+
+    # Should have reaction capability for trophy emoji
+    assert len(HallOfFameCog.CAPABILITIES.reactions) >= 1
+    assert any(
+        r.emoji == "\U0001f3c6" for r in HallOfFameCog.CAPABILITIES.reactions
+    )
+
+    # Should have scheduled capability for nomination checks
+    assert len(HallOfFameCog.CAPABILITIES.scheduled) >= 1
+
+
+def test_check_nominations_no_pool():
+    """_check_nominations should handle missing pool gracefully."""
+    bot = types.SimpleNamespace()
+    from gentlebot.cogs.hall_of_fame_cog import HallOfFameCog
+
+    cog = HallOfFameCog(bot)
+    cog.pool = None
+
+    async def run():
+        # Should return None without error due to @require_pool
+        result = await cog._check_nominations()
+        return result
+
+    result = asyncio.run(run())
+    assert result is None
+
+
+def test_on_raw_reaction_add_ignores_non_trophy():
+    """on_raw_reaction_add should ignore non-trophy reactions."""
+    bot = MagicMock()
+    bot.user = MagicMock()
+    bot.user.id = 12345
+    from gentlebot.cogs.hall_of_fame_cog import HallOfFameCog
+
+    cog = HallOfFameCog(bot)
+    cog.pool = MagicMock()  # Has pool
+
+    payload = MagicMock()
+    payload.emoji = MagicMock()
+    payload.emoji.__str__ = MagicMock(return_value="\u2764\ufe0f")  # Heart, not trophy
+    payload.user_id = 99999
+    payload.guild_id = 11111
+
+    async def run():
+        # Mock pool.fetchrow to track if it was called
+        cog.pool.fetchrow = AsyncMock(return_value=None)
+
+        with patch("gentlebot.cogs.hall_of_fame_cog.cfg") as mock_cfg:
+            mock_cfg.HALL_OF_FAME_ENABLED = True
+            mock_cfg.HOF_EMOJI = "\U0001f3c6"
+            await cog.on_raw_reaction_add(payload)
+
+        # Should not query database for non-trophy emoji
+        cog.pool.fetchrow.assert_not_called()
+
+    asyncio.run(run())
+
+
+def test_on_raw_reaction_add_ignores_bot_reactions():
+    """on_raw_reaction_add should ignore the bot's own reactions."""
+    bot = MagicMock()
+    bot.user = MagicMock()
+    bot.user.id = 12345
+    from gentlebot.cogs.hall_of_fame_cog import HallOfFameCog
+
+    cog = HallOfFameCog(bot)
+    cog.pool = MagicMock()
+
+    payload = MagicMock()
+    payload.emoji = MagicMock()
+    payload.emoji.__str__ = MagicMock(return_value="\U0001f3c6")  # Trophy
+    payload.user_id = 12345  # Same as bot
+    payload.guild_id = 11111
+
+    async def run():
+        cog.pool.fetchrow = AsyncMock(return_value=None)
+
+        with patch("gentlebot.cogs.hall_of_fame_cog.cfg") as mock_cfg:
+            mock_cfg.HALL_OF_FAME_ENABLED = True
+            mock_cfg.HOF_EMOJI = "\U0001f3c6"
+            await cog.on_raw_reaction_add(payload)
+
+        # Should not query database for bot's own reaction
+        cog.pool.fetchrow.assert_not_called()
+
+    asyncio.run(run())
+
+
+def test_on_raw_reaction_add_ignores_dms():
+    """on_raw_reaction_add should ignore DM reactions."""
+    bot = MagicMock()
+    bot.user = MagicMock()
+    bot.user.id = 12345
+    from gentlebot.cogs.hall_of_fame_cog import HallOfFameCog
+
+    cog = HallOfFameCog(bot)
+    cog.pool = MagicMock()
+
+    payload = MagicMock()
+    payload.emoji = MagicMock()
+    payload.emoji.__str__ = MagicMock(return_value="\U0001f3c6")
+    payload.user_id = 99999
+    payload.guild_id = None  # DM
+
+    async def run():
+        cog.pool.fetchrow = AsyncMock(return_value=None)
+
+        with patch("gentlebot.cogs.hall_of_fame_cog.cfg") as mock_cfg:
+            mock_cfg.HALL_OF_FAME_ENABLED = True
+            mock_cfg.HOF_EMOJI = "\U0001f3c6"
+            await cog.on_raw_reaction_add(payload)
+
+        # Should not query database for DM reactions
+        cog.pool.fetchrow.assert_not_called()
+
+    asyncio.run(run())
+
+
+def test_on_raw_reaction_add_ignores_non_nominated():
+    """on_raw_reaction_add should ignore reactions on non-nominated messages."""
+    bot = MagicMock()
+    bot.user = MagicMock()
+    bot.user.id = 12345
+    from gentlebot.cogs.hall_of_fame_cog import HallOfFameCog
+
+    cog = HallOfFameCog(bot)
+    cog.pool = MagicMock()
+
+    payload = MagicMock()
+    payload.emoji = MagicMock()
+    payload.emoji.__str__ = MagicMock(return_value="\U0001f3c6")
+    payload.user_id = 99999
+    payload.guild_id = 11111
+    payload.message_id = 55555
+
+    async def run():
+        # Return None = message not in hall_of_fame table
+        cog.pool.fetchrow = AsyncMock(return_value=None)
+        cog.pool.execute = AsyncMock()
+
+        with patch("gentlebot.cogs.hall_of_fame_cog.cfg") as mock_cfg:
+            mock_cfg.HALL_OF_FAME_ENABLED = True
+            mock_cfg.HOF_EMOJI = "\U0001f3c6"
+            await cog.on_raw_reaction_add(payload)
+
+        # Should query but not update (no nomination found)
+        cog.pool.fetchrow.assert_called_once()
+        cog.pool.execute.assert_not_called()
+
+    asyncio.run(run())
+
+
+def test_on_raw_reaction_add_ignores_already_inducted():
+    """on_raw_reaction_add should ignore reactions on already inducted messages."""
+    bot = MagicMock()
+    bot.user = MagicMock()
+    bot.user.id = 12345
+    from gentlebot.cogs.hall_of_fame_cog import HallOfFameCog
+    from datetime import datetime
+
+    cog = HallOfFameCog(bot)
+    cog.pool = MagicMock()
+
+    payload = MagicMock()
+    payload.emoji = MagicMock()
+    payload.emoji.__str__ = MagicMock(return_value="\U0001f3c6")
+    payload.user_id = 99999
+    payload.guild_id = 11111
+    payload.message_id = 55555
+
+    async def run():
+        # Return row with inducted_at set (already inducted)
+        cog.pool.fetchrow = AsyncMock(
+            return_value={
+                "entry_id": 1,
+                "vote_count": 5,
+                "inducted_at": datetime.now(),  # Already inducted
+                "channel_id": 22222,
+                "author_id": 33333,
+            }
+        )
+        cog.pool.execute = AsyncMock()
+
+        with patch("gentlebot.cogs.hall_of_fame_cog.cfg") as mock_cfg:
+            mock_cfg.HALL_OF_FAME_ENABLED = True
+            mock_cfg.HOF_EMOJI = "\U0001f3c6"
+            await cog.on_raw_reaction_add(payload)
+
+        # Should query but not update (already inducted)
+        cog.pool.fetchrow.assert_called_once()
+        cog.pool.execute.assert_not_called()
+
+    asyncio.run(run())
+
+
+def test_on_raw_reaction_add_increments_vote():
+    """on_raw_reaction_add should increment vote_count for nominated messages."""
+    bot = MagicMock()
+    bot.user = MagicMock()
+    bot.user.id = 12345
+    from gentlebot.cogs.hall_of_fame_cog import HallOfFameCog
+
+    cog = HallOfFameCog(bot)
+    cog.pool = MagicMock()
+
+    payload = MagicMock()
+    payload.emoji = MagicMock()
+    payload.emoji.__str__ = MagicMock(return_value="\U0001f3c6")
+    payload.user_id = 99999
+    payload.guild_id = 11111
+    payload.message_id = 55555
+
+    async def run():
+        # Return row with vote_count = 1, threshold = 3 (not yet inducted)
+        cog.pool.fetchrow = AsyncMock(
+            return_value={
+                "entry_id": 1,
+                "vote_count": 1,
+                "inducted_at": None,  # Not inducted
+                "channel_id": 22222,
+                "author_id": 33333,
+            }
+        )
+        cog.pool.execute = AsyncMock()
+
+        with patch("gentlebot.cogs.hall_of_fame_cog.cfg") as mock_cfg:
+            mock_cfg.HALL_OF_FAME_ENABLED = True
+            mock_cfg.HOF_EMOJI = "\U0001f3c6"
+            mock_cfg.HOF_VOTE_THRESHOLD = 3
+            await cog.on_raw_reaction_add(payload)
+
+        # Should update vote count (1 -> 2, still below threshold)
+        cog.pool.execute.assert_called_once()
+        call_args = cog.pool.execute.call_args
+        assert "UPDATE" in call_args[0][0]
+        assert call_args[0][1] == 2  # new vote_count
+
+    asyncio.run(run())
+
+
+def test_on_raw_message_delete_removes_nomination():
+    """on_raw_message_delete should remove non-inducted nominations."""
+    bot = MagicMock()
+    from gentlebot.cogs.hall_of_fame_cog import HallOfFameCog
+
+    cog = HallOfFameCog(bot)
+    cog.pool = MagicMock()
+
+    payload = MagicMock()
+    payload.message_id = 55555
+
+    async def run():
+        cog.pool.execute = AsyncMock(return_value="DELETE 1")
+
+        with patch("gentlebot.cogs.hall_of_fame_cog.cfg") as mock_cfg:
+            mock_cfg.HALL_OF_FAME_ENABLED = True
+            await cog.on_raw_message_delete(payload)
+
+        # Should attempt to delete nomination
+        cog.pool.execute.assert_called_once()
+        call_args = cog.pool.execute.call_args
+        assert "DELETE" in call_args[0][0]
+        assert "inducted_at IS NULL" in call_args[0][0]
+
+    asyncio.run(run())
+
+
+def test_feature_disabled_skips_processing():
+    """When HALL_OF_FAME_ENABLED is False, handlers should skip processing."""
+    bot = MagicMock()
+    bot.user = MagicMock()
+    bot.user.id = 12345
+    from gentlebot.cogs.hall_of_fame_cog import HallOfFameCog
+
+    cog = HallOfFameCog(bot)
+    cog.pool = MagicMock()
+
+    payload = MagicMock()
+    payload.emoji = MagicMock()
+    payload.emoji.__str__ = MagicMock(return_value="\U0001f3c6")
+    payload.user_id = 99999
+    payload.guild_id = 11111
+    payload.message_id = 55555
+
+    async def run():
+        cog.pool.fetchrow = AsyncMock()
+
+        with patch("gentlebot.cogs.hall_of_fame_cog.cfg") as mock_cfg:
+            mock_cfg.HALL_OF_FAME_ENABLED = False  # Disabled
+            mock_cfg.HOF_EMOJI = "\U0001f3c6"
+            await cog.on_raw_reaction_add(payload)
+
+        # Should not query database when feature is disabled
+        cog.pool.fetchrow.assert_not_called()
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- Adds a community-curated Hall of Fame feature where exceptional messages are nominated and inducted based on community votes
- Messages with 10+ reactions are automatically nominated with a 🏆 emoji
- When 3 community members tap the trophy, the message is cross-posted to #hall-of-fame

## Changes
| File | Purpose |
|------|---------|
| `db/versions/d4e5f6a7b8c9_create_hall_of_fame_table.py` | Alembic migration for `discord.hall_of_fame` table |
| `gentlebot/cogs/hall_of_fame_cog.py` | Main cog with nomination, voting, and induction logic |
| `gentlebot/bot_config.py` | Config variables for thresholds and channel ID |
| `tests/test_hall_of_fame.py` | 12 unit tests for edge cases |

## Configuration
```bash
HALL_OF_FAME_ENABLED=true          # Enable/disable feature
HALL_OF_FAME_CHANNEL_ID=123456     # Target channel for cross-posts
HOF_NOMINATION_THRESHOLD=10        # Reactions needed for nomination
HOF_VOTE_THRESHOLD=3               # Votes needed for induction
```

## Test plan
- [ ] Run `alembic upgrade head` to create the table
- [ ] Set `HALL_OF_FAME_CHANNEL_ID` to a test channel
- [ ] Post a message and add 10+ reactions → verify 🏆 appears
- [ ] Have 3 users tap 🏆 → verify cross-post to #hall-of-fame
- [ ] Verify same message cannot be inducted twice
- [ ] Verify private channel messages are excluded

🤖 Generated with [Claude Code](https://claude.ai/code)