### PR TITLE
Add feature discovery and lurker re-engagement cogs

### DIFF
--- a/db/versions/e5f6a7b8c9d0_create_feature_tip_and_welcome_back.py
+++ b/db/versions/e5f6a7b8c9d0_create_feature_tip_and_welcome_back.py
@@ -1,0 +1,89 @@
+"""Create feature_tip and welcome_back_event tables.
+
+feature_tip: Tracks one-time contextual feature tips sent to users.
+Each user sees each tip at most once (PK on user_id + tip_key).
+
+welcome_back_event: Records welcome-back reactions/messages sent when
+a lurker or ghost returns after a gap. Indexed on (user_id, sent_at)
+for cooldown lookups.
+
+Revision ID: e5f6a7b8c9d0
+Revises: d4e5f6a7b8c9
+Create Date: 2026-02-08 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "e5f6a7b8c9d0"
+down_revision: Union[str, None] = "d4e5f6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # -- feature_tip --
+    op.create_table(
+        "feature_tip",
+        sa.Column("user_id", sa.BigInteger, nullable=False),
+        sa.Column("tip_key", sa.Text, nullable=False),
+        sa.Column(
+            "sent_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("user_id", "tip_key"),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["discord.user.user_id"],
+            name="fk_feature_tip_user_id",
+        ),
+        schema="discord",
+    )
+
+    # -- welcome_back_event --
+    op.create_table(
+        "welcome_back_event",
+        sa.Column(
+            "id",
+            sa.Integer,
+            primary_key=True,
+            autoincrement=True,
+        ),
+        sa.Column("user_id", sa.BigInteger, nullable=False),
+        sa.Column("channel_id", sa.BigInteger, nullable=False),
+        sa.Column("gap_days", sa.Integer, nullable=False),
+        sa.Column(
+            "sent_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["discord.user.user_id"],
+            name="fk_welcome_back_event_user_id",
+        ),
+        schema="discord",
+    )
+
+    op.create_index(
+        "ix_welcome_back_user",
+        "welcome_back_event",
+        ["user_id", "sent_at"],
+        schema="discord",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_welcome_back_user",
+        table_name="welcome_back_event",
+        schema="discord",
+    )
+    op.drop_table("welcome_back_event", schema="discord")
+    op.drop_table("feature_tip", schema="discord")

--- a/gentlebot/bot_config.py
+++ b/gentlebot/bot_config.py
@@ -198,6 +198,17 @@ WEEKLY_RECAP_CHANNEL_ID = int_env("WEEKLY_RECAP_CHANNEL_ID", 0)  # 0 = LOBBY_CHA
 WEEKLY_RECAP_LLM_ENABLED = bool_env("WEEKLY_RECAP_LLM_ENABLED", True)
 MYSTATS_ENABLED = bool_env("MYSTATS_ENABLED", True)
 
+# ─── Feature Discovery ────────────────────────────────────────────────────
+# Contextual one-time tips and periodic feature spotlights
+FEATURE_DISCOVERY_ENABLED = bool_env("FEATURE_DISCOVERY_ENABLED", True)
+FEATURE_SPOTLIGHT_INTERVAL_DAYS = int_env("FEATURE_SPOTLIGHT_INTERVAL_DAYS", 5)
+
+# ─── Welcome Back / Lurker Re-engagement ─────────────────────────────────
+WELCOME_BACK_ENABLED = bool_env("WELCOME_BACK_ENABLED", True)
+WELCOME_BACK_MIN_GAP_DAYS = int_env("WELCOME_BACK_MIN_GAP_DAYS", 7)
+WELCOME_BACK_COOLDOWN_DAYS = int_env("WELCOME_BACK_COOLDOWN_DAYS", 30)
+MONTHLY_RECAP_DM_ENABLED = bool_env("MONTHLY_RECAP_DM_ENABLED", True)
+
 # ─── Hall of Fame ─────────────────────────────────────────────────────────
 # Community-curated archive of exceptional messages
 HALL_OF_FAME_ENABLED = bool_env("HALL_OF_FAME_ENABLED", True)

--- a/gentlebot/cogs/feature_discovery_cog.py
+++ b/gentlebot/cogs/feature_discovery_cog.py
@@ -1,0 +1,363 @@
+"""
+feature_discovery_cog.py – Contextual Tips & Feature Spotlight
+==============================================================
+Helps users discover unused bot features via two mechanisms:
+
+1. **Contextual tips** (on_message listener):
+   Detects message patterns that match an existing feature and replies
+   with a one-time, friendly hint.  Each tip is shown at most once per
+   user, with a global rate-limit of one tip per channel per 24 hours.
+
+2. **Periodic feature spotlight** (scheduled task):
+   Posts a "Feature Spotlight" embed highlighting an underused feature
+   every N days (configurable via FEATURE_SPOTLIGHT_INTERVAL_DAYS).
+
+Configuration in bot_config.py:
+  • FEATURE_DISCOVERY_ENABLED: Master toggle (default: True)
+  • FEATURE_SPOTLIGHT_INTERVAL_DAYS: Days between spotlights (default: 5)
+"""
+from __future__ import annotations
+
+import logging
+import re
+import time
+from datetime import date
+
+import discord
+import pytz
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+from discord.ext import commands
+
+from .. import bot_config as cfg
+from ..capabilities import (
+    CogCapabilities,
+    ScheduledCapability,
+    Category,
+)
+from ..infra import PoolAwareCog, require_pool, idempotent_task, daily_key
+
+log = logging.getLogger(f"gentlebot.{__name__}")
+
+LA = pytz.timezone("America/Los_Angeles")
+
+# ---------------------------------------------------------------------------
+# Tip definitions
+# ---------------------------------------------------------------------------
+
+# URL regex (reused from link_summarizer_cog)
+URL_PATTERN = re.compile(r'https?://[^\s<>"\')\]]+', re.IGNORECASE)
+
+# Domains to skip (image/GIF hosts that aren't summarizable)
+_SKIP_DOMAINS = {
+    "tenor.com", "giphy.com", "imgur.com", "gfycat.com",
+    "media.discordapp.net", "cdn.discordapp.com",
+    "i.redd.it", "v.redd.it", "preview.redd.it",
+    "i.imgur.com", "media.tenor.com", "c.tenor.com",
+}
+
+# Pattern to detect "how active" / "who's posting" style questions
+ACTIVITY_PATTERN = re.compile(
+    r"\b(how active|who'?s posting|server stats|activity report)\b",
+    re.IGNORECASE,
+)
+
+# Minimum message length for TL;DR tip
+LONG_MESSAGE_THRESHOLD = 500
+
+# Each entry: (tip_key, detect_func, tip_message)
+# detect_func(message) -> bool
+TIP_DEFINITIONS: list[tuple[str, str]] = [
+    (
+        "tldr",
+        "btw — I added a 📝 to that message. Tap it to get a quick TL;DR!",
+    ),
+    (
+        "link_summary",
+        "btw — I added a 📋 to that link. Tap it to get a quick summary!",
+    ),
+    (
+        "book_enrichment",
+        "btw — I added a 📚 to that book mention. Tap it for ratings, a synopsis, and similar reads!",
+    ),
+    (
+        "vibecheck",
+        "btw — try `/vibecheck` for a quick server activity snapshot, or `/mystats` to see your own engagement stats!",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Feature spotlight content
+# ---------------------------------------------------------------------------
+
+SPOTLIGHT_FEATURES: list[dict[str, str]] = [
+    {
+        "name": "📝 TL;DR Summaries",
+        "description": (
+            "When someone posts a long message, I add a 📝 reaction. "
+            "Tap it to get a quick 2-3 bullet summary!"
+        ),
+        "example": "Write a long message (500+ chars) → tap 📝 → instant summary",
+    },
+    {
+        "name": "📋 Link Summaries",
+        "description": (
+            "When someone shares a link, I add a 📋 reaction. "
+            "Tap it to get a concise summary of the linked page."
+        ),
+        "example": "Share a news article → tap 📋 → key takeaways in seconds",
+    },
+    {
+        "name": "📚 Book Enrichment",
+        "description": (
+            "Mention a book in #reading and I'll add a 📚 reaction. "
+            "Tap it for ratings, a synopsis, and similar book recommendations!"
+        ),
+        "example": "\"Just started Dune\" in #reading → tap 📚 → full book info",
+    },
+    {
+        "name": "📊 /vibecheck",
+        "description": (
+            "Get a quick snapshot of server activity — who's posting, "
+            "which channels are hot, and the overall community vibe."
+        ),
+        "example": "Type `/vibecheck` → instant server health report",
+    },
+    {
+        "name": "📈 /mystats",
+        "description": (
+            "See your personal engagement stats — message count, rank, "
+            "top channels, peak hours, and fun facts."
+        ),
+        "example": "Type `/mystats` → your personal dashboard",
+    },
+    {
+        "name": "🎉 /celebrate",
+        "description": (
+            "Celebrate a win or shout out a friend with a personalized "
+            "celebration message and GIF."
+        ),
+        "example": "Type `/celebrate @friend landed the job!` → party time",
+    },
+    {
+        "name": "🏆 Hall of Fame",
+        "description": (
+            "Messages that get lots of reactions automatically get nominated. "
+            "Tap 🏆 to vote — enough votes and it's inducted into the Hall of Fame!"
+        ),
+        "example": "Post a banger → community votes 🏆 → immortalized",
+    },
+    {
+        "name": "🔥 /trending",
+        "description": (
+            "See the hottest messages from the past day — the ones getting "
+            "the most reactions and engagement."
+        ),
+        "example": "Type `/trending` → today's greatest hits",
+    },
+]
+
+# Rate limit: max 1 tip per channel per 24 hours (in seconds)
+_CHANNEL_TIP_COOLDOWN = 86400
+
+# In-memory tracker: channel_id -> last_tip_timestamp
+_channel_last_tip: dict[int, float] = {}
+
+
+def _extract_domain(url: str) -> str:
+    """Extract domain from a URL."""
+    try:
+        domain = url.split("://", 1)[1] if "://" in url else url
+        domain = domain.split("/", 1)[0]
+        if domain.startswith("www."):
+            domain = domain[4:]
+        return domain.lower()
+    except Exception:
+        return ""
+
+
+class FeatureDiscoveryCog(PoolAwareCog):
+    """Contextual feature tips and periodic feature spotlights."""
+
+    CAPABILITIES = CogCapabilities(
+        scheduled=[
+            ScheduledCapability(
+                name="Feature Spotlight",
+                schedule=f"Every {cfg.FEATURE_SPOTLIGHT_INTERVAL_DAYS} days at 12 PM PT",
+                description="Highlights an underused bot feature in the lobby",
+                category=Category.SCHEDULED_DAILY,
+            ),
+        ],
+    )
+
+    def __init__(self, bot: commands.Bot) -> None:
+        super().__init__(bot)
+        self.scheduler: AsyncIOScheduler | None = None
+        self._spotlight_index = 0
+
+    async def cog_load(self) -> None:
+        await super().cog_load()
+        if not cfg.FEATURE_DISCOVERY_ENABLED:
+            log.info("FeatureDiscoveryCog disabled via FEATURE_DISCOVERY_ENABLED")
+            return
+
+        self.scheduler = AsyncIOScheduler(timezone=LA)
+        trigger = IntervalTrigger(
+            days=cfg.FEATURE_SPOTLIGHT_INTERVAL_DAYS,
+            timezone=LA,
+            start_date="2026-02-10 12:00:00",  # next spotlight
+        )
+        self.scheduler.add_job(self._post_spotlight_safe, trigger)
+        self.scheduler.start()
+        log.info(
+            "FeatureDiscoveryCog scheduler started (every %d days at 12 PM PT)",
+            cfg.FEATURE_SPOTLIGHT_INTERVAL_DAYS,
+        )
+
+    async def cog_unload(self) -> None:
+        if self.scheduler:
+            self.scheduler.shutdown(wait=False)
+            self.scheduler = None
+        await super().cog_unload()
+
+    # ------------------------------------------------------------------
+    # A. Contextual tips (on_message)
+    # ------------------------------------------------------------------
+
+    @commands.Cog.listener()
+    @require_pool
+    async def on_message(self, message: discord.Message) -> None:
+        """Detect patterns and offer one-time feature tips."""
+        if not cfg.FEATURE_DISCOVERY_ENABLED:
+            return
+        if message.author.bot or message.guild is None:
+            return
+        if message.guild.id != cfg.GUILD_ID:
+            return
+
+        # Determine which tip to offer (first match wins)
+        tip_key, tip_text = self._match_tip(message)
+        if tip_key is None:
+            return
+
+        # Channel rate-limit: max 1 tip per channel per 24h
+        now = time.time()
+        last = _channel_last_tip.get(message.channel.id, 0)
+        if now - last < _CHANNEL_TIP_COOLDOWN:
+            return
+
+        # Per-user dedup: check if user already received this tip
+        already_sent = await self.pool.fetchval(
+            """
+            SELECT 1 FROM discord.feature_tip
+            WHERE user_id = $1 AND tip_key = $2
+            """,
+            message.author.id,
+            tip_key,
+        )
+        if already_sent:
+            return
+
+        # Send the tip
+        try:
+            await message.reply(tip_text, mention_author=False)
+        except discord.HTTPException as exc:
+            log.warning("Failed to send feature tip: %s", exc)
+            return
+
+        # Record tip as sent
+        await self.pool.execute(
+            """
+            INSERT INTO discord.feature_tip (user_id, tip_key)
+            VALUES ($1, $2)
+            ON CONFLICT DO NOTHING
+            """,
+            message.author.id,
+            tip_key,
+        )
+
+        _channel_last_tip[message.channel.id] = now
+        log.info(
+            "Sent feature tip '%s' to user %s in #%s",
+            tip_key,
+            message.author.id,
+            getattr(message.channel, "name", "?"),
+        )
+
+    def _match_tip(
+        self, message: discord.Message,
+    ) -> tuple[str | None, str | None]:
+        """Return (tip_key, tip_text) for the first matching pattern, or (None, None)."""
+        content = message.content
+
+        # 1. Long message -> TL;DR tip
+        if len(content) >= LONG_MESSAGE_THRESHOLD:
+            return "tldr", TIP_DEFINITIONS[0][1]
+
+        # 2. URL (non-image host) -> link summary tip
+        urls = URL_PATTERN.findall(content)
+        valid_urls = [
+            u for u in urls
+            if not any(skip in _extract_domain(u) for skip in _SKIP_DOMAINS)
+        ]
+        if valid_urls:
+            return "link_summary", TIP_DEFINITIONS[1][1]
+
+        # 3. Book mention in #reading channel
+        if (
+            cfg.READING_CHANNEL_ID
+            and message.channel.id == cfg.READING_CHANNEL_ID
+        ):
+            return "book_enrichment", TIP_DEFINITIONS[2][1]
+
+        # 4. Activity question -> vibecheck/mystats tip
+        if ACTIVITY_PATTERN.search(content):
+            return "vibecheck", TIP_DEFINITIONS[3][1]
+
+        return None, None
+
+    # ------------------------------------------------------------------
+    # B. Periodic feature spotlight
+    # ------------------------------------------------------------------
+
+    async def _post_spotlight_safe(self) -> None:
+        """Error-handling wrapper for the spotlight task."""
+        try:
+            await self._post_spotlight()
+        except Exception as exc:
+            log.exception("Feature spotlight task failed: %s", exc)
+
+    @idempotent_task("feature_spotlight", daily_key)
+    async def _post_spotlight(self) -> str:
+        """Post a feature spotlight embed to the lobby."""
+        await self.bot.wait_until_ready()
+
+        channel_id = cfg.LOBBY_CHANNEL_ID
+        channel = self.bot.get_channel(channel_id)
+        if not isinstance(channel, discord.TextChannel):
+            log.error("Feature spotlight channel %d not found", channel_id)
+            return "error:channel_not_found"
+
+        # Pick the next feature in rotation
+        feature = SPOTLIGHT_FEATURES[self._spotlight_index % len(SPOTLIGHT_FEATURES)]
+        self._spotlight_index += 1
+
+        embed = discord.Embed(
+            title=f"✨ Feature Spotlight: {feature['name']}",
+            description=feature["description"],
+            color=discord.Color.gold(),
+        )
+        embed.add_field(
+            name="Try it",
+            value=feature["example"],
+            inline=False,
+        )
+        embed.set_footer(text="Gentlebot has lots of hidden talents — stay tuned for more!")
+
+        await channel.send(embed=embed)
+        log.info("Feature spotlight posted: %s", feature["name"])
+        return f"posted:{feature['name']}"
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(FeatureDiscoveryCog(bot))

--- a/gentlebot/cogs/welcome_back_cog.py
+++ b/gentlebot/cogs/welcome_back_cog.py
@@ -1,0 +1,411 @@
+"""
+welcome_back_cog.py – Lurker Re-engagement & Monthly Recap DMs
+==============================================================
+Re-engages inactive users with warm, in-channel welcome-back messages
+and provides opt-in monthly recap DMs.
+
+How it works:
+  A. **Welcome-back detection** (on_message listener):
+     When a user with Ghost or Lurker role posts a message:
+     - Gap > 7 days: react with 👋
+     - Gap > 14 days: also post a short welcome-back reply
+     - Cooldown: 30 days between welcome-backs per user
+
+  B. **Monthly recap DMs** (scheduled task, 1st of month):
+     Opted-in users receive a personalized engagement recap via DM.
+
+  C. **/recap** slash command:
+     Toggle opt-in for monthly recap DMs.
+
+Configuration in bot_config.py:
+  • WELCOME_BACK_ENABLED: Master toggle (default: True)
+  • WELCOME_BACK_MIN_GAP_DAYS: Minimum gap to trigger wave (default: 7)
+  • WELCOME_BACK_COOLDOWN_DAYS: Cooldown between events (default: 30)
+  • MONTHLY_RECAP_DM_ENABLED: Master toggle for DMs (default: True)
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from datetime import date
+
+import discord
+import pytz
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+from discord import app_commands
+from discord.ext import commands
+
+from .. import bot_config as cfg
+from ..capabilities import (
+    CogCapabilities,
+    CommandCapability,
+    ScheduledCapability,
+    Category,
+)
+from ..infra import PoolAwareCog, require_pool, idempotent_task, monthly_key
+from ..queries import engagement as eq
+from ..util import user_name
+
+log = logging.getLogger(f"gentlebot.{__name__}")
+
+LA = pytz.timezone("America/Los_Angeles")
+
+# Template pool for short welcome-back messages (< 14-day gap)
+WELCOME_TEMPLATES = [
+    "Welcome back, {name}! Good to see you around. 🙂",
+    "Hey {name}, welcome back! We missed you.",
+    "{name}'s back! Good to have you here again.",
+    "Welcome back, {name}! Jump right in. 🙌",
+]
+
+# Inactivity role IDs for detection
+_INACTIVITY_ROLES: set[int] = set()
+
+
+def _get_inactivity_roles() -> set[int]:
+    """Lazily build set of inactivity role IDs."""
+    global _INACTIVITY_ROLES
+    if not _INACTIVITY_ROLES:
+        _INACTIVITY_ROLES = {
+            r for r in (
+                cfg.ROLE_GHOST,
+                getattr(cfg, "ROLE_LURKER_FLAG", 0),
+                getattr(cfg, "ROLE_SHADOW_FLAG", 0),
+            ) if r
+        }
+    return _INACTIVITY_ROLES
+
+
+class WelcomeBackCog(PoolAwareCog):
+    """Welcomes back inactive users and sends monthly recap DMs."""
+
+    CAPABILITIES = CogCapabilities(
+        commands=[
+            CommandCapability(
+                name="recap",
+                description="/recap — Toggle opt-in for monthly recap DMs",
+                category=Category.ENGAGEMENT,
+            ),
+        ],
+        scheduled=[
+            ScheduledCapability(
+                name="Monthly Recap DM",
+                schedule="1st of month, 10 AM PT",
+                description="Sends personalized recap DMs to opted-in users",
+                category=Category.SCHEDULED_WEEKLY,
+            ),
+        ],
+    )
+
+    def __init__(self, bot: commands.Bot) -> None:
+        super().__init__(bot)
+        self.scheduler: AsyncIOScheduler | None = None
+
+    async def cog_load(self) -> None:
+        await super().cog_load()
+
+        if not cfg.WELCOME_BACK_ENABLED and not cfg.MONTHLY_RECAP_DM_ENABLED:
+            log.info("WelcomeBackCog fully disabled")
+            return
+
+        self.scheduler = AsyncIOScheduler(timezone=LA)
+
+        if cfg.MONTHLY_RECAP_DM_ENABLED:
+            trigger = CronTrigger(day=1, hour=10, minute=0, timezone=LA)
+            self.scheduler.add_job(self._send_monthly_recaps_safe, trigger)
+
+        self.scheduler.start()
+        log.info("WelcomeBackCog scheduler started")
+
+    async def cog_unload(self) -> None:
+        if self.scheduler:
+            self.scheduler.shutdown(wait=False)
+            self.scheduler = None
+        await super().cog_unload()
+
+    # ------------------------------------------------------------------
+    # A. Welcome-back detection (on_message)
+    # ------------------------------------------------------------------
+
+    @commands.Cog.listener()
+    @require_pool
+    async def on_message(self, message: discord.Message) -> None:
+        """Detect returning lurkers and welcome them back."""
+        if not cfg.WELCOME_BACK_ENABLED:
+            return
+        if message.author.bot or message.guild is None:
+            return
+        if message.guild.id != cfg.GUILD_ID:
+            return
+
+        member = message.author
+        if not isinstance(member, discord.Member):
+            return
+
+        # Check if user has an inactivity role
+        inactivity_roles = _get_inactivity_roles()
+        user_role_ids = {r.id for r in member.roles}
+        if not user_role_ids & inactivity_roles:
+            return
+
+        # Check cooldown: skip if we welcomed them recently
+        recent = await self.pool.fetchval(
+            """
+            SELECT 1 FROM discord.welcome_back_event
+            WHERE user_id = $1
+              AND sent_at > now() - ($2 || ' days')::interval
+            """,
+            member.id,
+            str(cfg.WELCOME_BACK_COOLDOWN_DAYS),
+        )
+        if recent:
+            return
+
+        # Calculate inactivity gap from last message
+        last_msg_at = await self.pool.fetchval(
+            """
+            SELECT MAX(created_at) FROM discord.message
+            WHERE author_id = $1
+              AND message_id != $2
+            """,
+            member.id,
+            message.id,
+        )
+
+        if last_msg_at is None:
+            gap_days = 999  # Never posted before — treat as long gap
+        else:
+            gap_days = (discord.utils.utcnow() - last_msg_at).days
+
+        min_gap = cfg.WELCOME_BACK_MIN_GAP_DAYS
+        if gap_days < min_gap:
+            return
+
+        # React with 👋 for any qualifying gap
+        try:
+            await message.add_reaction("👋")
+        except discord.HTTPException:
+            log.warning("Failed to add wave reaction to message %s", message.id)
+
+        # For longer gaps (2x min), also send a welcome-back message
+        if gap_days >= min_gap * 2:
+            template = random.choice(WELCOME_TEMPLATES)
+            text = template.format(name=member.display_name)
+            try:
+                await message.reply(text, mention_author=False)
+            except discord.HTTPException as exc:
+                log.warning("Failed to send welcome-back message: %s", exc)
+
+        # Record the event
+        await self.pool.execute(
+            """
+            INSERT INTO discord.welcome_back_event (user_id, channel_id, gap_days)
+            VALUES ($1, $2, $3)
+            """,
+            member.id,
+            message.channel.id,
+            gap_days,
+        )
+
+        log.info(
+            "Welcome-back for %s (gap=%d days) in #%s",
+            user_name(member),
+            gap_days,
+            getattr(message.channel, "name", "?"),
+        )
+
+    # ------------------------------------------------------------------
+    # B. /recap slash command
+    # ------------------------------------------------------------------
+
+    @app_commands.command(
+        name="recap",
+        description="Toggle monthly recap DMs with your personal engagement stats",
+    )
+    async def recap(self, interaction: discord.Interaction) -> None:
+        """Toggle opt-in for monthly recap DMs."""
+        if not self.pool:
+            await interaction.response.send_message(
+                "Database unavailable — try again later.", ephemeral=True,
+            )
+            return
+
+        user_id = interaction.user.id
+
+        # Upsert preference (toggle)
+        row = await self.pool.fetchrow(
+            """
+            INSERT INTO discord.user_recap_pref (user_id, opted_in)
+            VALUES ($1, true)
+            ON CONFLICT (user_id) DO UPDATE
+                SET opted_in = NOT discord.user_recap_pref.opted_in
+            RETURNING opted_in
+            """,
+            user_id,
+        )
+
+        opted_in = row["opted_in"]
+        if opted_in:
+            msg = (
+                "You're now **opted in** to monthly recap DMs! "
+                "On the 1st of each month, I'll send you a personalized "
+                "engagement summary. Use `/recap` again to opt out."
+            )
+        else:
+            msg = (
+                "You've **opted out** of monthly recap DMs. "
+                "Use `/recap` again anytime to re-subscribe."
+            )
+
+        await interaction.response.send_message(msg, ephemeral=True)
+        log.info("/recap toggled by %s -> opted_in=%s", user_name(interaction.user), opted_in)
+
+    # ------------------------------------------------------------------
+    # C. Monthly recap DMs
+    # ------------------------------------------------------------------
+
+    async def _send_monthly_recaps_safe(self) -> None:
+        """Error-handling wrapper for the monthly recap task."""
+        try:
+            await self._send_monthly_recaps()
+        except Exception as exc:
+            log.exception("Monthly recap DM task failed: %s", exc)
+
+    @idempotent_task("monthly_recap_dm", monthly_key)
+    async def _send_monthly_recaps(self) -> str:
+        """Build and send personalized recap DMs to opted-in users."""
+        await self.bot.wait_until_ready()
+
+        if not self.pool:
+            return "error:no_pool"
+
+        # Get opted-in users
+        rows = await self.pool.fetch(
+            """
+            SELECT user_id FROM discord.user_recap_pref
+            WHERE opted_in = true
+            """,
+        )
+
+        if not rows:
+            log.info("No users opted in for monthly recap DMs")
+            return "no_users"
+
+        guild = self.bot.get_guild(cfg.GUILD_ID)
+        if not guild:
+            return "error:guild_not_found"
+
+        interval = "30 days"
+        sent = 0
+        failed = 0
+
+        for row in rows:
+            user_id = row["user_id"]
+            try:
+                member = guild.get_member(user_id)
+                if not member:
+                    try:
+                        member = await guild.fetch_member(user_id)
+                    except discord.NotFound:
+                        log.warning("Monthly recap: member %d not found", user_id)
+                        continue
+                    except discord.HTTPException:
+                        continue
+
+                embed = await self._build_recap_embed(member, interval)
+
+                dm = await member.create_dm()
+                await dm.send(embed=embed)
+                sent += 1
+                log.info("Sent monthly recap DM to %s", user_name(member))
+
+                # Small delay to avoid rate limits
+                await asyncio.sleep(2)
+
+            except discord.Forbidden:
+                log.warning("Cannot DM %d (DMs disabled)", user_id)
+                failed += 1
+            except Exception:
+                log.exception("Failed to send recap DM to %d", user_id)
+                failed += 1
+
+        result = f"sent={sent}, failed={failed}"
+        log.info("Monthly recap DMs complete: %s", result)
+        return result
+
+    async def _build_recap_embed(
+        self, member: discord.Member, interval: str,
+    ) -> discord.Embed:
+        """Build a personalized recap embed for a user."""
+        pool = self.pool
+        user_id = member.id
+
+        # Gather stats
+        msg_count = await eq.user_message_count(pool, user_id, interval)
+        reactions = await eq.user_reactions_received(pool, user_id, interval)
+        top_channels = await eq.user_top_channels(pool, user_id, interval, limit=3)
+        top_emojis = await eq.user_top_emojis_received(pool, user_id, interval, limit=5)
+        msg_pct = await eq.user_message_percentile(pool, user_id, interval)
+        peak_hour = await eq.user_peak_hour(pool, user_id, interval)
+
+        embed = discord.Embed(
+            title="📊 Your Monthly Recap",
+            description=(
+                f"Here's how your month looked in **{member.guild.name}**!"
+            ),
+            color=discord.Color.blue(),
+        )
+
+        # Activity summary
+        pct_str = ""
+        if msg_pct is not None:
+            top_pct = round((1 - msg_pct) * 100)
+            if top_pct <= 50:
+                pct_str = f" (Top {max(top_pct, 1)}%)"
+        embed.add_field(
+            name="Messages",
+            value=f"**{msg_count:,}** messages{pct_str}",
+            inline=True,
+        )
+        embed.add_field(
+            name="Reactions Received",
+            value=f"**{reactions:,}** reactions",
+            inline=True,
+        )
+
+        # Peak hour
+        if peak_hour is not None:
+            suffix = "AM" if peak_hour < 12 else "PM"
+            display = peak_hour % 12 or 12
+            embed.add_field(
+                name="Peak Hour",
+                value=f"**{display} {suffix} PT**",
+                inline=True,
+            )
+
+        # Top channels
+        if top_channels:
+            lines = [f"#{name} ({cnt:,})" for _, name, cnt in top_channels]
+            embed.add_field(
+                name="Your Top Channels",
+                value="\n".join(lines),
+                inline=False,
+            )
+
+        # Top reactions received
+        if top_emojis:
+            emoji_text = " ".join(f"{emoji}×{cnt}" for emoji, cnt in top_emojis)
+            embed.add_field(
+                name="Top Reactions You Got",
+                value=emoji_text,
+                inline=False,
+            )
+
+        embed.set_footer(text="Use /recap to unsubscribe • Try /mystats anytime for live stats")
+        return embed
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(WelcomeBackCog(bot))

