### PR TITLE
Disable feature discovery and fantasy football recaps

### DIFF
--- a/gentlebot/bot_config.py
+++ b/gentlebot/bot_config.py
@@ -33,6 +33,7 @@ YAHOO_CLIENT_ID = os.getenv("YAHOO_CLIENT_ID")
 YAHOO_CLIENT_SECRET = os.getenv("YAHOO_CLIENT_SECRET")
 YAHOO_REFRESH_TOKEN = os.getenv("YAHOO_REFRESH_TOKEN")
 YAHOO_LEAGUE_KEY = os.getenv("YAHOO_LEAGUE_KEY")
+YAHOO_FANTASY_WEEKLY_ENABLED = bool_env("YAHOO_FANTASY_WEEKLY_ENABLED", False)
 
 # ─── IDs per environment ──────────────────────────────────────────────────
 if IS_TEST:
@@ -200,7 +201,7 @@ MYSTATS_ENABLED = bool_env("MYSTATS_ENABLED", True)
 
 # ─── Feature Discovery ────────────────────────────────────────────────────
 # Contextual one-time tips and periodic feature spotlights
-FEATURE_DISCOVERY_ENABLED = bool_env("FEATURE_DISCOVERY_ENABLED", True)
+FEATURE_DISCOVERY_ENABLED = bool_env("FEATURE_DISCOVERY_ENABLED", False)
 FEATURE_SPOTLIGHT_INTERVAL_DAYS = int_env("FEATURE_SPOTLIGHT_INTERVAL_DAYS", 5)
 
 # ─── Welcome Back / Lurker Re-engagement ─────────────────────────────────

--- a/gentlebot/cogs/yahoo_fantasy_weekly_cog.py
+++ b/gentlebot/cogs/yahoo_fantasy_weekly_cog.py
@@ -69,7 +69,7 @@ class YahooFantasyWeeklyCog(commands.Cog):
         self._channel_id = getattr(cfg, "FANTASY_CHANNEL_ID", 0) or getattr(
             cfg, "SPORTS_CHANNEL_ID", 0
         )
-        self._enabled = all(
+        self._enabled = getattr(cfg, "YAHOO_FANTASY_WEEKLY_ENABLED", False) and all(
             (
                 getattr(cfg, "YAHOO_CLIENT_ID", None),
                 getattr(cfg, "YAHOO_CLIENT_SECRET", None),

--- a/tests/test_welcome_back_cog.py
+++ b/tests/test_welcome_back_cog.py
@@ -191,5 +191,5 @@ def test_config_defaults():
     assert cfg.WELCOME_BACK_MIN_GAP_DAYS == 7
     assert cfg.WELCOME_BACK_COOLDOWN_DAYS == 30
     assert cfg.MONTHLY_RECAP_DM_ENABLED is True
-    assert cfg.FEATURE_DISCOVERY_ENABLED is True
+    assert cfg.FEATURE_DISCOVERY_ENABLED is False
     assert cfg.FEATURE_SPOTLIGHT_INTERVAL_DAYS == 5


### PR DESCRIPTION
## Summary
- Default `FEATURE_DISCOVERY_ENABLED` to `False` — disables contextual tips and Feature Spotlight embeds
- Add `YAHOO_FANTASY_WEEKLY_ENABLED` flag (default `False`) — credentials alone no longer auto-enable the Tuesday fantasy recap or `/fantasyrecap` command
- Both features can be re-enabled by setting the respective env var to `true`

## Test plan
- [x] Tests pass locally (`pytest tests/ -v` — 442 passed)
- [x] Verified fantasy and feature_discovery tests pass with new defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)