### PR TITLE
Add 429 retry support and lower Gemini free-tier quotas

### DIFF
--- a/tests/test_router_defaults.py
+++ b/tests/test_router_defaults.py
@@ -7,5 +7,12 @@ def test_image_route_defaults_to_free_model(monkeypatch):
     monkeypatch.delenv("GEMINI_IMAGE_RPM", raising=False)
     router = LLMRouter()
     assert router.models["image"] == "gemini-2.5-flash-image"
-    assert router.quota.limits["image"].rpm == 10
+    assert router.quota.limits["image"].rpm == 5
 
+
+def test_general_route_default_rpm(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "fake")
+    monkeypatch.delenv("MODEL_GENERAL", raising=False)
+    monkeypatch.delenv("GEMINI_GENERAL_RPM", raising=False)
+    router = LLMRouter()
+    assert router.quota.limits["general"].rpm == 5


### PR DESCRIPTION
## Summary
- **429 retry**: `call_with_backoff` now retries on HTTP 429 with a 12s minimum delay (matching 5 RPM free-tier window). A new `_extract_status` helper reads status codes from both httpx-style responses and Gemini SDK `APIError.code`.
- **Lower quotas**: Default RPM limits lowered to match free tier — `general` 15→5, `image` 10→5. Paid-tier users override via `GEMINI_GENERAL_RPM` / `GEMINI_IMAGE_RPM` env vars.
- **Fallback fix**: Router's scheduled→general fallback now correctly detects Gemini 429 errors (previously only checked httpx-style status).

## Test plan
- [x] `test_retries.py`: New tests for `_extract_status` (response-style, code-style, None) and 429 retry behavior (success on retry, exhaustion)
- [x] `test_router_defaults.py`: Updated RPM assertions for `image` (5) and added `general` RPM test (5)
- [x] Full suite: 327 passed, 0 failures

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)