--- a/tests/test_feature_discovery_cog.py
+++ b/tests/test_feature_discovery_cog.py
@@ -1,0 +1,219 @@
+"""Tests for the Feature Discovery cog."""
+import asyncio
+import time
+import types
+
+
+def test_long_message_threshold():
+    """LONG_MESSAGE_THRESHOLD should be 500 characters."""
+    from gentlebot.cogs.feature_discovery_cog import LONG_MESSAGE_THRESHOLD
+
+    assert LONG_MESSAGE_THRESHOLD == 500
+
+
+def test_spotlight_features_not_empty():
+    """SPOTLIGHT_FEATURES should have at least one entry."""
+    from gentlebot.cogs.feature_discovery_cog import SPOTLIGHT_FEATURES
+
+    assert len(SPOTLIGHT_FEATURES) >= 1
+    for feat in SPOTLIGHT_FEATURES:
+        assert "name" in feat
+        assert "description" in feat
+        assert "example" in feat
+
+
+def test_tip_definitions_structure():
+    """TIP_DEFINITIONS should be a list of (key, message) tuples."""
+    from gentlebot.cogs.feature_discovery_cog import TIP_DEFINITIONS
+
+    assert len(TIP_DEFINITIONS) == 4
+    keys = {t[0] for t in TIP_DEFINITIONS}
+    assert "tldr" in keys
+    assert "link_summary" in keys
+    assert "book_enrichment" in keys
+    assert "vibecheck" in keys
+
+
+def test_capabilities_registered():
+    """FeatureDiscoveryCog should have CAPABILITIES with scheduled task."""
+    from gentlebot.cogs.feature_discovery_cog import FeatureDiscoveryCog
+    from gentlebot.capabilities import CogCapabilities
+
+    assert hasattr(FeatureDiscoveryCog, "CAPABILITIES")
+    assert isinstance(FeatureDiscoveryCog.CAPABILITIES, CogCapabilities)
+    assert len(FeatureDiscoveryCog.CAPABILITIES.scheduled) == 1
+    assert "Spotlight" in FeatureDiscoveryCog.CAPABILITIES.scheduled[0].name
+
+
+def test_match_tip_long_message():
+    """_match_tip should detect long messages for TL;DR tip."""
+    async def run():
+        bot = types.SimpleNamespace()
+        bot.user = types.SimpleNamespace(id=123)
+
+        from gentlebot.cogs.feature_discovery_cog import FeatureDiscoveryCog
+
+        cog = FeatureDiscoveryCog(bot)
+
+        msg = types.SimpleNamespace(
+            content="A" * 600,
+            channel=types.SimpleNamespace(id=789),
+        )
+
+        key, text = cog._match_tip(msg)
+        assert key == "tldr"
+        assert text is not None
+        assert "📝" in text
+
+    asyncio.run(run())
+
+
+def test_match_tip_url():
+    """_match_tip should detect URLs for link summary tip."""
+    async def run():
+        bot = types.SimpleNamespace()
+        bot.user = types.SimpleNamespace(id=123)
+
+        from gentlebot.cogs.feature_discovery_cog import FeatureDiscoveryCog
+
+        cog = FeatureDiscoveryCog(bot)
+
+        msg = types.SimpleNamespace(
+            content="Check out https://example.com/article",
+            channel=types.SimpleNamespace(id=789),
+        )
+
+        key, text = cog._match_tip(msg)
+        assert key == "link_summary"
+        assert "📋" in text
+
+    asyncio.run(run())
+
+
+def test_match_tip_skips_image_urls():
+    """_match_tip should skip image host URLs."""
+    async def run():
+        bot = types.SimpleNamespace()
+        bot.user = types.SimpleNamespace(id=123)
+
+        from gentlebot.cogs.feature_discovery_cog import FeatureDiscoveryCog
+
+        cog = FeatureDiscoveryCog(bot)
+
+        msg = types.SimpleNamespace(
+            content="Look at this https://i.imgur.com/abc.png",
+            channel=types.SimpleNamespace(id=789),
+        )
+
+        key, text = cog._match_tip(msg)
+        assert key is None
+        assert text is None
+
+    asyncio.run(run())
+
+
+def test_match_tip_activity_question():
+    """_match_tip should detect activity questions for vibecheck tip."""
+    async def run():
+        bot = types.SimpleNamespace()
+        bot.user = types.SimpleNamespace(id=123)
+
+        from gentlebot.cogs.feature_discovery_cog import FeatureDiscoveryCog
+
+        cog = FeatureDiscoveryCog(bot)
+
+        msg = types.SimpleNamespace(
+            content="how active has the server been?",
+            channel=types.SimpleNamespace(id=789),
+        )
+
+        key, text = cog._match_tip(msg)
+        assert key == "vibecheck"
+        assert "/vibecheck" in text
+
+    asyncio.run(run())
+
+
+def test_match_tip_short_message_no_match():
+    """_match_tip should return None for short plain messages."""
+    async def run():
+        bot = types.SimpleNamespace()
+        bot.user = types.SimpleNamespace(id=123)
+
+        from gentlebot.cogs.feature_discovery_cog import FeatureDiscoveryCog
+
+        cog = FeatureDiscoveryCog(bot)
+
+        msg = types.SimpleNamespace(
+            content="hey what's up",
+            channel=types.SimpleNamespace(id=789),
+        )
+
+        key, text = cog._match_tip(msg)
+        assert key is None
+        assert text is None
+
+    asyncio.run(run())
+
+
+def test_channel_tip_cooldown_constant():
+    """Channel tip cooldown should be 24 hours in seconds."""
+    from gentlebot.cogs.feature_discovery_cog import _CHANNEL_TIP_COOLDOWN
+
+    assert _CHANNEL_TIP_COOLDOWN == 86400
+
+
+def test_extract_domain():
+    """_extract_domain should strip protocol, www, and path."""
+    from gentlebot.cogs.feature_discovery_cog import _extract_domain
+
+    assert _extract_domain("https://www.example.com/path") == "example.com"
+    assert _extract_domain("http://cdn.discordapp.com/img.png") == "cdn.discordapp.com"
+    assert _extract_domain("https://i.imgur.com/abc.jpg") == "i.imgur.com"
+
+
+def test_on_message_skips_bot():
+    """on_message should skip bot messages."""
+    async def run():
+        bot = types.SimpleNamespace()
+        bot.user = types.SimpleNamespace(id=123)
+
+        from gentlebot.cogs.feature_discovery_cog import FeatureDiscoveryCog
+
+        cog = FeatureDiscoveryCog(bot)
+        cog.pool = types.SimpleNamespace()  # Simulate pool present
+
+        msg = types.SimpleNamespace(
+            id=456,
+            author=types.SimpleNamespace(bot=True),
+            guild=types.SimpleNamespace(id=999),
+            content="A" * 600,
+        )
+
+        # Should return early without error
+        await cog.on_message(msg)
+
+    asyncio.run(run())
+
+
+def test_on_message_skips_dm():
+    """on_message should skip DMs (guild=None)."""
+    async def run():
+        bot = types.SimpleNamespace()
+        bot.user = types.SimpleNamespace(id=123)
+
+        from gentlebot.cogs.feature_discovery_cog import FeatureDiscoveryCog
+
+        cog = FeatureDiscoveryCog(bot)
+        cog.pool = types.SimpleNamespace()
+
+        msg = types.SimpleNamespace(
+            id=456,
+            author=types.SimpleNamespace(bot=False),
+            guild=None,
+            content="A" * 600,
+        )
+
+        await cog.on_message(msg)
+
+    asyncio.run(run())

