### PR TITLE
Add engagement-based cooldown to daily prompts

### DIFF
--- a/gentlebot/bot_config.py
+++ b/gentlebot/bot_config.py
@@ -131,7 +131,7 @@ else:
 
 # ─── Optional overrides via env‑vars ───────────────────────────────────────
 INACTIVE_DAYS = int_env("INACTIVE_DAYS", 14)
-DAILY_PROMPT_ENABLED = bool_env("DAILY_PROMPT_ENABLED", False)
+DAILY_PROMPT_ENABLED = bool_env("DAILY_PROMPT_ENABLED", True)
 
 # ─── Daily Prompt Schedule ─────────────────────────────────────────────────
 # Schedule time in LA timezone (America/Los_Angeles)
@@ -140,6 +140,11 @@ PROMPT_SCHEDULE_HOUR = int_env("PROMPT_SCHEDULE_HOUR", 12)
 PROMPT_SCHEDULE_MINUTE = int_env("PROMPT_SCHEDULE_MINUTE", 30)
 # Ratio of polls vs text prompts (0.0 = all text, 1.0 = all polls)
 PROMPT_POLL_RATIO = float(os.getenv("PROMPT_POLL_RATIO", "0.4"))
+# Engagement-based cooldown: if prompts get low engagement, back off exponentially
+# Minimum message count to consider a prompt "engaged" (at least 2 responses)
+PROMPT_MIN_RESPONSES = int_env("PROMPT_MIN_RESPONSES", 2)
+# Maximum cooldown days (caps exponential growth)
+PROMPT_MAX_COOLDOWN_DAYS = int_env("PROMPT_MAX_COOLDOWN_DAYS", 7)
 
 # ─── Streak milestone roles ───────────────────────────────────────────────────
 # Create these roles in Discord and add the IDs via env vars.


### PR DESCRIPTION
## Summary
- Re-enables the daily prompt feature with smart cooldown logic
- Backs off exponentially when prompts receive low engagement (< 2 responses)
- Cooldown progression: 1 day → 2 days → 4 days → 7 days (capped)
- Good engagement immediately resets the cooldown
- Adds cooldown status display to `prompt_stats` command

## How it works
The system queries the last 10 prompts and counts consecutive low-engagement ones from most recent. Cooldown = 2^(count-1) days, capped at 7. This is calculated on-the-fly from historical data, so it's self-healing—no additional state to persist.

## Configuration
| Setting | Default | Description |
|---------|---------|-------------|
| `PROMPT_MIN_RESPONSES` | 2 | Minimum responses to consider "engaged" |
| `PROMPT_MAX_COOLDOWN_DAYS` | 7 | Maximum cooldown cap |

## Test plan
- [ ] Verify `prompt_stats` shows cooldown status correctly
- [ ] Test with simulated low-engagement data in database
- [ ] Confirm exponential backoff calculation matches expected values
- [ ] Verify cooldown resets when engagement improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)