--- a/tests/test_welcome_back_cog.py
+++ b/tests/test_welcome_back_cog.py
@@ -1,0 +1,194 @@
+"""Tests for the Welcome Back cog."""
+import asyncio
+import types
+
+
+def test_welcome_templates_not_empty():
+    """WELCOME_TEMPLATES should have at least one entry."""
+    from gentlebot.cogs.welcome_back_cog import WELCOME_TEMPLATES
+
+    assert len(WELCOME_TEMPLATES) >= 1
+    for t in WELCOME_TEMPLATES:
+        assert "{name}" in t
+
+
+def test_welcome_templates_format():
+    """All templates should format correctly with a name."""
+    from gentlebot.cogs.welcome_back_cog import WELCOME_TEMPLATES
+
+    for t in WELCOME_TEMPLATES:
+        result = t.format(name="TestUser")
+        assert "TestUser" in result
+
+
+def test_capabilities_registered():
+    """WelcomeBackCog should have CAPABILITIES with command and scheduled."""
+    from gentlebot.cogs.welcome_back_cog import WelcomeBackCog
+    from gentlebot.capabilities import CogCapabilities
+
+    assert hasattr(WelcomeBackCog, "CAPABILITIES")
+    assert isinstance(WelcomeBackCog.CAPABILITIES, CogCapabilities)
+    assert len(WelcomeBackCog.CAPABILITIES.commands) == 1
+    assert WelcomeBackCog.CAPABILITIES.commands[0].name == "recap"
+    assert len(WelcomeBackCog.CAPABILITIES.scheduled) == 1
+
+
+def test_inactivity_roles_detection():
+    """_get_inactivity_roles should return a non-empty set in prod."""
+    from gentlebot.cogs.welcome_back_cog import _get_inactivity_roles
+
+    roles = _get_inactivity_roles()
+    # Should have at least one role ID (ROLE_GHOST is always set)
+    assert isinstance(roles, set)
+    assert len(roles) >= 1
+
+
+def test_on_message_skips_bot():
+    """on_message should skip bot messages."""
+    async def run():
+        bot = types.SimpleNamespace()
+        bot.user = types.SimpleNamespace(id=123)
+
+        from gentlebot.cogs.welcome_back_cog import WelcomeBackCog
+
+        cog = WelcomeBackCog(bot)
+        cog.pool = types.SimpleNamespace()
+
+        msg = types.SimpleNamespace(
+            id=456,
+            author=types.SimpleNamespace(bot=True),
+            guild=types.SimpleNamespace(id=999),
+            content="hello",
+        )
+
+        await cog.on_message(msg)
+
+    asyncio.run(run())
+
+
+def test_on_message_skips_dm():
+    """on_message should skip DMs (guild=None)."""
+    async def run():
+        bot = types.SimpleNamespace()
+        bot.user = types.SimpleNamespace(id=123)
+
+        from gentlebot.cogs.welcome_back_cog import WelcomeBackCog
+
+        cog = WelcomeBackCog(bot)
+        cog.pool = types.SimpleNamespace()
+
+        msg = types.SimpleNamespace(
+            id=456,
+            author=types.SimpleNamespace(bot=False),
+            guild=None,
+            content="hello",
+        )
+
+        await cog.on_message(msg)
+
+    asyncio.run(run())
+
+
+def test_on_message_skips_non_member():
+    """on_message should skip if author is not a Member (no roles)."""
+    async def run():
+        bot = types.SimpleNamespace()
+        bot.user = types.SimpleNamespace(id=123)
+
+        from gentlebot.cogs import welcome_back_cog
+        from gentlebot.cogs.welcome_back_cog import WelcomeBackCog
+        import gentlebot.bot_config as cfg
+
+        cog = WelcomeBackCog(bot)
+        cog.pool = types.SimpleNamespace()
+
+        # SimpleNamespace isn't a discord.Member, so isinstance check fails
+        msg = types.SimpleNamespace(
+            id=456,
+            author=types.SimpleNamespace(
+                bot=False,
+                roles=[],
+                id=789,
+                display_name="Test",
+            ),
+            guild=types.SimpleNamespace(id=cfg.GUILD_ID),
+            content="hello",
+        )
+
+        await cog.on_message(msg)
+
+    asyncio.run(run())
+
+
+def test_on_message_skips_wrong_guild():
+    """on_message should skip messages from other guilds."""
+    async def run():
+        bot = types.SimpleNamespace()
+        bot.user = types.SimpleNamespace(id=123)
+
+        from gentlebot.cogs.welcome_back_cog import WelcomeBackCog
+
+        cog = WelcomeBackCog(bot)
+        cog.pool = types.SimpleNamespace()
+
+        msg = types.SimpleNamespace(
+            id=456,
+            author=types.SimpleNamespace(bot=False),
+            guild=types.SimpleNamespace(id=99999),  # Wrong guild
+            content="hello",
+        )
+
+        await cog.on_message(msg)
+
+    asyncio.run(run())
+
+
+def test_build_recap_embed_empty_stats():
+    """_build_recap_embed should handle zero-stat users gracefully."""
+    async def run():
+        bot = types.SimpleNamespace()
+        bot.user = types.SimpleNamespace(id=123)
+
+        from gentlebot.cogs.welcome_back_cog import WelcomeBackCog
+
+        cog = WelcomeBackCog(bot)
+
+        # Mock pool that returns 0/empty for all queries
+        async def fetchval(*args, **kwargs):
+            return 0
+
+        async def fetch(*args, **kwargs):
+            return []
+
+        async def fetchrow(*args, **kwargs):
+            return None
+
+        cog.pool = types.SimpleNamespace(
+            fetchval=fetchval,
+            fetch=fetch,
+            fetchrow=fetchrow,
+        )
+
+        member = types.SimpleNamespace(
+            id=789,
+            display_name="TestUser",
+            guild=types.SimpleNamespace(name="TestGuild"),
+        )
+
+        embed = await cog._build_recap_embed(member, "30 days")
+        assert embed.title == "📊 Your Monthly Recap"
+        assert "TestGuild" in embed.description
+
+    asyncio.run(run())
+
+
+def test_config_defaults():
+    """Config defaults should be sensible."""
+    import gentlebot.bot_config as cfg
+
+    assert cfg.WELCOME_BACK_ENABLED is True
+    assert cfg.WELCOME_BACK_MIN_GAP_DAYS == 7
+    assert cfg.WELCOME_BACK_COOLDOWN_DAYS == 30
+    assert cfg.MONTHLY_RECAP_DM_ENABLED is True
+    assert cfg.FEATURE_DISCOVERY_ENABLED is True
+    assert cfg.FEATURE_SPOTLIGHT_INTERVAL_DAYS == 5


### PR DESCRIPTION
## Summary

- **FeatureDiscoveryCog**: Contextual one-time feature tips triggered by message patterns (long messages → TL;DR, URLs → link summary, book mentions → enrichment, activity questions → /vibecheck), plus periodic Feature Spotlight embeds every 5 days
- **WelcomeBackCog**: Detects returning Ghost/Lurker-flagged users and warmly welcomes them back (👋 react for 7d gap, message for 14d gap), with `/recap` slash command to toggle monthly recap DM opt-in and scheduled monthly personalized engagement DMs
- Alembic migration for `feature_tip` and `welcome_back_event` tables, 6 config flags, and 23 new tests (427 total passing)

## Design Highlights

| Mechanism | Anti-spam guard |
|-----------|----------------|
| Contextual tips | Per-user per-feature dedup (DB) + per-channel 24h rate limit (memory) |
| Feature spotlight | Idempotent task via `@idempotent_task` — safe across restarts |
| Welcome-back | 30-day cooldown per user, role-based detection (no extra DB queries) |
| Monthly recap DMs | Idempotent monthly task, opt-in only via `/recap` |

## New files
- `gentlebot/cogs/feature_discovery_cog.py`
- `gentlebot/cogs/welcome_back_cog.py`
- `db/versions/e5f6a7b8c9d0_create_feature_tip_and_welcome_back.py`
- `tests/test_feature_discovery_cog.py`
- `tests/test_welcome_back_cog.py`

## Test plan
- [ ] Run `alembic upgrade head` and verify `feature_tip` + `welcome_back_event` tables via SQL
- [ ] Post a 500+ char message → bot reacts with 📝 and replies with TL;DR tip (once per user)
- [ ] Post same pattern again → no duplicate tip
- [ ] Verify channel rate limit: second tip in same channel within 24h is suppressed
- [ ] Simulate lurker return: set Ghost role + old last message → post → bot reacts 👋
- [ ] `/recap` → toggles opt-in in `user_recap_pref` (ephemeral response)
- [ ] Feature spotlight fires on schedule (or trigger manually) → embed in lobby
- [ ] Full test suite: `pytest tests/ -v` → 427 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)